### PR TITLE
[SM-34] feat: 공통 컴포넌트 Badge 추가

### DIFF
--- a/src/components/ui/Badge/index.stories.tsx
+++ b/src/components/ui/Badge/index.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Badge } from '.';
+
+const meta = {
+  title: 'components/Badge',
+  component: Badge,
+  args: {
+    children: 'Badge',
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['category', 'status', 'tag'],
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Category: Story = {
+  args: {
+    variant: 'category',
+    children: '카테고리',
+  },
+};
+
+export const Status: Story = {
+  args: {
+    variant: 'status',
+    children: '모집중',
+  },
+};
+
+export const Tag: Story = {
+  args: {
+    variant: 'tag',
+    children: '태그',
+  },
+};

--- a/src/components/ui/Badge/index.tsx
+++ b/src/components/ui/Badge/index.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+const badgeVariants = cva('', {
+  variants: {
+    variant: {
+      category: '',
+      status: '',
+      tag: '',
+    },
+  },
+  defaultVariants: {
+    variant: 'tag',
+  },
+});
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {
+  children: ReactNode;
+}
+
+export function Badge({ children, variant, className, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Badge/index.tsx
+++ b/src/components/ui/Badge/index.tsx
@@ -1,7 +1,5 @@
-'use client';
-
-import { cva, type VariantProps } from 'class-variance-authority';
 import { type HTMLAttributes, type ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/cn';
 
 const badgeVariants = cva('', {


### PR DESCRIPTION
## ❓ 이슈

- close #31 

## ✍️ Description

모임 카테고리, 상태, 태그 등을 표시하는 범용 Badge 컴포넌트 생성 


- src/components/ui/Badge/index.tsx 생성 (스타일 없이 구조만)

- src/components/ui/Badge/index.stories.tsx 생성 (기본 스토리)


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes


