### PR TITLE
[SM-35] feat: 공통 컴포넌트 Card 추가

### DIFF
--- a/src/components/ui/Card/index.stories.tsx
+++ b/src/components/ui/Card/index.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Card } from '.';
+
+const meta = {
+  title: 'components/Card',
+  component: Card,
+  args: {
+    children: 'Card',
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/ui/Card/index.tsx
+++ b/src/components/ui/Card/index.tsx
@@ -1,0 +1,25 @@
+import React, { HTMLAttributes } from 'react';
+import { cva, VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/cn';
+
+const cardVariants = cva('', {
+  variants: {
+    variant: {},
+    size: {},
+    interactive: {},
+  },
+  defaultVariants: {},
+});
+
+interface CardProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof cardVariants> {
+  children: React.ReactNode;
+}
+
+export function Card({ children, variant, size, interactive, className, ...props }: CardProps) {
+  const cardClasses = cn(cardVariants({ variant, size, interactive }), className);
+  return (
+    <div className={cardClasses} {...props}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## ❓ 이슈

- close #32 

## ✍️ Description

범용 Card 컴포넌트 생성 (GatheringCard 등에서 활용 예정)

src/components/ui/Card/index.tsx 생성 (스타일 없이 구조만)
src/components/ui/Card/index.stories.tsx 생성 (기본 스토리)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


