### PR TITLE
[SM-39] feat: 공통 컴포넌트 Textarea 추가

### DIFF
--- a/src/components/ui/Textarea/index.stories.tsx
+++ b/src/components/ui/Textarea/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Textarea } from '.';
+
+const meta = {
+  title: 'components/Textarea',
+  component: Textarea,
+  args: {
+    placeholder: 'Textarea',
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    variant: {
+      control: 'select',
+      options: ['default'],
+    },
+    state: {
+      control: 'select',
+      options: ['default', 'error'],
+    },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Goal: Story = {
+  args: {
+    placeholder: '이 모임에서 달성할 목표를 적어주세요.',
+  },
+};
+
+export const ShortIntro: Story = {
+  args: {
+    placeholder: '모임장에게 한마디를 적어주세요.',
+  },
+};

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,0 +1,32 @@
+import { TextareaHTMLAttributes } from 'react';
+import { cva, VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/cn';
+
+const textareaVariants = cva('w-full px-3 py-2 outline-none focus:ring-2 resize-none', {
+  variants: {
+    variant: {
+      default: 'border border-gray-300 rounded-md',
+    },
+    size: {
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-base',
+    },
+    state: {
+      default: '',
+      error: 'border-red-500 focus:ring-red-500',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'md',
+    state: 'default',
+  },
+});
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, VariantProps<typeof textareaVariants> {}
+
+export function Textarea({ variant, size, state, className, ...props }: TextareaProps) {
+  const textareaClasses = cn(textareaVariants({ variant, size, state }), className);
+  return <textarea className={textareaClasses} {...props} />;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #39 

## ✍️ Description

앱 전역에서 사용할 Textarea 컴포넌트 생성 

src/components/ui/Textarea/index.tsx 생성 (스타일 없이 구조만)
src/components/ui/Textarea/index.stories.tsx 생성 (기본 스토리)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

