### PR TITLE
[SM-31] ui: Input 공통 컴포넌트 설계

### DIFF
--- a/src/components/ui/Input/index.stories.tsx
+++ b/src/components/ui/Input/index.stories.tsx
@@ -2,20 +2,16 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Input } from './index';
 
 const meta: Meta<typeof Input> = {
-  title: 'components/Input', // 스토리북 좌측 메뉴 구조
+  title: 'components/Input',
   component: Input,
-  tags: ['autodocs'], // 자동으로 Props 문서 생성
+  tags: ['autodocs'],
   argTypes: {
-    // 스토리북 제어판에서 테스트할 속성들
     type: {
       control: 'select',
       options: ['text', 'password', 'email'],
     },
-    error: {
-      control: 'text',
-    },
   },
-};
+} satisfies Meta<typeof Input>;
 
 export default meta;
 type Story = StoryObj<typeof Input>;
@@ -51,7 +47,7 @@ export const Password: Story = {
   args: {
     label: '비밀번호',
     type: 'password',
-    placeholder: '비밀번호를 입력해주세요',
+    placeholder: '영문, 숫자, 특수문자 포함 8자 이상 입력해주세요',
   },
 };
 

--- a/src/components/ui/Input/index.stories.tsx
+++ b/src/components/ui/Input/index.stories.tsx
@@ -1,8 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/nextjs';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Input } from './index';
 
 const meta: Meta<typeof Input> = {
-  title: 'Common/Input', // 스토리북 좌측 메뉴 구조
+  title: 'Components/Input', // 스토리북 좌측 메뉴 구조
   component: Input,
   tags: ['autodocs'], // 자동으로 Props 문서 생성
   argTypes: {

--- a/src/components/ui/Input/index.stories.tsx
+++ b/src/components/ui/Input/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Input } from './index';
 
 const meta: Meta<typeof Input> = {
-  title: 'Components/Input', // 스토리북 좌측 메뉴 구조
+  title: 'components/Input', // 스토리북 좌측 메뉴 구조
   component: Input,
   tags: ['autodocs'], // 자동으로 Props 문서 생성
   argTypes: {

--- a/src/components/ui/Input/index.stories.tsx
+++ b/src/components/ui/Input/index.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { Input } from './index';
+
+const meta: Meta<typeof Input> = {
+  title: 'Common/Input', // 스토리북 좌측 메뉴 구조
+  component: Input,
+  tags: ['autodocs'], // 자동으로 Props 문서 생성
+  argTypes: {
+    // 스토리북 제어판에서 테스트할 속성들
+    type: {
+      control: 'select',
+      options: ['text', 'password', 'email'],
+    },
+    error: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+// 1. 이메일 타입 (Email)
+export const Email: Story = {
+  args: {
+    label: '이메일',
+    placeholder: '이메일을 입력해주세요',
+  },
+};
+
+// 2. 닉네임 타입 (Nickname)
+export const Nickname: Story = {
+  args: {
+    label: '닉네임',
+    placeholder: '닉네임을 입력해주세요',
+  },
+};
+
+// 3. 에러 발생 상태 (Error)
+export const WithError: Story = {
+  args: {
+    label: '이메일',
+    placeholder: '이메일을 입력해주세요',
+    error: '올바른 이메일 형식이 아닙니다.',
+    defaultValue: 'wrong-email@',
+  },
+};
+
+// 4. 비밀번호 타입 (Password)
+export const Password: Story = {
+  args: {
+    label: '비밀번호',
+    type: 'password',
+    placeholder: '비밀번호를 입력해주세요',
+  },
+};
+
+// 5. 라벨 없는 상태 (No Label)
+export const NoLabel: Story = {
+  args: {
+    placeholder: '',
+  },
+};

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,0 +1,38 @@
+import React, { forwardRef, useId } from 'react';
+import { cn } from '../../../lib/utils'; // cn 유틸리티 사용 가정
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string; // 라벨 텍스트
+  error?: string; // 에러 메시지
+  wrapperClassName?: string; // 라벨 + 인풋 + 에러 메시지 컨테이너
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, wrapperClassName, className, ...props }, ref) => {
+    const id = useId();
+
+    return (
+      <div className={cn('flex flex-col gap-1.5', wrapperClassName)}>
+        {label && (
+          <label htmlFor={id} className='text-sm font-medium'>
+            {label}
+          </label>
+        )}
+
+        <input
+          id={id}
+          ref={ref}
+          className={cn('w-full outline-none', error && 'border-red-500', className)}
+          {...props}
+        />
+
+        {/* Error Message: 에러가 있을 때만 텍스트 노출 */}
+        {error && <p className='text-xs text-red-500'>{error}</p>}
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';
+
+export { Input };

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,39 +1,40 @@
 'use client';
-import React, { forwardRef, useId } from 'react';
-import { cn } from '@/lib/cn'; // cn 유틸리티 사용 가정
+import { cva, type VariantProps } from 'class-variance-authority';
+import { forwardRef, useId, type InputHTMLAttributes } from 'react';
+import { cn } from '@/lib/cn';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  label?: string; // 라벨 텍스트
-  error?: string; // 에러 메시지
-  wrapperClassName?: string; // 라벨 + 인풋 + 에러 메시지 컨테이너
+const inputVariants = cva('w-full border rounded px-3 py-2 outline-none', {
+  variants: {
+    hasError: {
+      true: 'border-red-500', // 에러 시 빨간 테두리만 미리 지정
+      false: 'border-gray-300', // 기본 상태
+    },
+  },
+  defaultVariants: {
+    hasError: false,
+  },
+});
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement>, VariantProps<typeof inputVariants> {
+  label?: string;
+  error?: string;
 }
 
-const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, wrapperClassName, className, ...props }, ref) => {
-    const id = useId();
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ label, error, className, type, ...props }, ref) => {
+  const id = useId();
+  const hasError = !!error;
 
-    return (
-      <div className={cn('flex flex-col gap-1.5', wrapperClassName)}>
-        {label && (
-          <label htmlFor={id} className='text-sm font-medium'>
-            {label}
-          </label>
-        )}
-
-        <input
-          id={id}
-          ref={ref}
-          className={cn('w-full outline-none', error && 'border-red-500', className)}
-          {...props}
-        />
-
-        {/* Error Message: 에러가 있을 때만 텍스트 노출 */}
-        {error && <p className='text-xs text-red-500'>{error}</p>}
-      </div>
-    );
-  },
-);
+  return (
+    <div className='flex flex-col gap-1.5'>
+      {label && (
+        <label htmlFor={id} className='text-sm font-bold'>
+          {label}
+        </label>
+      )}
+      <input id={id} type={type} ref={ref} className={cn(inputVariants({ hasError }), className)} {...props} />
+      {error && <p className='text-xs text-red-500'>{error}</p>}
+    </div>
+  );
+});
 
 Input.displayName = 'Input';
-
-export { Input };

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -20,7 +20,10 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement>, VariantProps
   error?: string;
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(({ label, error, className, type, ...props }, ref) => {
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { label, error, className, type, ...props },
+  ref,
+) {
   const id = useId();
   const hasError = !!error;
 
@@ -36,5 +39,3 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({ label, error, c
     </div>
   );
 });
-
-Input.displayName = 'Input';

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useId } from 'react';
-import { cn } from '../../../lib/utils'; // cn 유틸리티 사용 가정
+import { cn } from '@/lib/cn'; // cn 유틸리티 사용 가정
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string; // 라벨 텍스트

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { forwardRef, useId } from 'react';
 import { cn } from '@/lib/cn'; // cn 유틸리티 사용 가정
 


### PR DESCRIPTION
## ❓ 이슈

- close #22 

## ✍️ Description

디자인 시스템 확정 전 공통 컴포넌트 기반 작업입니다.

- 공통 Input 컴포넌트의 기본 구조를 생성했습니다.
- Storybook 스토리 파일을 생성하여 기본 렌더링을 확인할 수 있도록 했습니다.

현재는 스타일 없이 구조만 정의했으며, variant, size 등의 스타일 옵션은 디자인 시스템 확정 이후 추가 예정입니다.
## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

