### PR TITLE
[SM-44] feat: Users 도메인 타입 및 스키마 선언

### DIFF
--- a/src/api/users/schemas.ts
+++ b/src/api/users/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+const nicknameField = z
+  .string()
+  .min(1, '닉네임은 필수 입력입니다.')
+  .min(2, '닉네임은 최소 2자 이상입니다.')
+  .max(10, '닉네임은 최대 10자까지 가능합니다.');
+
+const newPasswordField = z
+  .string()
+  .min(1, '비밀번호는 필수 입력입니다.')
+  .min(8, '비밀번호는 최소 8자 이상입니다.')
+  .refine(
+    (value) => {
+      const hasNumber = /[0-9]/.test(value);
+      const hasAlphabet = /[a-zA-Z]/.test(value);
+      const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(value);
+      return hasNumber && hasAlphabet && hasSpecialChar;
+    },
+    { message: '비밀번호는 숫자, 영문, 특수문자를 포함해야 합니다.' },
+  );
+
+export const updateProfileRequestSchema = z.object({
+  nickname: nicknameField,
+  profileImage: z.union([
+    z.string().url('프로필 이미지 URL 형식이 올바르지 않습니다.'),
+    z
+      .string()
+      .refine(
+        (value) => value.match(/^https?:\/\/.+\.(jpg|png|webp)$/i),
+        '프로필 이미지는 jpg, png, webp 형식이어야 합니다.',
+      ),
+    z.string().refine((value) => value.length <= 5 * 1024 * 1024, '프로필 이미지는 5MB 이하여야 합니다.'),
+    z.literal(''),
+  ]),
+});
+
+export const updateProfileFormSchema = updateProfileRequestSchema;
+
+export const updatePasswordRequestSchema = z.object({
+  currentPassword: z.string().min(1, '현재 비밀번호를 입력해 주세요.'),
+  newPassword: newPasswordField,
+});
+
+export const updatePasswordFormSchema = z
+  .object({
+    currentPassword: z.string().min(1, '현재 비밀번호를 입력해 주세요.'),
+    newPassword: newPasswordField,
+    newPasswordConfirmation: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
+  })
+  .refine((data) => data.newPassword === data.newPasswordConfirmation, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['newPasswordConfirmation'],
+  });

--- a/src/api/users/schemas.ts
+++ b/src/api/users/schemas.ts
@@ -22,17 +22,22 @@ const newPasswordField = z
 
 export const updateProfileRequestSchema = z.object({
   nickname: nicknameField,
-  profileImage: z.union([
-    z.string().url('프로필 이미지 URL 형식이 올바르지 않습니다.'),
-    z
-      .string()
-      .refine(
-        (value) => value.match(/^https?:\/\/.+\.(jpg|png|webp)$/i),
-        '프로필 이미지는 jpg, png, webp 형식이어야 합니다.',
-      ),
-    z.string().refine((value) => value.length <= 5 * 1024 * 1024, '프로필 이미지는 5MB 이하여야 합니다.'),
-    z.literal(''),
-  ]),
+  profileImage: z
+    .string()
+    .refine(
+      (value) => {
+        if (value === '') return true;
+        // URL 형식 체크
+        try {
+          new URL(value);
+        } catch {
+          return false;
+        }
+        // 파일 확장자 체크
+        return /\.(jpg|png|webp)$/i.test(value);
+      },
+      { message: '프로필 이미지는 유효한 URL이어야 하며 jpg, png, webp 형식이어야 합니다.' },
+    ),
 });
 
 export const updateProfileFormSchema = updateProfileRequestSchema;

--- a/src/api/users/types.ts
+++ b/src/api/users/types.ts
@@ -1,0 +1,95 @@
+import type { z } from 'zod';
+
+import type { ApiResponse } from '@/api/common/types';
+
+import type {
+  updatePasswordFormSchema,
+  updatePasswordRequestSchema,
+  updateProfileFormSchema,
+  updateProfileRequestSchema,
+} from './schemas';
+
+/**
+ * PATCH /api/v1/users/me 요청 body
+ */
+export type UpdateProfileRequest = z.infer<typeof updateProfileRequestSchema>;
+
+/**
+ * PATCH /api/v1/users/me — 폼 (요청 body와 동일)
+ */
+export type UpdateProfileForm = z.infer<typeof updateProfileFormSchema>;
+
+/**
+ * PATCH /api/v1/users/me/password 요청 body
+ */
+export type UpdatePasswordRequest = z.infer<typeof updatePasswordRequestSchema>;
+
+/**
+ * PATCH /api/v1/users/me/password — 비밀번호 확인 필드 포함 폼
+ */
+export type UpdatePasswordForm = z.infer<typeof updatePasswordFormSchema>;
+
+// 응답 타입
+
+/** 인증 제공자 (GET 응답 `provider`) */
+export type AuthProvider = 'EMAIL' | 'GOOGLE' | 'KAKAO';
+
+/**
+ * GET /api/v1/users/me 응답 `data`
+ */
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImage: string;
+  provider: AuthProvider;
+  reputationScore: number;
+  reputationLabel: string;
+}
+
+/**
+ * GET /api/v1/users/{userId} 응답 `data`
+ */
+export type UserPublicProfile = Pick<User, 'id' | 'nickname' | 'profileImage' | 'reputationScore' | 'reputationLabel'>;
+
+/**
+ * GET /api/v1/users/me
+ */
+export type GetMeResponse = ApiResponse<User>;
+
+/**
+ * GET /api/v1/users/{userId}
+ */
+export type GetUserByIdResponse = ApiResponse<UserPublicProfile>;
+
+/**
+ * PATCH /api/v1/users/me 응답 (표준 래퍼, `data`는 갱신된 사용자)
+ */
+export type PatchMeResponse = ApiResponse<User>;
+
+/**
+ * PATCH /api/v1/users/me/password 200 응답 `data`
+ */
+export type UpdatePasswordResponseData = Record<string, never>;
+
+/**
+ * PATCH /api/v1/users/me/password 성공 응답
+ *
+ * 실패 시 예시:
+ * - 이메일 가입(`provider: EMAIL`) 전용. 소셜 로그인 사용자는 비밀번호 변경 불가 (`ApiError`, `errorCode`는 `PatchPasswordErrorCode` 참고)
+ */
+export type PatchPasswordResponse = ApiResponse<UpdatePasswordResponseData>;
+
+// PATCH 실패 (HTTP / errorCode — mutation에서 분기 시 사용, 백엔드 `errorCode`와 동기화)
+
+/** PATCH /users/me — 닉네임 중복 등 **409** 응답 시 `errorCode`로 올 수 있는 값 */
+export type PatchMeErrorCode = 'NICKNAME_DUPLICATE';
+
+/** PATCH /users/me/password — 소셜 계정 등 **403** 응답 시 `errorCode`로 올 수 있는 값 */
+export type PatchPasswordErrorCode = 'PASSWORD_CHANGE_FORBIDDEN';
+
+/** 닉네임 중복 충돌 시 HTTP 상태 */
+export const PATCH_ME_NICKNAME_CONFLICT_STATUS = 409 as const;
+
+/** 비밀번호 변경 불가(소셜 로그인 등) 시 HTTP 상태 */
+export const PATCH_PASSWORD_FORBIDDEN_STATUS = 403 as const;


### PR DESCRIPTION
## ❓ 이슈

- close #48 

## ✍️ Description

`src/api/users/schemas.ts` - updateProfileFormSchema, updatePasswordFormSchema
`src/api/users/types.ts` - users 엔티티, 요청/응답 타입 (API 명세서 기반)


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

