### PR TITLE
[SM-48] feat: Todos 도메인 타입 및 스키마 선언

### DIFF
--- a/src/api/todos/schemas.ts
+++ b/src/api/todos/schemas.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+/** POST `/gatherings/:gatheringId/todos` — Todo 생성 폼 */
+export const createTodoFormSchema = z.object({
+  week: z.number().min(1, '주차는 1 이상이어야 합니다.'),
+  content: z.string().min(1, '할 일을 입력해 주세요.').max(200, '할 일은 최대 200자까지 가능합니다.'),
+});
+
+/** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정/체크 폼 */
+export const updateTodoFormSchema = z.object({
+  content: z.string().min(1, '할 일을 입력해 주세요.').max(200, '할 일은 최대 200자까지 가능합니다.').optional(),
+  isCompleted: z.boolean().optional(),
+});

--- a/src/api/todos/types.ts
+++ b/src/api/todos/types.ts
@@ -19,17 +19,16 @@ export interface Todo {
   createdAt: string;
 }
 
-// 요청 타입
+// 요청 타입 (Form 타입 재사용)
 /** POST `/gatherings/:gatheringId/todos` — Todo 생성 요청 바디 */
-export interface CreateTodoRequest {
-  week: number;
-  content: string;
-}
+export type CreateTodoRequest = CreateTodoForm;
 
 /** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정 요청 바디 */
-export interface UpdateTodoRequest {
-  content?: string;
-  isCompleted?: boolean;
+export type UpdateTodoRequest = UpdateTodoForm;
+
+/** GET `/gatherings/:gatheringId/todos` — 쿼리 파라미터 */
+export interface TodoListParams {
+  week?: number;
 }
 
 /** GET `/gatherings/:gatheringId/todos` — 쿼리 파라미터 */

--- a/src/api/todos/types.ts
+++ b/src/api/todos/types.ts
@@ -19,18 +19,6 @@ export interface Todo {
   createdAt: string;
 }
 
-// 요청 타입 (Form 타입 재사용)
-/** POST `/gatherings/:gatheringId/todos` — Todo 생성 요청 바디 */
-export type CreateTodoRequest = CreateTodoForm;
-
-/** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정 요청 바디 */
-export type UpdateTodoRequest = UpdateTodoForm;
-
-/** GET `/gatherings/:gatheringId/todos` — 쿼리 파라미터 */
-export interface TodoListParams {
-  week?: number;
-}
-
 /** GET `/gatherings/:gatheringId/todos` — 쿼리 파라미터 */
 export interface TodoListParams {
   week?: number;

--- a/src/api/todos/types.ts
+++ b/src/api/todos/types.ts
@@ -1,0 +1,77 @@
+import type { z } from 'zod';
+
+import type { createTodoFormSchema, updateTodoFormSchema } from './schemas';
+
+/** POST `/gatherings/:gatheringId/todos` — Todo 생성 폼 */
+export type CreateTodoForm = z.infer<typeof createTodoFormSchema>;
+
+/** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정/체크 폼 */
+export type UpdateTodoForm = z.infer<typeof updateTodoFormSchema>;
+
+/** GET `/gatherings/:gatheringId/todos` — 모임 전체 Todo 조회 시 개별 Todo */
+export interface Todo {
+  id: number;
+  userId: number;
+  nickname: string;
+  week: number;
+  content: string;
+  isCompleted: boolean;
+  createdAt: string;
+}
+
+// 요청 타입
+/** POST `/gatherings/:gatheringId/todos` — Todo 생성 요청 바디 */
+export interface CreateTodoRequest {
+  week: number;
+  content: string;
+}
+
+/** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정 요청 바디 */
+export interface UpdateTodoRequest {
+  content?: string;
+  isCompleted?: boolean;
+}
+
+/** GET `/gatherings/:gatheringId/todos` — 쿼리 파라미터 */
+export interface TodoListParams {
+  week?: number;
+}
+
+// 응답 타입
+/** GET `/gatherings/:gatheringId/todos` — 모임 전체 Todo 조회 응답 */
+export interface TodoListResponse {
+  todos: Todo[];
+}
+
+/** GET `/gatherings/:gatheringId/todos/me` — 내 Todo + 달성률 응답 */
+export interface MyTodoListResponse {
+  todos: Todo[];
+  weeklyAchievementRate: number;
+  overallAchievementRate: number;
+}
+
+/** POST `/gatherings/:gatheringId/todos` — Todo 생성 응답 내 todo 객체 */
+export interface CreatedTodo {
+  id: number;
+  week: number;
+  content: string;
+  isCompleted: boolean;
+  createdAt: string;
+}
+
+/** POST `/gatherings/:gatheringId/todos` — Todo 생성 응답 */
+export interface CreateTodoResponse {
+  todo: CreatedTodo;
+}
+
+/** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정 응답 내 todo 객체 */
+export interface UpdatedTodo {
+  id: number;
+  content: string;
+  isCompleted: boolean;
+}
+
+/** PATCH `/gatherings/:gatheringId/todos/:todoId` — Todo 수정 응답 */
+export interface UpdateTodoResponse {
+  todo: UpdatedTodo;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #52 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
Todos 도메인의 Zod 스키마 및 TypeScript 타입을 선언합니다.

  - `src/api/todos/schemas.ts` — createTodoFormSchema,updateTodoFormSchema
  - `src/api/todos/types.ts` — Todo 엔티티, 요청/응답 타입 (API 명세서 기반)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->


