### PR TITLE
[SM-47] feat: Memberships 도메인 타입 선언

### DIFF
--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -1,0 +1,58 @@
+export type GatheringStatusFilter = 'recruiting' | 'in_progress' | 'completed' | 'all';
+
+// GET /users/me/gatherings 쿼리 파라미터
+export interface MyGatheringsParams {
+  status?: GatheringStatusFilter;
+  page?: number;
+  limit?: number;
+}
+
+// 공통 유니온 타입
+export type GatheringStatus = 'RECRUITING' | 'IN_PROGRESS' | 'COMPLETED';
+export type MemberRole = 'LEADER' | 'MEMBER';
+
+// 개별 모임 항목
+export interface Gathering {
+  id: number;
+  type: string;
+  category: string;
+  title: string;
+  shortDescription: string;
+  tags: string[];
+  maxMembers: number;
+  currentMembers: number;
+  startDate: string;
+  endDate: string;
+  status: GatheringStatus;
+  myRole: MemberRole;
+  isLiked: boolean;
+}
+
+// GET /users/me/gatherings 응답
+export interface MyGatheringList {
+  gatherings: Gathering[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+}
+
+// 개별 멤버 항목
+export interface Member {
+  userId: number;
+  nickname: string;
+  profileImage: string;
+  role: MemberRole;
+  overallAchievementRate: number;
+  isActive: boolean;
+}
+
+// GET /gatherings/:gatheringId/members 응답
+export interface GatheringMembersList {
+  members: Member[];
+}
+
+// DELETE /gatherings/:gatheringId/members/:userId 응답
+// DELETE /gatherings/:gatheringId/members/me 응답
+export interface DeleteMember {
+  success: boolean;
+}

--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -11,8 +11,8 @@ export interface MyGatheringsParams {
 export type GatheringStatus = 'RECRUITING' | 'IN_PROGRESS' | 'COMPLETED';
 export type MemberRole = 'LEADER' | 'MEMBER';
 
-// 개별 모임 항목
-export interface Gathering {
+// 개별 모임 항목 (GET /users/me/gatherings 응답 내 모임)
+export interface MembershipGathering {
   id: number;
   type: string;
   category: string;
@@ -30,7 +30,7 @@ export interface Gathering {
 
 // GET /users/me/gatherings 응답
 export interface MyGatheringList {
-  gatherings: Gathering[];
+  gatherings: MembershipGathering[];
   totalCount: number;
   totalPages: number;
   currentPage: number;


### PR DESCRIPTION
## ❓ 이슈

- close #51 

## ✍️ Description

API 명세 기반으로 Memberships 도메인의 응답 타입을 선언합니다.

다음 항목을 포함합니다.

GatheringStatusFilter — 모임 상태 필터 유니온 타입 (recruiting | in_progress | completed | all)
GatheringStatus, MemberRole — 공통 유니온 타입
MyGatheringsParams — GET /users/me/gatherings 쿼리 파라미터
MembershipGathering, MyGatheringList — GET /users/me/gatherings 응답 타입
Member, GatheringMembersList — GET /gatherings/:gatheringId/members 응답 타입
DeleteMember — DELETE /gatherings/:gatheringId/members/:userId 및 /me 응답 타입

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

