### PR TITLE
[SM-14] fix: Jira 에픽 키 파싱 실패 부분 수정

### DIFF
--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -34,7 +34,7 @@ jobs:
         id: parse-epic
         shell: bash
         run: |
-          EPIC_KEY_RAW=$(echo "${{ github.event.issue.body }}" | grep -oE 'SM-[0-9]+' | head -1 || true)
+          EPIC_KEY_RAW=$(echo "${{ github.event.issue.body }}" | grep -A1 '상위 작업' | grep -oE 'SM-[0-9]+' || true)
           if [ -z "$EPIC_KEY_RAW" ]; then
             echo "HAS_EPIC=false" >> $GITHUB_ENV
           else


### PR DESCRIPTION
## ❓ 이슈

- close #6 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
Jira 에픽 키 파싱 시 정규식 에러를 수정한다.                                
                                                                                                  
  ### 문제                                                                                      
                                                                                                  
  GitHub 이슈 생성 시 에픽 키(SM-번호)를 파싱하는 grep 정규식에서 에러 발생                     
                                                                    
  - **에러 메시지:** `lookbehind assertion is not fixed length`
  - **원인:** lookbehind `(?<=...)` 안에 `\s{0,100}` 가변 길이 패턴 사용 → grep -P에서 지원하지
  않음
  - **영향:** 에픽 키가 파싱되지 않아 Jira 태스크가 에픽 하위로 연결되지 않음

  ### 수정 과정

  **기존 방식 (에러):**
  ```bash
  grep -oP '(?<=🎟️ 상위 작업 \(에픽 키\)\s{0,100})SM-\d+'
  → lookbehind 가변 길이 에러

  1차 수정안:
  grep -oE 'SM-[0-9]+' | head -1
  → 동작하지만 본문 전체에서 첫 번째 SM-번호를 가져오기 때문에 에픽 키가 아닌 다른 SM-번호를 잘못
  파싱할 가능성 있음

  최종 수정:
  grep -A1 '상위 작업' | grep -oE 'SM-[0-9]+'
  → "상위 작업" 헤더 + 바로 다음 줄에서만 SM-번호를 추출하여 오탐 없이 정확하게 파싱
```

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
### Test

- [ ] 이슈 생성 시 에픽 키 파싱 정상 동작 확인
- [ ] 에픽 키 미입력 시 독립 태스크 생성 확인
