### PR TITLE
[SM-45] feat: Gatherings 도메인 타입 및 스키마 선언

### DIFF
--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+/** 날짜 문자열 공통 스키마 (YYYY-MM-DD) */
+const dateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)');
+
+/** 주차별 가이드 스키마 (모임 생성 폼용) */
+export const weeklyGuideSchema = z.object({
+  week: z.number().min(1, '주차는 1 이상이어야 합니다.'),
+  title: z.string().min(1, '주제는 필수 입력입니다.'),
+  content: z.string().min(1, '내용은 필수 입력입니다.'),
+});
+
+/** POST `/gatherings` — 모임 생성 폼 */
+export const gatheringFormSchema = z.object({
+  type: z.enum(['스터디', '프로젝트'], {
+    message: '모임 유형을 지정해 주세요.',
+  }),
+  category: z.string().min(1, '카테고리를 선택해 주세요.'),
+  title: z.string().min(1, '모임 제목을 입력해 주세요.').max(50, '제목은 최대 50자까지 가능합니다.'),
+  shortDescription: z
+    .string()
+    .min(1, '한 줄 소개를 입력해 주세요.')
+    .max(100, '한 줄 소개는 최대 100자까지 가능합니다.'),
+  description: z.string().min(1, '상세 소개를 입력해 주세요.'),
+  tags: z.array(z.string()).min(1, '최소 1개의 태그를 입력해 주세요.').max(5, '태그는 최대 5개까지 가능합니다.'),
+  goal: z.string().min(1, '모임 목표를 입력해 주세요.'),
+  maxMembers: z.number().min(2, '최소 2명 이상이어야 합니다.').max(20, '최대 20명 이하이어야 합니다.'),
+  recruitDeadline: dateStringSchema,
+  startDate: dateStringSchema,
+  endDate: dateStringSchema,
+  weeklyGuides: z.array(weeklyGuideSchema).optional(),
+  images: z
+    .array(z.instanceof(File, { message: '유효한 파일이 아닙니다.' }))
+    .max(6, '이미지는 최대 6장까지 업로드 가능합니다.')
+    .optional(),
+});
+
+/** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (모든 필드 optional) */
+export const gatheringUpdateFormSchema = gatheringFormSchema.partial();

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-/** 날짜 문자열 공통 스키마 (YYYY-MM-DD) */
+/** 날짜 문자열 스키마 (YYYY-MM-DD) */
 const dateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)');
 
 /** 주차별 가이드 스키마 (모임 생성 폼용) */
@@ -28,7 +28,7 @@ export const gatheringFormSchema = z.object({
   recruitDeadline: dateStringSchema,
   startDate: dateStringSchema,
   endDate: dateStringSchema,
-  weeklyGuides: z.array(weeklyGuideSchema).optional(),
+  weeklyGuides: z.array(weeklyGuideSchema).min(1, '최소 1주차 계획은 입력해 주세요.'),
   images: z
     .array(z.instanceof(File, { message: '유효한 파일이 아닙니다.' }))
     .max(6, '이미지는 최대 6장까지 업로드 가능합니다.')

--- a/src/api/gatherings/types.ts
+++ b/src/api/gatherings/types.ts
@@ -1,0 +1,134 @@
+import type { z } from 'zod';
+
+import type { gatheringFormSchema, gatheringUpdateFormSchema } from './schemas';
+
+/** 모임 유형 */
+export type GatheringType = '스터디' | '프로젝트';
+
+/** 모임 상태 */
+export type GatheringStatus = 'RECRUITING' | 'IN_PROGRESS' | 'COMPLETED';
+
+/** 참여 신청 상태 */
+export type ApplicationStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED';
+
+/** 모임 내 역할 */
+export type GatheringRole = 'LEADER' | 'MEMBER';
+
+/** 모임장 정보 */
+export interface LeaderInfo {
+  id: number;
+  nickname: string;
+  profileImage: string | null;
+}
+
+/** 모임 멤버 정보 */
+export interface MemberInfo {
+  userId: number;
+  nickname: string;
+  profileImage: string | null;
+  role: GatheringRole;
+}
+
+/** 모임 이미지 */
+export interface GatheringImage {
+  url: string;
+  displayOrder: number;
+}
+
+/** 주차별 계획 (상세 응답용) */
+export interface WeeklyPlan {
+  week: number;
+  title: string;
+  startDate: string;
+  endDate: string;
+}
+
+/** GET `/gatherings` — 모임 목록 아이템 */
+export interface GatheringListItem {
+  id: number;
+  type: GatheringType;
+  category: string;
+  title: string;
+  shortDescription: string;
+  tags: string[];
+  maxMembers: number;
+  currentMembers: number;
+  recruitDeadline: string;
+  startDate: string;
+  endDate: string;
+  status: GatheringStatus;
+  isLiked: boolean;
+  leader: LeaderInfo;
+}
+
+/** GET `/gatherings/:gatheringId` — 모임 상세 정보 */
+export interface GatheringDetail extends GatheringListItem {
+  description: string;
+  goal: string;
+  totalWeeks: number;
+  images: GatheringImage[];
+  weeklyPlans: WeeklyPlan[];
+  members: MemberInfo[];
+  myApplicationStatus: ApplicationStatus | null;
+}
+
+/** POST `/gatherings` — 모임 생성 폼 */
+export type GatheringForm = z.infer<typeof gatheringFormSchema>;
+
+/** PUT `/gatherings/:gatheringId` — 모임 수정 폼 */
+export type GatheringUpdateForm = z.infer<typeof gatheringUpdateFormSchema>;
+
+/** GET `/gatherings` — 쿼리 파라미터 */
+export interface GetGatheringsParams {
+  type?: GatheringType;
+  category?: string;
+  sort?: 'latest' | 'popular' | 'deadline';
+  status?: GatheringStatus | 'ALL';
+  query?: string;
+  page?: number;
+  limit?: number;
+}
+
+/** GET `/gatherings` — 모임 목록 응답 */
+export interface GetGatheringsResponse {
+  gatherings: GatheringListItem[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+}
+
+/** POST `/gatherings` — 모임 생성 요청 body */
+export type CreateGatheringRequest = GatheringForm;
+
+/** POST `/gatherings` — 모임 생성 응답 */
+export interface CreateGatheringResponse {
+  gathering: GatheringDetail;
+}
+
+/** GET `/gatherings/main` — 쿼리 파라미터 */
+export interface GetMainGatheringsParams {
+  limit?: number;
+}
+
+/** GET `/gatherings/main` — 메인 페이지 모임 응답 */
+export interface GetMainGatheringsResponse {
+  popular: GatheringListItem[];
+  deadline: GatheringListItem[];
+  latest: GatheringListItem[];
+}
+
+/** GET `/gatherings/:gatheringId` — 모임 상세 응답 */
+export type GetGatheringDetailResponse = GatheringDetail;
+
+/** PUT `/gatherings/:gatheringId` — 모임 수정 요청 body */
+export type UpdateGatheringRequest = GatheringUpdateForm;
+
+/** PUT `/gatherings/:gatheringId` — 모임 수정 응답 */
+export interface UpdateGatheringResponse {
+  gathering: GatheringDetail;
+}
+
+/** DELETE `/gatherings/:gatheringId` — 모임 삭제 응답 */
+export interface DeleteGatheringResponse {
+  success: boolean;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #49 

## ✍️ Description

- src/api/gatherings/schemas.ts: Zod를 활용한 모임(Gatherings) 관련 폼 스키마 정의
  - 모임 생성 및 수정에 필요한 데이터 유효성 검사 로직 추가
  - 날짜 형식(YYYY-MM-DD) 검증을 위한 정규식 적용 등 세부 규칙 명시
  - 프로젝트 컨벤션에 맞춘 JSDoc 주석 추가
- src/api/gatherings/types.ts: Gatherings 관련 데이터 타입 및 API 스펙 정의
  - 모임 도메인 타입(GatheringType, GatheringStatus, 등) 선언
  - 요청(Request) 및 응답(Response) 인터페이스 정의
  - Zod를 이용한 폼 타입 추론(z.infer) 연결
  - API 엔드포인트 명세가 포함된 JSDoc 기반 가이드 주석 작성

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)
