### PR TITLE
[SM-37] feat: useQueryParams 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sail-mate",
       "version": "0.1.0",
       "dependencies": {
+        "@frontend-toolkit-js/hooks": "^0.6.0",
         "@hookform/resolvers": "^5.2.2",
         "@sentry/nextjs": "^10.43.0",
         "@tanstack/react-query": "^5.90.21",
@@ -1465,6 +1466,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@frontend-toolkit-js/hooks": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@frontend-toolkit-js/hooks/-/hooks-0.6.0.tgz",
+      "integrity": "sha512-FtmgDK9O1awjGKVQmEjprsibe1e80twA/4//DoKbsp85se6m1fQMl5jsBdMHJxjCY2NNa/KZn+Wrlng2tCIVJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "next": ">=13.0.0",
+        "react": ">=18.0.0",
+        "react-router-dom": ">=6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hookform/resolvers": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@frontend-toolkit-js/hooks": "^0.6.0",
     "@hookform/resolvers": "^5.2.2",
     "@sentry/nextjs": "^10.43.0",
     "@tanstack/react-query": "^5.90.21",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import { QueryParamsProvider } from '@/providers/QueryParamsProvider';
 import { QueryProvider } from '@/providers/QueryProvider';
 
 export default function RootLayout({
@@ -9,7 +10,9 @@ export default function RootLayout({
   return (
     <html lang='ko'>
       <body>
-        <QueryProvider>{children}</QueryProvider>
+        <QueryProvider>
+          <QueryParamsProvider>{children}</QueryParamsProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/src/providers/QueryParamsProvider.tsx
+++ b/src/providers/QueryParamsProvider.tsx
@@ -4,12 +4,20 @@ import { ReactNode, Suspense } from 'react';
 import { QueryParamsProvider as Provider } from '@frontend-toolkit-js/hooks';
 import { useNextAppAdapter } from '@frontend-toolkit-js/hooks/useQueryParams/adapters/next-app';
 
-function QueryParamsProviderInner({ children }: { children: ReactNode }) {
+interface QueryParamsProviderInnerProps {
+  children: ReactNode;
+}
+
+function QueryParamsProviderInner({ children }: QueryParamsProviderInnerProps) {
   const adapter = useNextAppAdapter();
   return <Provider adapter={adapter}>{children}</Provider>;
 }
 
-export function QueryParamsProvider({ children }: { children: ReactNode }) {
+interface QueryParamsProviderProps {
+  children: ReactNode;
+}
+
+export function QueryParamsProvider({ children }: QueryParamsProviderProps) {
   return (
     <Suspense fallback={null}>
       <QueryParamsProviderInner>{children}</QueryParamsProviderInner>

--- a/src/providers/QueryParamsProvider.tsx
+++ b/src/providers/QueryParamsProvider.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { ReactNode, Suspense } from 'react';
+import { QueryParamsProvider as Provider } from '@frontend-toolkit-js/hooks';
+import { useNextAppAdapter } from '@frontend-toolkit-js/hooks/useQueryParams/adapters/next-app';
+
+function QueryParamsProviderInner({ children }: { children: ReactNode }) {
+  const adapter = useNextAppAdapter();
+  return <Provider adapter={adapter}>{children}</Provider>;
+}
+
+export function QueryParamsProvider({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={null}>
+      <QueryParamsProviderInner>{children}</QueryParamsProviderInner>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## ❓ 이슈

- close #34 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
@frontend-toolkit-js/hooks의 useQueryParams 훅 사용을 위한
  Provider 설정

  - @frontend-toolkit-js/hooks 패키지 설치
  - QueryParamsProvider 컴포넌트 생성 (useNextAppAdapter + Suspense 래핑)
  - 루트 레이아웃(layout.tsx)에 QueryParamsProvider 적용

### 가이드
https://frontend-toolkit-dev.vercel.app/hooks/use-query-params

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->
- 테스트 페이지로 수동 검증 완료 (URL 동기화, 상태 유지, 잘못
   값 fallback 등)
- 추후 검색 등에서 useDebounce / useDebounceCallback으로 query
  params 디바운스 처리 필요

