### PR TITLE
[SM-32] feat: TanStack Query 초기 설정 및 QueryClient 구조 구성

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import QueryProvider from '@/providers/QueryProvider';
+import { QueryProvider } from '@/providers/QueryProvider';
 
 export default function RootLayout({
   children,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import QueryProvider from '@/providers/QueryProvider';
 
 export default function RootLayout({
   children,
@@ -7,7 +8,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-      <body>{children}</body>
+      <body>
+        <QueryProvider>{children}</QueryProvider>
+      </body>
     </html>
   );
 }

--- a/src/lib/getQueryClient.ts
+++ b/src/lib/getQueryClient.ts
@@ -1,7 +1,7 @@
 import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/react-query';
 import { cache } from 'react';
 
-function makeQueryClient() {
+const makeQueryClient = () => {
   return new QueryClient({
     defaultOptions: {
       queries: {
@@ -12,7 +12,7 @@ function makeQueryClient() {
       },
     },
   });
-}
+};
 
 const getServerQueryClient = cache(() => makeQueryClient());
 

--- a/src/lib/getQueryClient.ts
+++ b/src/lib/getQueryClient.ts
@@ -1,0 +1,28 @@
+import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/react-query';
+import { cache } from 'react';
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // 1분
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) => defaultShouldDehydrateQuery(query) || query.state.status === 'pending',
+      },
+    },
+  });
+}
+
+const getServerQueryClient = cache(() => makeQueryClient());
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export function getQueryClient() {
+  if (isServer) {
+    return getServerQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}

--- a/src/lib/invalidateServerCache.ts
+++ b/src/lib/invalidateServerCache.ts
@@ -1,0 +1,5 @@
+import { updateTag } from 'next/cache';
+
+export function invalidateServerCache(tag: string) {
+  updateTag(tag);
+}

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -3,7 +3,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { getQueryClient } from '@/lib/getQueryClient';
 
-export default function QueryProvider({ children }: { children: React.ReactNode }) {
+export function QueryProvider({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { getQueryClient } from '@/lib/getQueryClient';
+
+export default function QueryProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = getQueryClient();
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #26 

## ✍️ Description

TanStack Query를 프로젝트에 도입하기 위한 초기 세팅을 진행했습니다.

서버와 클라이언트 환경에서 각각 적절한 방식으로 QueryClient를 생성하도록 구조를 분리하고,  
prefetch + HydrationBoundary 패턴을 사용할 수 있도록 기반을 구성했습니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- 서버에서는 `React.cache`를 사용해 요청 단위로 QueryClient가 재사용되도록 구성
- 클라이언트에서는 싱글톤 형태로 QueryClient를 유지
- prefetch된 데이터를 HydrationBoundary로 전달할 수 있는 구조 확보
- `staleTime`을 설정하여 prefetch의 의미가 유지되도록 고려
