### PR TITLE
[SM-38] feat:공통 컴포넌트 Toast 설계

### DIFF
--- a/src/components/ui/Toast/ToastProvider.tsx
+++ b/src/components/ui/Toast/ToastProvider.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Toast } from './index';
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastItem {
+  id: string;
+  variant?: ToastVariant;
+  title?: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+}
+
+interface ToastProviderProps {
+  children: ReactNode;
+  durationMs?: number;
+}
+
+interface ToastContextType {
+  showToast: (toast: Omit<ToastItem, 'id'>) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+const createToastId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export function ToastProvider({ children, durationMs = 3000 }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timeoutIdsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const removeToast = useCallback((id: string) => {
+    const timeoutId = timeoutIdsRef.current.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutIdsRef.current.delete(id);
+    }
+
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    ({ variant, title, description, action }: Omit<ToastItem, 'id'>) => {
+      const id = createToastId();
+      setToasts((prev) => [...prev, { id, variant, title, description, action }]);
+
+      const timeoutId = setTimeout(() => {
+        removeToast(id);
+      }, durationMs);
+
+      timeoutIdsRef.current.set(id, timeoutId);
+    },
+    [durationMs, removeToast],
+  );
+
+  useEffect(() => {
+    return () => {
+      timeoutIdsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIdsRef.current.clear();
+    };
+  }, []);
+
+  const value = useMemo<ToastContextType>(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        style={{
+          position: 'fixed',
+          top: '1rem',
+          right: '1rem',
+          zIndex: 9999,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.5rem',
+        }}
+      >
+        {toasts.map((toast) => (
+          <Toast
+            key={toast.id}
+            variant={toast.variant}
+            title={toast.title}
+            description={toast.description}
+            action={toast.action}
+            onClose={() => removeToast(toast.id)} // 닫기 버튼 클릭 시 수동 삭제
+          />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) throw new Error('useToast must be used within ToastProvider');
+  return context;
+};

--- a/src/components/ui/Toast/ToastProvider.tsx
+++ b/src/components/ui/Toast/ToastProvider.tsx
@@ -1,102 +1,42 @@
 'use client';
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/lib/cn';
+
 import { Toast } from './index';
+import { useToastStore } from './useToastStore';
 
-type ToastVariant = 'success' | 'error' | 'warning' | 'info';
-
-interface ToastItem {
-  id: string;
-  variant?: ToastVariant;
-  title?: ReactNode;
-  description?: ReactNode;
-  action?: ReactNode;
-}
+import type { ReactNode } from 'react';
 
 interface ToastProviderProps {
   children: ReactNode;
-  durationMs?: number;
 }
 
-interface ToastContextType {
-  showToast: (toast: Omit<ToastItem, 'id'>) => void;
-}
-
-const ToastContext = createContext<ToastContextType | undefined>(undefined);
-
-const createToastId = () => {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-};
-
-export function ToastProvider({ children, durationMs = 3000 }: ToastProviderProps) {
-  const [toasts, setToasts] = useState<ToastItem[]>([]);
-  const timeoutIdsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-
-  const removeToast = useCallback((id: string) => {
-    const timeoutId = timeoutIdsRef.current.get(id);
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      timeoutIdsRef.current.delete(id);
-    }
-
-    setToasts((prev) => prev.filter((t) => t.id !== id));
-  }, []);
-
-  const showToast = useCallback(
-    ({ variant, title, description, action }: Omit<ToastItem, 'id'>) => {
-      const id = createToastId();
-      setToasts((prev) => [...prev, { id, variant, title, description, action }]);
-
-      const timeoutId = setTimeout(() => {
-        removeToast(id);
-      }, durationMs);
-
-      timeoutIdsRef.current.set(id, timeoutId);
-    },
-    [durationMs, removeToast],
-  );
-
-  useEffect(() => {
-    return () => {
-      timeoutIdsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
-      timeoutIdsRef.current.clear();
-    };
-  }, []);
-
-  const value = useMemo<ToastContextType>(() => ({ showToast }), [showToast]);
+export function ToastProvider({ children }: ToastProviderProps) {
+  const { toasts, removeToast } = useToastStore();
+  const portalRoot = typeof document !== 'undefined' ? document.body : null;
 
   return (
-    <ToastContext.Provider value={value}>
+    <>
       {children}
-      <div
-        style={{
-          position: 'fixed',
-          top: '1rem',
-          right: '1rem',
-          zIndex: 9999,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '0.5rem',
-        }}
-      >
-        {toasts.map((toast) => (
-          <Toast
-            key={toast.id}
-            variant={toast.variant}
-            title={toast.title}
-            description={toast.description}
-            action={toast.action}
-            onClose={() => removeToast(toast.id)} // 닫기 버튼 클릭 시 수동 삭제
-          />
-        ))}
-      </div>
-    </ToastContext.Provider>
+      {portalRoot &&
+        createPortal(
+          <div className={cn('pointer-events-none fixed top-4 right-4 z-9999 flex flex-col gap-2')}>
+            {toasts.map((toast) => (
+              <div key={toast.id} className='pointer-events-auto'>
+                <Toast
+                  variant={toast.variant}
+                  title={toast.title}
+                  description={toast.description}
+                  action={toast.action}
+                  onClose={() => removeToast(toast.id)}
+                />
+              </div>
+            ))}
+          </div>,
+          portalRoot,
+        )}
+    </>
   );
 }
-
-export const useToast = () => {
-  const context = useContext(ToastContext);
-  if (!context) throw new Error('useToast must be used within ToastProvider');
-  return context;
-};

--- a/src/components/ui/Toast/ToastProvider.tsx
+++ b/src/components/ui/Toast/ToastProvider.tsx
@@ -22,7 +22,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
       {children}
       {portalRoot &&
         createPortal(
-          <div className={cn('pointer-events-none fixed top-4 right-4 z-9999 flex flex-col gap-2')}>
+          <div className={cn('pointer-events-none fixed top-4 right-4 z-50 flex flex-col gap-2')}>
             {toasts.map((toast) => (
               <div key={toast.id} className='pointer-events-auto'>
                 <Toast

--- a/src/components/ui/Toast/index.stories.tsx
+++ b/src/components/ui/Toast/index.stories.tsx
@@ -1,9 +1,13 @@
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { ToastProvider, useToast } from './ToastProvider';
 import { Button } from '../Button';
+import { Toast } from './index';
+import { ToastProvider } from './ToastProvider';
+import { useToastStore } from './useToastStore';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
   title: 'components/Toast',
+  component: Toast,
   parameters: {
     layout: 'centered',
   },
@@ -23,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Interactive: Story = {
   render: () => {
-    const { showToast } = useToast();
+    const showToast = useToastStore((state) => state.showToast);
 
     return (
       <div style={{ display: 'flex', gap: '10px' }}>
@@ -32,7 +36,7 @@ export const Interactive: Story = {
             showToast({
               variant: 'success',
               title: '성공!',
-              description: '데이터가 저장되었습니다.',
+              description: '성공하였습니다.',
             })
           }
         >
@@ -44,7 +48,7 @@ export const Interactive: Story = {
             showToast({
               variant: 'error',
               title: '에러 발생',
-              description: '다시 시도해 주세요.',
+              description: '에러가 발생하였습니다.',
             })
           }
         >

--- a/src/components/ui/Toast/index.stories.tsx
+++ b/src/components/ui/Toast/index.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ToastProvider, useToast } from './ToastProvider';
+import { Button } from '../Button';
+
+const meta = {
+  title: 'components/Toast',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Interactive: Story = {
+  render: () => {
+    const { showToast } = useToast();
+
+    return (
+      <div style={{ display: 'flex', gap: '10px' }}>
+        <Button
+          onClick={() =>
+            showToast({
+              variant: 'success',
+              title: '성공!',
+              description: '데이터가 저장되었습니다.',
+            })
+          }
+        >
+          성공 토스트
+        </Button>
+
+        <Button
+          onClick={() =>
+            showToast({
+              variant: 'error',
+              title: '에러 발생',
+              description: '다시 시도해 주세요.',
+            })
+          }
+        >
+          에러 토스트
+        </Button>
+      </div>
+    );
+  },
+};

--- a/src/components/ui/Toast/index.stories.tsx
+++ b/src/components/ui/Toast/index.stories.tsx
@@ -1,9 +1,10 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
 import { Button } from '../Button';
+
 import { Toast } from './index';
 import { ToastProvider } from './ToastProvider';
 import { useToastStore } from './useToastStore';
-
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
   title: 'components/Toast',
@@ -30,7 +31,7 @@ export const Interactive: Story = {
     const showToast = useToastStore((state) => state.showToast);
 
     return (
-      <div style={{ display: 'flex', gap: '10px' }}>
+      <div className='flex gap-[10px]'>
         <Button
           onClick={() =>
             showToast({

--- a/src/components/ui/Toast/index.tsx
+++ b/src/components/ui/Toast/index.tsx
@@ -24,27 +24,20 @@ interface ToastProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'>, Vari
 }
 
 export function Toast({ variant = 'info', title, description, action, onClose, className, ...props }: ToastProps) {
-  const role = variant === 'error' || variant === 'warning' ? 'alert' : 'status';
-
   return (
-    <div
-      role={role}
-      aria-live={role === 'alert' ? 'assertive' : 'polite'}
-      className={cn(toastVariants({ variant }), className)}
-      {...props}
-    >
+    <div role='status' className={cn(toastVariants({ variant }), className)} {...props}>
       {(title || onClose) && (
-        <div>
-          {title && <div>{title}</div>}
+        <div className='toast-header'>
+          {title && <strong className='toast-title'>{title}</strong>}
           {onClose && (
-            <button type='button' onClick={onClose} aria-label='닫기'>
-              닫기
+            <button type='button' onClick={onClose}>
+              X
             </button>
           )}
         </div>
       )}
-      {description && <div>{description}</div>}
-      {action && <div>{action}</div>}
+      {description && <div className='toast-description'>{description}</div>}
+      {action && <div className='toast-action'>{action}</div>}
     </div>
   );
 }

--- a/src/components/ui/Toast/index.tsx
+++ b/src/components/ui/Toast/index.tsx
@@ -1,5 +1,7 @@
 import { type HTMLAttributes, type ReactNode } from 'react';
+
 import { cva, type VariantProps } from 'class-variance-authority';
+
 import { cn } from '@/lib/cn';
 
 const toastVariants = cva('', {

--- a/src/components/ui/Toast/index.tsx
+++ b/src/components/ui/Toast/index.tsx
@@ -1,0 +1,50 @@
+import { type HTMLAttributes, type ReactNode } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/cn';
+
+const toastVariants = cva('', {
+  variants: {
+    variant: {
+      success: '',
+      error: '',
+      warning: '',
+      info: '',
+    },
+  },
+  defaultVariants: {
+    variant: 'info',
+  },
+});
+
+interface ToastProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'>, VariantProps<typeof toastVariants> {
+  title?: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+  onClose?: () => void;
+}
+
+export function Toast({ variant = 'info', title, description, action, onClose, className, ...props }: ToastProps) {
+  const role = variant === 'error' || variant === 'warning' ? 'alert' : 'status';
+
+  return (
+    <div
+      role={role}
+      aria-live={role === 'alert' ? 'assertive' : 'polite'}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    >
+      {(title || onClose) && (
+        <div>
+          {title && <div>{title}</div>}
+          {onClose && (
+            <button type='button' onClick={onClose} aria-label='닫기'>
+              닫기
+            </button>
+          )}
+        </div>
+      )}
+      {description && <div>{description}</div>}
+      {action && <div>{action}</div>}
+    </div>
+  );
+}

--- a/src/components/ui/Toast/useToastStore.ts
+++ b/src/components/ui/Toast/useToastStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+import type { ReactNode } from 'react';
+
+const DEFAULT_DURATION = 3000; // showToast의 duration 기본값
+
+const timeoutIdsByToastId = new Map<string, ReturnType<typeof setTimeout>>();
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface ToastItem {
+  id: string;
+  variant?: ToastVariant;
+  title?: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+}
+
+interface ToastState {
+  toasts: ToastItem[];
+  showToast: (toast: Omit<ToastItem, 'id'>, durationMs?: number) => string;
+  removeToast: (id: string) => void;
+}
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+  showToast: (toast, durationMs = DEFAULT_DURATION) => {
+    const id = crypto.randomUUID();
+    set((state) => ({
+      toasts: [...state.toasts, { ...toast, id }],
+    }));
+
+    const timeoutId = setTimeout(() => {
+      get().removeToast(id);
+      timeoutIdsByToastId.delete(id);
+    }, durationMs);
+    timeoutIdsByToastId.set(id, timeoutId);
+
+    return id;
+  },
+  removeToast: (id) => {
+    const timeoutId = timeoutIdsByToastId.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutIdsByToastId.delete(id);
+    }
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.id !== id),
+    }));
+  },
+}));


### PR DESCRIPTION
## ❓ 이슈

- close #38 

## ✍️ Description

성공, 에러, 경고 등을 표시하는 범용 Toast 컴포넌트 생성 스타일 없이 뼈대만 작업합니다.

- src/components/ui/Toast/index.tsx 생성 (스타일 없이 구조만)
- src/components/ui/Toast/ToastProvider.tsx 생성 (Toast의 상태와 함수 관리)
- src/components/ui/Toast/index.stories.tsx 생성 (기본 스토리)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes
