### PR TITLE
[SM-41] feat: 공통 컴포넌트 Dropdown 구현

### DIFF
--- a/src/components/ui/Dropdown/Item.tsx
+++ b/src/components/ui/Dropdown/Item.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { useDropdown } from './context';
+
+interface ItemProps {
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+  closeOnSelect?: boolean;
+}
+export function Item({ children, onClick, className, closeOnSelect = true }: ItemProps) {
+  const { close } = useDropdown();
+
+  const handleClick = () => {
+    onClick?.();
+    if (closeOnSelect) close();
+  };
+  return (
+    <li
+      role='option'
+      tabIndex={-1}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+        if (e.key === 'Escape') close();
+      }}
+      onClick={handleClick}
+      className={cn('transition-colors', className)}
+    >
+      {children}
+    </li>
+  );
+}

--- a/src/components/ui/Dropdown/Menu.tsx
+++ b/src/components/ui/Dropdown/Menu.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { ReactNode, useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+
+import { OVERLAY_ANIMATION_DURATION } from '@/constants/overlay';
+import { cn } from '@/lib/cn';
+
+import { useDropdown } from './context';
+
+interface MenuProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function Menu({ children, className }: MenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { isOpen, close } = useDropdown();
+  const [shouldRender, setShouldRender] = useState(isOpen);
+
+  if (isOpen && !shouldRender) setShouldRender(true);
+
+  useEffect(() => {
+    if (!isOpen && shouldRender) {
+      const timer = setTimeout(() => setShouldRender(false), OVERLAY_ANIMATION_DURATION);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, shouldRender]);
+
+  if (!shouldRender) return null;
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const items = Array.from(menuRef.current?.querySelectorAll('[role="option"]') ?? []) as HTMLElement[];
+    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      items[(currentIndex + 1) % items.length]?.focus();
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      items[(currentIndex - 1 + items.length) % items.length]?.focus();
+    }
+    if (e.key === 'Tab') {
+      close();
+    }
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      role='listbox'
+      onKeyDown={handleKeyDown}
+      className={cn('absolute mt-2', isOpen ? 'animate-modal-fade-in' : 'animate-modal-fade-out', className)}
+    >
+      <ul>{children}</ul>
+    </div>
+  );
+}

--- a/src/components/ui/Dropdown/Trigger.tsx
+++ b/src/components/ui/Dropdown/Trigger.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { ReactNode, useRef } from 'react';
+import type { KeyboardEvent } from 'react';
+
+import { OVERLAY_ANIMATION_DURATION } from '@/constants/overlay';
+import { cn } from '@/lib/cn';
+
+import { useDropdown } from './context';
+
+interface TriggerProps {
+  children: ReactNode;
+}
+
+export function Trigger({ children }: TriggerProps) {
+  const { toggle, isOpen, close } = useDropdown();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowDown' && isOpen) {
+      e.preventDefault();
+      const firstItem = triggerRef.current?.closest('[data-dropdown]')?.querySelector('[role="option"]') as HTMLElement;
+      firstItem?.focus();
+    }
+    if (e.key === 'Tab' && isOpen) {
+      close();
+    }
+  };
+
+  return (
+    <button
+      ref={triggerRef}
+      type='button'
+      aria-expanded={isOpen}
+      aria-haspopup='listbox'
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
+      style={{ transitionDuration: `${OVERLAY_ANIMATION_DURATION}ms` }}
+      className={cn('border transition-colors', isOpen ? 'border-black' : 'border-transparent')}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Dropdown/context.ts
+++ b/src/components/ui/Dropdown/context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+interface DropdownContextType {
+  isOpen: boolean;
+  toggle: () => void;
+  close: () => void;
+}
+
+export const DropdownContext = createContext<DropdownContextType | null>(null);
+
+export const useDropdown = () => {
+  const ctx = useContext(DropdownContext);
+  if (!ctx) throw new Error('Dropdown 내부에서만 사용 가능');
+  return ctx;
+};

--- a/src/components/ui/Dropdown/index.stories.tsx
+++ b/src/components/ui/Dropdown/index.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Dropdown } from '.';
+import { useState } from 'react';
+
+const meta = {
+  title: 'components/Dropdown',
+  component: Dropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const dropdownStyle = 'w-60 overflow-hidden bg-gray-100 text-sm';
+const itemStyle = 'cursor-pointer px-4 py-2 transition-colors hover:bg-gray-200';
+
+export const Default: Story = {
+  args: {
+    children: null,
+  },
+  render: () => (
+    <Dropdown>
+      <Dropdown.Trigger>
+        <div className='w-60 cursor-pointer bg-gray-100 px-4 py-2 text-sm'>항목을 선택해주세요</div>
+      </Dropdown.Trigger>
+      <Dropdown.Menu className={dropdownStyle}>
+        <Dropdown.Item className={itemStyle}>항목 1</Dropdown.Item>
+        <Dropdown.Item className={itemStyle}>항목 2</Dropdown.Item>
+        <Dropdown.Item className={itemStyle}>항목 3</Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  ),
+};
+
+// 모임 유형
+export const GatheringType: Story = {
+  args: {
+    children: null,
+  },
+  render: () => {
+    const [selected, setSelected] = useState('모임 유형을 선택해주세요');
+    return (
+      <Dropdown>
+        <Dropdown.Trigger>
+          <div className='w-60 cursor-pointer bg-gray-100 px-4 py-2 text-sm'>{selected}</div>
+        </Dropdown.Trigger>
+        <Dropdown.Menu className={dropdownStyle}>
+          {['전체', '스터디', '사이드 프로젝트'].map((item) => (
+            <Dropdown.Item key={item} className={itemStyle} onClick={() => setSelected(item)}>
+              {item}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    );
+  },
+};

--- a/src/components/ui/Dropdown/index.stories.tsx
+++ b/src/components/ui/Dropdown/index.stories.tsx
@@ -18,25 +18,34 @@ type Story = StoryObj<typeof meta>;
 const dropdownStyle = 'w-60 overflow-hidden bg-gray-100 text-sm';
 const itemStyle = 'cursor-pointer px-4 py-2 transition-colors hover:bg-gray-200';
 
+// closeOnSelect={false}: 항목 선택 후 메뉴가 닫히지 않는 예시
+// 메뉴를 유지해야 할 때 사용
 export const Default: Story = {
   args: {
     children: null,
   },
-  render: () => (
-    <Dropdown>
-      <Dropdown.Trigger>
-        <div className='w-60 cursor-pointer bg-gray-100 px-4 py-2 text-sm'>항목을 선택해주세요</div>
-      </Dropdown.Trigger>
-      <Dropdown.Menu className={dropdownStyle}>
-        <Dropdown.Item className={itemStyle}>항목 1</Dropdown.Item>
-        <Dropdown.Item className={itemStyle}>항목 2</Dropdown.Item>
-        <Dropdown.Item className={itemStyle}>항목 3</Dropdown.Item>
-      </Dropdown.Menu>
-    </Dropdown>
-  ),
+  render: () => {
+    const [selected, setSelected] = useState('항목을 선택해주세요');
+    return (
+      <Dropdown>
+        <Dropdown.Trigger>
+          <div className='w-60 cursor-pointer bg-gray-100 px-4 py-2 text-sm'>{selected}</div>
+        </Dropdown.Trigger>
+        <Dropdown.Menu className={dropdownStyle}>
+          {['항목 1', '항목 2', '항목 3'].map((item) => (
+            // closeOnSelect={false}: 클릭해도 메뉴 유지
+            <Dropdown.Item key={item} className={itemStyle} closeOnSelect={false} onClick={() => setSelected(item)}>
+              {item}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+    );
+  },
 };
 
-// 모임 유형
+// 단일 선택 드롭다운: 항목 선택 시 메뉴가 닫히고 Trigger 텍스트가 선택값으로 업데이트됨
+// closeOnSelect 기본값(true)이므로 별도 prop 불필요
 export const GatheringType: Story = {
   args: {
     children: null,

--- a/src/components/ui/Dropdown/index.test.tsx
+++ b/src/components/ui/Dropdown/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { Dropdown } from '.';
 
 const TestDropdown = () => (
@@ -32,7 +32,7 @@ describe('Dropdown', () => {
     expect(screen.getByRole('listbox')).toBeInTheDocument();
   });
 
-  test('Item 클릭 시 Menu가 닫힌다', () => {
+  test('Item 클릭 시 Menu가 닫힌다', async () => {
     render(<TestDropdown />);
 
     const trigger = screen.getByRole('button');
@@ -41,10 +41,10 @@ describe('Dropdown', () => {
     const item = screen.getByText('항목 1');
     fireEvent.click(item);
 
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
   });
 
-  test('외부 영역 클릭 시 Menu가 닫힌다', () => {
+  test('외부 영역 클릭 시 Menu가 닫힌다', async () => {
     render(<TestDropdown />);
 
     const trigger = screen.getByRole('button');
@@ -52,6 +52,6 @@ describe('Dropdown', () => {
     fireEvent.click(trigger);
     fireEvent.mouseDown(document.body);
 
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
   });
 });

--- a/src/components/ui/Dropdown/index.test.tsx
+++ b/src/components/ui/Dropdown/index.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Dropdown } from '.';
+
+const TestDropdown = () => (
+  <Dropdown>
+    <Dropdown.Trigger>
+      <span>열기</span>
+    </Dropdown.Trigger>
+    <Dropdown.Menu>
+      <Dropdown.Item>항목 1</Dropdown.Item>
+      <Dropdown.Item>항목 2</Dropdown.Item>
+    </Dropdown.Menu>
+  </Dropdown>
+);
+
+describe('Dropdown', () => {
+  test('초기 상태에서 Menu가 렌더링되지 않는다', () => {
+    render(<TestDropdown />);
+
+    const menu = screen.queryByRole('listbox');
+
+    expect(menu).not.toBeInTheDocument();
+  });
+
+  test('Trigger 클릭 시 Menu가 열린다', () => {
+    render(<TestDropdown />);
+
+    const trigger = screen.getByRole('button');
+
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  test('Item 클릭 시 Menu가 닫힌다', () => {
+    render(<TestDropdown />);
+
+    const trigger = screen.getByRole('button');
+    fireEvent.click(trigger);
+
+    const item = screen.getByText('항목 1');
+    fireEvent.click(item);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('외부 영역 클릭 시 Menu가 닫힌다', () => {
+    render(<TestDropdown />);
+
+    const trigger = screen.getByRole('button');
+
+    fireEvent.click(trigger);
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -1,26 +1,14 @@
 'use client';
 
-import React, { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 
-import { OVERLAY_ANIMATION_DURATION } from '@/constants/overlay';
 import { cn } from '@/lib/cn';
 
-// context
-interface DropdownContextType {
-  isOpen: boolean;
-  toggle: () => void;
-  close: () => void;
-}
+import { DropdownContext } from './context';
+import { Trigger } from './Trigger';
+import { Menu } from './Menu';
+import { Item } from './Item';
 
-const DropdownContext = createContext<DropdownContextType | null>(null);
-
-const useDropdown = () => {
-  const ctx = useContext(DropdownContext);
-  if (!ctx) throw new Error('Dropdown 내부에서만 사용 가능');
-  return ctx;
-};
-
-// base
 interface DropdownProps {
   children: ReactNode;
   className?: string;
@@ -53,126 +41,6 @@ function DropdownBase({ children, className }: DropdownProps) {
   );
 }
 
-// trigger
-interface TriggerProps {
-  children: ReactNode;
-}
-
-function Trigger({ children }: TriggerProps) {
-  const { toggle, isOpen, close } = useDropdown();
-  const triggerRef = useRef<HTMLButtonElement>(null);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown' && isOpen) {
-      e.preventDefault();
-      const firstItem = triggerRef.current?.closest('[data-dropdown]')?.querySelector('[role="option"]') as HTMLElement;
-      firstItem?.focus();
-    }
-    if (e.key === 'Tab' && isOpen) {
-      close();
-    }
-  };
-
-  return (
-    <button
-      ref={triggerRef}
-      type='button'
-      aria-expanded={isOpen}
-      aria-haspopup='listbox'
-      onClick={toggle}
-      onKeyDown={handleKeyDown}
-      style={{ transitionDuration: `${OVERLAY_ANIMATION_DURATION}ms` }}
-      className={cn('border transition-colors', isOpen ? 'border-black' : 'border-transparent')}
-    >
-      {children}
-    </button>
-  );
-}
-
-// menu
-interface MenuProps {
-  children: ReactNode;
-  className?: string;
-}
-
-function Menu({ children, className }: MenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  const { isOpen, close } = useDropdown();
-  const [shouldRender, setShouldRender] = useState(isOpen);
-
-  if (isOpen && !shouldRender) setShouldRender(true);
-
-  useEffect(() => {
-    if (!isOpen && shouldRender) {
-      const timer = setTimeout(() => setShouldRender(false), OVERLAY_ANIMATION_DURATION);
-      return () => clearTimeout(timer);
-    }
-  }, [isOpen, shouldRender]);
-
-  if (!shouldRender) return null;
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    const items = Array.from(menuRef.current?.querySelectorAll('[role="option"]') ?? []) as HTMLElement[];
-    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
-
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      items[(currentIndex + 1) % items.length]?.focus();
-    }
-    if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      items[(currentIndex - 1 + items.length) % items.length]?.focus();
-    }
-    if (e.key === 'Tab') {
-      close();
-    }
-  };
-
-  return (
-    <div
-      ref={menuRef}
-      role='listbox'
-      onKeyDown={handleKeyDown}
-      className={cn('absolute mt-2', isOpen ? 'animate-modal-fade-in' : 'animate-modal-fade-out', className)}
-    >
-      <ul>{children}</ul>
-    </div>
-  );
-}
-
-// item
-interface ItemProps {
-  children: ReactNode;
-  onClick?: () => void;
-  className?: string;
-}
-function Item({ children, onClick, className }: ItemProps) {
-  const { close } = useDropdown();
-
-  const handleClick = () => {
-    onClick?.();
-    close();
-  };
-  return (
-    <li
-      role='option'
-      tabIndex={-1}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleClick();
-        }
-        if (e.key === 'Escape') close();
-      }}
-      onClick={handleClick}
-      className={cn('transition-colors', className)}
-    >
-      {children}
-    </li>
-  );
-}
-
-// export
 export const Dropdown = Object.assign(DropdownBase, {
   Trigger,
   Menu,

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -59,10 +59,11 @@ function Trigger({ children }: TriggerProps) {
   const { toggle, isOpen } = useDropdown();
   return (
     <button
+      type='button'
       aria-expanded={isOpen}
       aria-haspopup='listbox'
       onClick={toggle}
-      className={cn('', isOpen && 'border border-black')}
+      className={cn(isOpen && 'border border-black')}
     >
       {children}
     </button>
@@ -104,11 +105,14 @@ function Item({ children, onClick, className }: ItemProps) {
       role='option'
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') handleClick();
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
         if (e.key === 'Escape') close();
       }}
       onClick={handleClick}
-      className={cn('', className)}
+      className={cn(className)}
     >
       {children}
     </li>

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -43,7 +43,7 @@ function DropdownBase({ children, className }: DropdownProps) {
 
   return (
     <DropdownContext.Provider value={{ isOpen, toggle, close }}>
-      <div ref={containerRef} className={cn('relative inline-block', className)}>
+      <div ref={containerRef} data-dropdown className={cn('relative inline-block', className)}>
         {children}
       </div>
     </DropdownContext.Provider>
@@ -56,13 +56,28 @@ interface TriggerProps {
 }
 
 function Trigger({ children }: TriggerProps) {
-  const { toggle, isOpen } = useDropdown();
+  const { toggle, isOpen, close } = useDropdown();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown' && isOpen) {
+      e.preventDefault();
+      const firstItem = triggerRef.current?.closest('[data-dropdown]')?.querySelector('[role="option"]') as HTMLElement;
+      firstItem?.focus();
+    }
+    if (e.key === 'Tab' && isOpen) {
+      close();
+    }
+  };
+
   return (
     <button
+      ref={triggerRef}
       type='button'
       aria-expanded={isOpen}
       aria-haspopup='listbox'
       onClick={toggle}
+      onKeyDown={handleKeyDown}
       className={cn(isOpen && 'border border-black')}
     >
       {children}
@@ -77,11 +92,29 @@ interface MenuProps {
 }
 
 function Menu({ children, className }: MenuProps) {
-  const { isOpen } = useDropdown();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { isOpen, close } = useDropdown();
   if (!isOpen) return null;
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const items = Array.from(menuRef.current?.querySelectorAll('[role="option"]') ?? []) as HTMLElement[];
+    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      items[(currentIndex + 1) % items.length]?.focus();
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      items[(currentIndex - 1 + items.length) % items.length]?.focus();
+    }
+    if (e.key === 'Tab') {
+      close();
+    }
+  };
+
   return (
-    <div role='listbox' className={cn('absolute mt-2', className)}>
+    <div ref={menuRef} role='listbox' onKeyDown={handleKeyDown} className={cn('absolute mt-2', className)}>
       <ul>{children}</ul>
     </div>
   );
@@ -98,12 +131,12 @@ function Item({ children, onClick, className }: ItemProps) {
 
   const handleClick = () => {
     onClick?.();
-    close(); // 선택하면 자동 닫기
+    close();
   };
   return (
     <li
       role='option'
-      tabIndex={0}
+      tabIndex={-1}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -32,6 +32,7 @@ function DropdownBase({ children, className }: DropdownProps) {
   const close = () => setIsOpen(false);
 
   useEffect(() => {
+    if (!isOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
       if (!containerRef.current?.contains(e.target as Node)) {
         close();
@@ -39,7 +40,7 @@ function DropdownBase({ children, className }: DropdownProps) {
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [isOpen]);
 
   return (
     <DropdownContext.Provider value={{ isOpen, toggle, close }}>

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+import { cn } from '@/lib/cn';
+
+// context
+interface DropdownContextType {
+  isOpen: boolean;
+  toggle: () => void;
+  close: () => void;
+}
+
+const DropdownContext = createContext<DropdownContextType | null>(null);
+
+const useDropdown = () => {
+  const ctx = useContext(DropdownContext);
+  if (!ctx) throw new Error('Dropdown 내부에서만 사용 가능');
+  return ctx;
+};
+
+// base
+interface DropdownProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function DropdownBase({ children, className }: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = () => setIsOpen((prev) => !prev);
+  const close = () => setIsOpen(false);
+
+  return (
+    <DropdownContext.Provider value={{ isOpen, toggle, close }}>
+      <div className={cn('relative inline-block', className)}>{children}</div>
+    </DropdownContext.Provider>
+  );
+}
+
+// trigger
+interface TriggerProps {
+  children: ReactNode;
+}
+
+function Trigger({ children }: TriggerProps) {
+  const { toggle, isOpen } = useDropdown();
+  return (
+    <button onClick={toggle} className={cn('', isOpen && 'border border-black')}>
+      {children}
+    </button>
+  );
+}
+
+// menu
+interface MenuProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function Menu({ children, className }: MenuProps) {
+  const { isOpen } = useDropdown();
+  if (!isOpen) return null;
+
+  return (
+    <div className={cn('absolute mt-2', className)}>
+      <ul>{children}</ul>
+    </div>
+  );
+}
+
+// item
+interface ItemProps {
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+function Item({ children, onClick, className }: ItemProps) {
+  const { close } = useDropdown();
+
+  const handleClick = () => {
+    onClick?.();
+    close(); // 선택하면 자동 닫기
+  };
+  return (
+    <li onClick={handleClick} className={cn('', className)}>
+      {children}
+    </li>
+  );
+}
+
+// export
+export const Dropdown = Object.assign(DropdownBase, {
+  Trigger,
+  Menu,
+  Item,
+});

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React, { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
+
+import { OVERLAY_ANIMATION_DURATION } from '@/constants/overlay';
 import { cn } from '@/lib/cn';
 
 // context
@@ -79,7 +81,8 @@ function Trigger({ children }: TriggerProps) {
       aria-haspopup='listbox'
       onClick={toggle}
       onKeyDown={handleKeyDown}
-      className={cn(isOpen && 'border border-black')}
+      style={{ transitionDuration: `${OVERLAY_ANIMATION_DURATION}ms` }}
+      className={cn('border transition-colors', isOpen ? 'border-black' : 'border-transparent')}
     >
       {children}
     </button>
@@ -95,7 +98,18 @@ interface MenuProps {
 function Menu({ children, className }: MenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const { isOpen, close } = useDropdown();
-  if (!isOpen) return null;
+  const [shouldRender, setShouldRender] = useState(isOpen);
+
+  if (isOpen && !shouldRender) setShouldRender(true);
+
+  useEffect(() => {
+    if (!isOpen && shouldRender) {
+      const timer = setTimeout(() => setShouldRender(false), OVERLAY_ANIMATION_DURATION);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, shouldRender]);
+
+  if (!shouldRender) return null;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     const items = Array.from(menuRef.current?.querySelectorAll('[role="option"]') ?? []) as HTMLElement[];
@@ -115,7 +129,12 @@ function Menu({ children, className }: MenuProps) {
   };
 
   return (
-    <div ref={menuRef} role='listbox' onKeyDown={handleKeyDown} className={cn('absolute mt-2', className)}>
+    <div
+      ref={menuRef}
+      role='listbox'
+      onKeyDown={handleKeyDown}
+      className={cn('absolute mt-2', isOpen ? 'animate-modal-fade-in' : 'animate-modal-fade-out', className)}
+    >
       <ul>{children}</ul>
     </div>
   );
@@ -146,7 +165,7 @@ function Item({ children, onClick, className }: ItemProps) {
         if (e.key === 'Escape') close();
       }}
       onClick={handleClick}
-      className={cn(className)}
+      className={cn('transition-colors', className)}
     >
       {children}
     </li>

--- a/src/components/ui/Dropdown/index.tsx
+++ b/src/components/ui/Dropdown/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, ReactNode, useContext, useState } from 'react';
+import React, { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/cn';
 
 // context
@@ -26,13 +26,26 @@ interface DropdownProps {
 
 function DropdownBase({ children, className }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const toggle = () => setIsOpen((prev) => !prev);
   const close = () => setIsOpen(false);
 
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
   return (
     <DropdownContext.Provider value={{ isOpen, toggle, close }}>
-      <div className={cn('relative inline-block', className)}>{children}</div>
+      <div ref={containerRef} className={cn('relative inline-block', className)}>
+        {children}
+      </div>
     </DropdownContext.Provider>
   );
 }
@@ -45,7 +58,12 @@ interface TriggerProps {
 function Trigger({ children }: TriggerProps) {
   const { toggle, isOpen } = useDropdown();
   return (
-    <button onClick={toggle} className={cn('', isOpen && 'border border-black')}>
+    <button
+      aria-expanded={isOpen}
+      aria-haspopup='listbox'
+      onClick={toggle}
+      className={cn('', isOpen && 'border border-black')}
+    >
       {children}
     </button>
   );
@@ -62,7 +80,7 @@ function Menu({ children, className }: MenuProps) {
   if (!isOpen) return null;
 
   return (
-    <div className={cn('absolute mt-2', className)}>
+    <div role='listbox' className={cn('absolute mt-2', className)}>
       <ul>{children}</ul>
     </div>
   );
@@ -82,7 +100,16 @@ function Item({ children, onClick, className }: ItemProps) {
     close(); // 선택하면 자동 닫기
   };
   return (
-    <li onClick={handleClick} className={cn('', className)}>
+    <li
+      role='option'
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') handleClick();
+        if (e.key === 'Escape') close();
+      }}
+      onClick={handleClick}
+      className={cn('', className)}
+    >
       {children}
     </li>
   );


### PR DESCRIPTION
## ❓ 이슈

- close #44 

## ✍️ Description

Compound Component 패턴으로 Dropdown 공통 컴포넌트를 구현했습니다.

- `Dropdown.Trigger` — 메뉴 열기/닫기 버튼
- `Dropdown.Menu` — 메뉴 리스트 컨테이너
- `Dropdown.Item` — 개별 항목, 선택 시 자동 닫힘

**접근성 (a11y)**
- `aria-expanded`, `aria-haspopup` 속성 추가
- `role="listbox"`, `role="option"` 적용
- 키보드 `Enter`, `Space`, `Escape` 지원

**UX**
- 외부 클릭 시 메뉴 자동 닫힘

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

