### PR TITLE
[SM-49] feat: Achievements 도메인 타입 선언

### DIFF
--- a/src/api/achievements/types.ts
+++ b/src/api/achievements/types.ts
@@ -1,0 +1,34 @@
+// 주차별 달성률
+export interface WeeklyRate {
+  week: number;
+  rate: number;
+}
+
+// GET /gatherings/:gatheringId/achievements - 멤버별 달성률
+export interface MemberAchievement {
+  userId: number;
+  nickname: string;
+  weeklyRates: WeeklyRate[];
+  overallRate: number;
+}
+
+// GET /gatherings/:gatheringId/achievements 응답
+export interface GatheringAchievements {
+  members: MemberAchievement[];
+  teamWeeklyRates: WeeklyRate[];
+  teamOverallRate: number;
+}
+
+// GET /gatherings/:gatheringId/achievements/ranking - 순위 항목
+export interface AchievementRankingItem {
+  rank: number;
+  userId: number;
+  nickname: string;
+  profileImage: string;
+  overallRate: number;
+}
+
+// GET /gatherings/:gatheringId/achievements/ranking 응답
+export interface AchievementRanking {
+  ranking: AchievementRankingItem[];
+}


### PR DESCRIPTION
## ❓ 이슈

- close #53 

## ✍️ Description

API 명세 기반으로 Achievements 도메인 타입 선언

- `WeeklyRate`: 주차별 달성률 타입
- `MemberAchievement`: 멤버별 달성률 항목 타입
- `GatheringAchievements`: 모임 전체 달성률 조회 응답 타입
- `AchievementRankingItem`: 달성률 순위 항목 타입
- `AchievementRanking`: 달성률 순위 조회 응답 타입

GET 엔드포인트만 존재하므로 Zod 스키마 불필요


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


