### PR TITLE
[SM-46] feat: Applications 도메인 타입 및 스키마 선언

### DIFF
--- a/src/api/applications/schemas.ts
+++ b/src/api/applications/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const applyGatheringFormSchema = z.object({
+  personalGoal: z
+    .string()
+    .min(5, '목표는 최소 5자 이상 입력해 주세요.')
+    .max(200, '목표는 최대 200자까지 입력 가능합니다.'),
+  selfIntroduction: z.string().max(100, '한 줄 소개는 최대 100자까지 입력 가능합니다.').optional(),
+});

--- a/src/api/applications/types.ts
+++ b/src/api/applications/types.ts
@@ -1,0 +1,104 @@
+import type { z } from 'zod';
+
+import type { applyGatheringFormSchema } from './schemas';
+
+/**
+ * POST /gatherings/:gatheringId/applications 요청 body
+ * 모임 참여 신청 폼
+ */
+export type ApplyGatheringForm = z.infer<typeof applyGatheringFormSchema>;
+
+/** 신청 상태 */
+export type ApplicationStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
+
+/**
+ * GET /gatherings/:gatheringId/applications 응답 내 신청자 정보
+ */
+export interface Applicant {
+  id: number;
+  nickname: string;
+  profileImage: string;
+  reputationScore: number;
+}
+
+/**
+ * GET /gatherings/:gatheringId/applications 응답 내 개별 신청 항목
+ * 모임장이 조회하는 신청 목록의 각 항목
+ */
+export interface ApplicationDetail {
+  id: number;
+  applicant: Applicant;
+  personalGoal: string;
+  selfIntroduction?: string;
+  status: ApplicationStatus;
+  createdAt: string;
+}
+
+/**
+ * GET /gatherings/:gatheringId/applications 응답
+ * 모임장용 신청 목록
+ */
+export interface ApplicationListResponse {
+  applications: ApplicationDetail[];
+}
+
+/**
+ * POST /gatherings/:gatheringId/applications 응답
+ * 모임 참여 신청 생성 결과 (application 객체로 래핑)
+ */
+export interface CreateApplicationResponse {
+  application: {
+    id: number;
+    status: ApplicationStatus;
+    createdAt: string;
+  };
+}
+
+/**
+ * PATCH /gatherings/:gatheringId/applications/:applicationId 요청 body
+ * 모임장의 신청 수락/거절
+ */
+export interface UpdateApplicationStatusRequest {
+  status: Exclude<ApplicationStatus, 'PENDING'>;
+}
+
+/**
+ * PATCH /gatherings/:gatheringId/applications/:applicationId 응답
+ * 신청 수락/거절 결과 (application 객체로 래핑)
+ */
+export interface UpdateApplicationStatusResponse {
+  application: {
+    id: number;
+    status: Exclude<ApplicationStatus, 'PENDING'>;
+  };
+}
+
+/**
+ * GET /users/me/applications 응답 내 모임 정보
+ */
+export interface MyApplicationGathering {
+  id: number;
+  title: string;
+  type: string;
+  status: string;
+}
+
+/**
+ * GET /users/me/applications 응답 내 개별 신청 항목
+ * 내가 신청한 모임의 각 항목
+ */
+export interface MyApplication {
+  id: number;
+  gathering: MyApplicationGathering;
+  personalGoal: string;
+  status: ApplicationStatus;
+  createdAt: string;
+}
+
+/**
+ * GET /users/me/applications 응답
+ * 내 신청 목록
+ */
+export interface MyApplicationListResponse {
+  applications: MyApplication[];
+}

--- a/src/api/applications/types.ts
+++ b/src/api/applications/types.ts
@@ -11,6 +11,19 @@ export type ApplyGatheringForm = z.infer<typeof applyGatheringFormSchema>;
 /** 신청 상태 */
 export type ApplicationStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
 
+// TODO: Reviews 도메인 타입 생성 후 ApplicantReview → Review 타입으로 교체
+/**
+ * GET /gatherings/:gatheringId/applications 응답 내 신청자의 리뷰 정보
+ */
+export interface ApplicantReview {
+  id: number;
+  reviewer: { id: number; nickname: string };
+  gatheringTitle: string;
+  tags: string[];
+  comment?: string;
+  createdAt: string;
+}
+
 /**
  * GET /gatherings/:gatheringId/applications 응답 내 신청자 정보
  */
@@ -19,6 +32,7 @@ export interface Applicant {
   nickname: string;
   profileImage: string;
   reputationScore: number;
+  reviews: ApplicantReview[];
 }
 
 /**


### PR DESCRIPTION
## ❓ 이슈

- close #50 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
API 명세 기반으로 Applications 도메인의 폼 검증 스키마와 API 응답/요청 타입을 선언합니다.

 **생성 파일:**
  - `src/api/applications/schemas.ts` — applyGatheringFormSchema (모임 참여 신청 폼)
  - `src/api/applications/types.ts` — 폼 타입(z.infer) + 요청/응답 타입(interface)

 **타입 목록:**
  | 타입 | 엔드포인트 | 설명 |
  |------|-----------|------|
  | `ApplyGatheringForm` | POST 신청 요청 body | Zod 스키마 추론 |
  | `ApplicationStatus` | 공통 | `PENDING \| ACCEPTED \| REJECTED` |
  | `ApplicantReview` | GET 신청 목록 내 신청자 리뷰 | TODO: Reviews 도메인 타입으로 교체 예정 |
  | `Applicant` | GET 신청 목록 내 신청자 정보 | reviews 포함 |
  | `ApplicationDetail` | GET 신청 목록 내 개별 항목 | 모임장용 |
  | `ApplicationListResponse` | GET 신청 목록 응답 | 모임장용 |
  | `CreateApplicationResponse` | POST 신청 생성 응답 | |
  | `UpdateApplicationStatusRequest` | PATCH 수락/거절 요청 body | |
  | `UpdateApplicationStatusResponse` | PATCH 수락/거절 응답 | |
  | `MyApplicationGathering` | GET 내 신청 목록 내 모임 정보 | |
  | `MyApplication` | GET 내 신청 목록 내 개별 항목 | |
  | `MyApplicationListResponse` | GET 내 신청 목록 응답 | |


  **컨벤션:** Auth 도메인(#47) 레퍼런스 동일 패턴 적용

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] Reviews 도메인 타입 생성 후 `ApplicantReview` → Review 공통 타입으로 교체
