### PR TITLE
[SM-43] feat: Auth 도메인 Zod 스키마 및 타입 선언

### DIFF
--- a/src/api/auth/schemas.ts
+++ b/src/api/auth/schemas.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const loginFormSchema = z.object({
+  email: z.string().min(1, '이메일은 필수 입력입니다.').pipe(z.email('이메일 형식으로 작성해 주세요.')),
+  password: z.string().min(1, '비밀번호는 필수 입력입니다.'),
+});
+
+export const signupFormSchema = z
+  .object({
+    email: z.string().min(1, '이메일은 필수 입력입니다.').pipe(z.email('이메일 형식으로 작성해 주세요.')),
+    nickname: z
+      .string()
+      .min(1, '닉네임은 필수 입력입니다.')
+      .min(2, '닉네임은 최소 2자 이상입니다.')
+      .max(10, '닉네임은 최대 10자까지 가능합니다.'),
+    password: z
+      .string()
+      .min(1, '비밀번호는 필수 입력입니다.')
+      .min(8, '비밀번호는 최소 8자 이상입니다.')
+      .refine(
+        (value) => {
+          const hasNumber = /[0-9]/.test(value);
+          const hasAlphabet = /[a-zA-Z]/.test(value);
+          const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(value);
+          return hasNumber && hasAlphabet && hasSpecialChar;
+        },
+        { message: '비밀번호는 숫자, 영문, 특수문자를 포함해야 합니다.' },
+      ),
+    passwordConfirmation: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
+  })
+  .refine((data) => data.password === data.passwordConfirmation, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirmation'],
+  });

--- a/src/api/auth/types.ts
+++ b/src/api/auth/types.ts
@@ -1,0 +1,35 @@
+import type { z } from 'zod';
+
+import type { loginFormSchema, signupFormSchema } from './schemas';
+
+// 폼 타입 (스키마 추론)
+export type LoginForm = z.infer<typeof loginFormSchema>;
+
+export type SignupForm = z.infer<typeof signupFormSchema>;
+
+// 응답 타입
+export interface LoginUser {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImage: string;
+  reputationScore: number;
+}
+
+export interface LoginResponse {
+  user: LoginUser;
+}
+
+export interface RegisterResponse {
+  userId: number;
+  email: string;
+  nickname: string;
+}
+
+export interface OAuthCallbackResponse {
+  isNewUser: boolean;
+}
+
+export interface CheckAvailabilityResponse {
+  available: boolean;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #46 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
API 명세 기반으로 Auth 도메인의 폼 검증 스키마와 API 응답 타입을 선언합니다.
다른 도메인 타입 작업의 레퍼런스가 되는 첫 번째 작업

**생성 파일:**
  - `src/api/auth/schemas.ts` — loginFormSchema, signupFormSchema (Zod v4)
  - `src/api/auth/types.ts` — 폼 타입(z.infer) + 응답 타입(interface)

  **컨벤션:**
  - 요청/폼: Zod 스키마 → z.infer 추론
  - 응답: interface 직접 선언 (BFF에서 토큰 strip되므로 응답 타입에서 제외)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
