### PR TITLE
[SM-28] chore: AI 룰셋 및 워크플로우 세팅

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,49 @@
+---
+paths:
+  - 'src/**/*.tsx'
+  - 'src/**/*.ts'
+---
+
+# 코드 스타일 규칙
+
+## 함수 선언 스타일
+
+- 컴포넌트, 페이지: **function 선언문** 사용
+- 훅, 유틸리티, API 함수, 스키마 등 나머지: **화살표 함수** 사용
+
+## 파일 & 폴더 명명
+
+- 컴포넌트: PascalCase 폴더 + index.tsx (예: `GatheringCard/index.tsx`)
+- 훅: useCamelCase.ts (예: `useJoinGathering.ts`)
+- 유틸리티: camelCase.ts (예: `formatDate.ts`)
+- API: 도메인별 폴더 (예: `api/users/index.ts`)
+- Server Action: camelCase.ts (예: `cache.ts`)
+
+## Export
+
+- named export 기본 (예: `export function GatheringCard()`)
+- default export는 page.tsx, layout.tsx, loading.tsx, error.tsx만
+
+## TypeScript
+
+- strict 모드 사용
+- any 사용 금지. unknown 후 타입 가드 사용
+- interface 우선 (type은 유니온, 교차 타입 시만)
+- Props interface는 같은 파일, 컴포넌트 바로 위에 선언
+
+## 컴포넌트 구조
+
+- `'use client'`는 파일 최상단, 첫 줄에만
+- 컴포넌트는 폴더 단위로 관리 (index.tsx, index.test.tsx, index.stories.tsx)
+- Props destructuring은 함수 파라미터에서
+- early return 활용 (조건부 렌더링보다 우선)
+
+## import 순서
+
+1. React / Next.js (`react`, `next/*`)
+2. 외부 라이브러리 (`@tanstack/*`, `zustand`, `zod`, `axios` 등)
+3. 내부 모듈 (`@/components/*`, `@/hooks/*`, `@/lib/*`, `@/api/*` 등)
+4. 상대 경로 (`./`, `../`)
+5. 타입 import (`import type`)
+
+- 각 그룹 사이에 빈 줄 구분

--- a/.claude/rules/rendering.md
+++ b/.claude/rules/rendering.md
@@ -1,0 +1,63 @@
+---
+paths:
+  - 'src/app/**/*.tsx'
+  - 'src/app/**/*.ts'
+  - 'src/components/**/*.tsx'
+---
+
+# 렌더링 & 캐싱 규칙
+
+## 페이지별 렌더링 전략
+
+| 페이지       | 렌더링 | 캐시                                            | 비고                                     |
+| ------------ | ------ | ----------------------------------------------- | ---------------------------------------- |
+| 랜딩         | Static | 없음                                            | 정적 페이지                              |
+| 로그인       | Static | 없음                                            | 폼은 클라이언트 컴포넌트                 |
+| 회원가입     | Static | 없음                                            | 폼은 클라이언트 컴포넌트                 |
+| 메인         | ISR    | 온디맨드(revalidateTag) + revalidate: 3600 보험 | prefetchQuery + HydrationBoundary        |
+| 모임 상세    | ISR    | 온디맨드(revalidateTag) + revalidate: 3600 보험 | 모임 설명, 주차별 계획 등 정적 정보 캐시 |
+| 그 외 페이지 | 미정   | 미정                                            | 추후 확정                                |
+
+## 서버/클라이언트 컴포넌트 분리
+
+### 서버 컴포넌트로 유지
+
+- page.tsx, layout.tsx (항상)
+- 텍스트/이미지 표시만 하는 컴포넌트
+- SEO가 중요한 콘텐츠
+- header, nav, footer
+
+### 클라이언트 컴포넌트로 분리
+
+- useState, useEffect, onClick 등 인터랙션이 필요한 컴포넌트
+- useQuery, useMutation 등 TanStack Query 훅 사용 컴포넌트
+- 폼 컴포넌트 (react-hook-form)
+- 브라우저 API 사용 컴포넌트 (localStorage, window 등)
+
+## 데이터 페칭 패턴
+
+### 공개 데이터 (인증 불필요)
+
+- page.tsx에서 getQueryClient() → prefetchQuery (queryFn에 fetch + next.tags 지정) → HydrationBoundary로 감싸기
+- 클라이언트 컴포넌트에서 동일한 queryKey로 useQuery → 캐시 히트
+
+### 유저별 데이터 (인증 필요)
+
+- page.tsx에서 SuspenseBoundary로 감싸기 (fallback: Skeleton, errorFallback: ErrorFallback)
+- 클라이언트 컴포넌트에서 useSuspenseQuery → Suspense 연동 자동 로딩 처리
+
+## ErrorBoundary / SuspenseBoundary 사용 규칙
+
+| 상황          | 감싸는 것        | 이유                                      |
+| ------------- | ---------------- | ----------------------------------------- |
+| prefetch 있음 | ErrorBoundary    | 로딩 없음 (이미 데이터 있음), 에러만 대비 |
+| prefetch 없음 | SuspenseBoundary | 로딩 + 에러 둘 다 필요                    |
+| API 호출 없음 | 불필요           | 에러 날 일 없음                           |
+
+- 섹션 단위로 ErrorBoundary/SuspenseBoundary를 감싸서 에러가 페이지 전체를 깨뜨리지 않도록 격리
+
+## 주의사항
+
+- **MUST**: 서버에서 axios 사용 금지 (Next.js Data Cache 연동 불가, fetch만 사용)
+- **MUST**: page.tsx에서 직접 useQuery 금지 (서버 컴포넌트)
+- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + revalidateTag

--- a/.claude/rules/tanstack-query.md
+++ b/.claude/rules/tanstack-query.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - 'src/**/*.tsx'
+  - 'src/**/*.ts'
+  - 'src/api/**/*.ts'
+---
+
+# TanStack Query 규칙
+
+## QueryClient 설정
+
+- 서버: 요청마다 새로 생성 (getQueryClient → React.cache)
+- 클라이언트: 싱글턴 재사용 (useState로 생성)
+- defaultOptions.queries.staleTime: 60 \* 1000 (1분) 이상 필수
+
+## queryKey 관리
+
+- `src/api/도메인별/queries.ts`에서 팩토리 패턴으로 중앙 정의
+- 서버 prefetchQuery와 클라이언트 useQuery의 queryKey 정확히 일치
+- 키 불일치 = 캐시 미스 = prefetch 무의미
+- 팩토리 구조: `all → list(filters) → detail(id)` 계층으로 구성하고 `as const` 사용
+
+## prefetch 패턴 (서버 컴포넌트)
+
+- queryFn에 fetch 사용 (axios 금지), `next: { tags }` 로 Data Cache 태그 지정
+- 병렬 prefetch: Promise.all 필수
+- HydrationBoundary로 감싸서 클라이언트에 전달
+
+## 클라이언트 Query 패턴
+
+- **prefetch된 데이터 이어받기**: useQuery에 동일 queryKey 사용 → 캐시 히트로 isLoading = false
+- **유저별 데이터 (prefetch 없음)**: useSuspenseQuery 사용 → Suspense 연동 자동 로딩 처리
+- 클라이언트 queryFn에서는 axios 인스턴스 사용 가능
+
+## Mutation + 이중 캐시 무효화
+
+- mutation 성공 시 반드시 클라이언트 + 서버 캐시 둘 다 무효화
+- `invalidateQueries` → 현재 유저 화면 즉시 갱신
+- `revalidateTag` (Server Action) → 서버 Data Cache 무효화, 다른 유저도 최신 데이터
+- invalidateQueries만 → 새로고침 시 옛날 데이터 / revalidateTag만 → 현재 유저는 새로고침 필요
+
+## 낙관적 업데이트 (찜 등 즉각 반응 필요 시)
+
+- onMutate: cancelQueries → getQueryData(이전값 저장) → setQueryData(낙관적 변경)
+- onError: 이전값으로 롤백
+- onSettled: invalidateQueries + revalidateTag로 서버/클라이언트 둘 다 최종 동기화
+
+## 주의사항
+
+- staleTime = 0이면 클라이언트 도착 즉시 재요청 → prefetch 의미 없음
+- useOptimistic과 TanStack Query를 같은 데이터에 혼용 금지 (충돌)
+- 서버 컴포넌트에서 useQuery/useMutation 사용 불가 (React 훅이므로)

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: local-review
+description: 프로젝트 규칙 기반 코드 리뷰 수행
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash(gh *)
+---
+
+현재 변경된 파일들을 프로젝트 규칙 기준으로 리뷰해줘.
+
+## 리뷰 체크리스트
+
+### 1. 서버/클라이언트 분리 (CRITICAL)
+
+- page.tsx, layout.tsx에 'use client' 없는지
+- 'use client'가 말단 컴포넌트에만 있는지
+- 인터랙션 없는 컴포넌트가 불필요하게 클라이언트인지
+- 서버 컴포넌트에서 useQuery, useState 등 훅 사용하지 않는지
+
+### 2. 데이터 Fetch 패턴 (CRITICAL)
+
+- 공개 데이터: prefetchQuery + HydrationBoundary + useQuery 패턴인지
+- 유저별 데이터: useSuspenseQuery + SuspenseBoundary인지
+- 서버에서 fetch 사용하는지 (axios 사용 금지)
+- 클라이언트에서 axios 사용하는지
+- 병렬 fetch에 Promise.all 사용하는지
+
+### 3. 캐싱 & 무효화 (HIGH)
+
+- 서버 fetch에 next: { tags } 지정했는지
+- mutation 시 이중 무효화 (invalidateQueries + revalidateTag) 하는지
+- staleTime > 0 설정했는지
+- queryKey가 서버/클라이언트에서 일치하는지
+
+### 4. ErrorBoundary / SuspenseBoundary (HIGH)
+
+- API 호출 있는 컴포넌트에 ErrorBoundary 있는지
+- prefetch 없는 클라이언트 컴포넌트에 SuspenseBoundary 있는지
+- 섹션 단위로 개별 감싸고 있는지 (페이지 전체 X)
+
+### 5. 코드 스타일 (MEDIUM)
+
+- named export 사용하는지 (page.tsx 제외)
+- TypeScript strict: any 사용하지 않는지
+- interface로 Props 정의했는지
+- 파일 명명 규칙 (PascalCase, useCamelCase)
+
+### 6. 보안 (HIGH)
+
+- 서버 전용 코드 (API 키, DB 접근)가 클라이언트에 유출되지 않는지
+- process.env를 클라이언트 컴포넌트에서 직접 사용하지 않는지
+
+## 참조 문서
+
+- 렌더링 규칙: @.claude/rules/rendering.md
+- TanStack Query 규칙: @.claude/rules/tanstack-query.md
+- 코드 스타일: @.claude/rules/code-style.md
+
+## 출력 형식
+
+발견된 이슈를 심각도별로 정리:
+
+- **CRITICAL**: 반드시 수정 필요
+- **HIGH**: 수정 권장
+- **MEDIUM**: 개선 제안
+- **OK**: 문제 없음 (체크리스트 통과 항목)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,74 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          claude_args: |
+            --model claude-sonnet-4-5-20250929
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            이 PR을 프로젝트 규칙(CLAUDE.md, .claude/rules/)에 따라 리뷰해줘.
+
+            ## 리뷰 기준 (심각도 순)
+
+            ### CRITICAL
+            - page.tsx에 'use client' 사용 여부
+            - 서버 컴포넌트에서 React 훅(useQuery, useState 등) 사용 여부
+            - 서버에서 axios 사용 여부 (fetch만 허용)
+            - mutation 시 이중 캐시 무효화 누락 (invalidateQueries + revalidateTag)
+
+            ### HIGH
+            - 공개 데이터에 prefetchQuery + HydrationBoundary 패턴 사용 여부
+            - API 호출 컴포넌트의 ErrorBoundary 누락
+            - prefetch 없는 클라이언트 컴포넌트의 SuspenseBoundary 누락
+            - staleTime 미설정 (prefetch 무의미)
+            - queryKey 서버/클라이언트 불일치
+
+            ### MEDIUM
+            - 'use client' 경계가 불필요하게 넓은지
+            - named export 미사용
+            - any 타입 사용
+            - Promise.all 누락 (순차 fetch)
+
+            ## 코멘트 방식
+            - 구체적인 코드 이슈는 인라인 코멘트(mcp__github_inline_comment__create_inline_comment, confirmed: true)로 남겨줘
+            - 수정이 필요한 코드는 GitHub Suggestion 블록으로 제안해줘:
+              ```suggestion
+              수정된 코드
+              ```
+            - 전체적인 피드백과 요약은 `gh pr comment`로 PR 탑레벨 코멘트로 남겨줘
+            - 잘 작성된 부분도 언급해줘

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# 완성도 - AI 코딩 가이드
+
+> 이 파일은 Cursor, Copilot, Windsurf 등 다양한 AI 코딩 도구를 위한 프로젝트 규칙입니다.
+> 프로젝트의 모든 코딩 규칙은 **CLAUDE.md**에 원본이 관리되며, 이 파일은 이를 참조합니다.
+
+## 규칙 원본
+
+이 프로젝트는 `CLAUDE.md`를 Single Source of Truth로 사용합니다.
+모든 AI 도구는 아래 파일들을 읽고 규칙을 따라주세요.
+
+| 파일                              | 내용                                                               |
+| --------------------------------- | ------------------------------------------------------------------ |
+| `CLAUDE.md`                       | 프로젝트 전체 규칙 (빌드, 검증, 아키텍처, Git 컨벤션, 코드 스타일) |
+| `.claude/rules/rendering.md`      | 렌더링 & 캐싱 전략 상세                                            |
+| `.claude/rules/tanstack-query.md` | TanStack Query v5 패턴 상세                                        |
+| `.claude/rules/code-style.md`     | 코드 스타일 규칙 상세                                              |
+
+규칙 변경 시 `CLAUDE.md` 또는 `.claude/rules/` 파일을 직접 수정하세요.
+이 파일은 참조 안내 역할이므로 별도 수정이 필요하지 않습니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@
 - 커밋: Conventional Commits (`feat:`, `fix:`, `chore:`, `style:`, `refactor:`, `docs:`)
 - Jira 이슈 키: SM-XX 형식
 - **IMPORTANT**: PR은 Squash and Merge만 사용 (PR 제목 = 최종 커밋 메시지)
+- PR 전 base 브랜치(dev) 최신화: `git fetch origin && git rebase origin/dev`
+- 충돌 발생 시: 충돌 해결 → `git add .` → `git rebase --continue`
 
 ## 코드 스타일
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# 완성도 (스터디, 프로젝트 모임 서비스)
+
+## 빌드 & 실행
+
+- `npm install` → 의존성 설치
+- `npm run dev` → 개발 서버
+- `npm run build` → 프로덕션 빌드
+- `npm run lint` → ESLint 검사
+- `npm run storybook` → Storybook 개발 서버
+
+## 검증
+
+- 코드 변경 후 반드시 `npm run build`로 빌드 확인
+- 린트: `npm run lint`
+- 타입 체크: `npx tsc --noEmit`
+- 단위 테스트: `npx jest` (단일 파일: `npx jest path/to/file`)
+- E2E 테스트: `npx playwright test`
+- **IMPORTANT**: 전체 테스트 대신 관련 파일만 단일 실행 선호
+
+## 기술 스택
+
+- Next.js 16 (App Router), React 19, TypeScript strict
+- TanStack Query v5, Zustand (클라이언트 상태), react-hook-form + Zod
+- Axios (클라이언트), fetch (서버)
+- TailwindCSS v4, CVA, clsx, tailwind-merge
+- Storybook 10
+
+## 아키텍처 원칙
+
+- **IMPORTANT**: page.tsx, layout.tsx는 항상 서버 컴포넌트 유지
+- **MUST**: 'use client'는 인터랙션이 필요한 말단(leaf) 컴포넌트에만 선언
+- 서버에서 fetch 가능하면 서버에서. 클라이언트 fetch는 최후 수단
+- 병렬 fetch는 Promise.all 필수
+
+## 렌더링 & 캐싱 전략
+
+- 상세 규칙: @.claude/rules/rendering.md
+- 공개 데이터: 서버 prefetchQuery + HydrationBoundary + 클라이언트 useQuery
+- 유저별 데이터: 클라이언트 useSuspenseQuery + Suspense 경계
+- API 호출 있는 컴포넌트: ErrorBoundary로 에러 격리
+- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + revalidateTag
+
+## TanStack Query
+
+- 상세 규칙: @.claude/rules/tanstack-query.md
+
+## Git 컨벤션
+
+- 브랜치: `feat/SM-XX`, `fix/SM-XX`, `chore/SM-XX` (Jira 이슈 키 기반)
+- 커밋: Conventional Commits (`feat:`, `fix:`, `chore:`, `style:`, `refactor:`, `docs:`)
+- Jira 이슈 키: SM-XX 형식
+- **IMPORTANT**: PR은 Squash and Merge만 사용 (PR 제목 = 최종 커밋 메시지)
+
+## 코드 스타일
+
+- 상세 규칙: @.claude/rules/code-style.md
+- 함수 선언: 컴포넌트/페이지는 `function`, 나머지(훅, 유틸, API 등)는 화살표 함수
+- named export 사용 (default export는 page.tsx, layout.tsx만)
+- 컴포넌트는 폴더로 관리: `ComponentName/index.tsx`, `index.test.tsx`, `index.stories.tsx`
+- 훅 파일명: `useCamelCase.ts`
+- 타입은 interface 우선 (type은 유니온/교차 시만)
+- Props interface는 같은 파일, 컴포넌트 바로 위에 선언
+
+## 폴더 구조
+
+```
+src/
+├── app/                    # Next.js App Router (페이지, 레이아웃)
+├── components/             # 공통 컴포넌트
+│   └── GatheringCard/      # 컴포넌트 폴더 단위
+│       ├── index.tsx
+│       ├── index.test.tsx
+│       └── index.stories.tsx
+├── hooks/                  # 공통 커스텀 훅
+├── stores/                 # Zustand 스토어
+├── lib/                    # 유틸리티, 헬퍼
+├── types/                  # 공통 타입 정의
+├── api/                    # API 관련
+│   └── users/              # 도메인별 폴더
+│       ├── index.ts        # API 함수
+│       ├── types.ts        # 요청/응답 타입
+│       ├── schemas.ts      # Zod 스키마
+│       └── queries.ts      # queryKey, queryFn
+└── actions/                # Server Actions
+```


### PR DESCRIPTION
## ❓ 이슈

- close #18 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
팀원 간 코드 일관성을 위해 AI 코딩 도구에 프로젝트 규칙을 주입합니다.

  **추가된 파일:**
  - `CLAUDE.md` — Claude Code 세션 규칙 (빌드, 검증, 아키텍처, Git 컨벤션, 코드
  스타일)
  - `AGENTS.md` — Cursor/Copilot/Windsurf용 규칙 참조 안내
  - `.claude/rules/rendering.md` — 렌더링 & 캐싱 전략
  - `.claude/rules/tanstack-query.md` — TanStack Query v5 패턴
  - `.claude/rules/code-style.md` — 코드 스타일 규칙
  - `.claude/skills/local-review/SKILL.md` — /local-review 코드 리뷰 스킬
  - `.github/workflows/claude-review.yml` — PR 자동 리뷰 워크플로우

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes
- GitHub에 CLAUDE_CODE_OAUTH_TOKEN Secret 등록
 - https://github.com/apps/claude 레포에 설치