### PR TITLE
[SM-17] fix: Jira 에픽 키 파싱 및 상위 작업 연결 수정

### DIFF
--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -72,6 +72,7 @@ jobs:
           fi
 
       - name: Update GitHub Issue Title with Jira Ticket Number
+        if: always() && steps.create.outputs.issue
         uses: actions-cool/issues-helper@v3
         with:
           actions: 'update-issue'


### PR DESCRIPTION
## ❓ 이슈

- close #10 

 ## ✍️ Descriptions                                                                          
                                                                                                  
  Jira 에픽 키 파싱 및 상위 작업 연결 오류를 수정                                            
                                                                                                  
  ### 문제                                                                                        
                                                                                                  
  1. grep lookbehind 가변 길이 에러로 에픽 키 파싱 실패
  2. 파싱 성공 후에도 gajira-create의 fields 파라미터로 parent를 넘기면 Jira API v2에서 에러 발생
  (팀 관리 프로젝트 미지원)

  ### 수정 내용

  **에픽 키 파싱:**
  - lookbehind 방식 → `grep -A2 '상위 작업'` 방식으로 변경
  - "상위 작업" 헤더 + 다음 2줄에서 SM-번호 추출

  **에픽 연결:**
  - gajira-create에서 parent 필드 제거 → 태스크만 먼저 생성
  - 생성 후 별도 스텝에서 REST API v3으로 parent 연결
  - HTTP 상태 코드 및 응답 로깅으로 디버깅 용이

  **안정성:**
  - 에픽 연결 실패 시에도 이슈 제목 업데이트는 항상 실행되도록 `if: always()` 추가

  ## 📸 스크린샷 (UI 변경 시)

  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인

  ### Test

  - [ ] 에픽 키 입력 시 파싱 및 상위 작업 연결 정상 동작 확인
  - [ ] 에픽 키 미입력 시 독립 태스크 생성 확인
  - [ ] 에픽 연결 실패 시 이슈 제목 업데이트 정상 동작 확인
