### PR TITLE
[SM-51] feat: Reviews 도메인 타입 및 스키마 선언

### DIFF
--- a/src/api/reviews/schemas.ts
+++ b/src/api/reviews/schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+/** 선택 가능한 리뷰 태그 목록 (태그 추가/수정 시 여기만 변경하면 됨) */
+export const REVIEW_TAGS = [
+  '성실해요',
+  '소통이 좋아요',
+  '잘 도와줘요',
+  '시간을 잘 지켜요',
+  '다시 함께하고 싶어요',
+] as const;
+
+/** 태그 단일 값 검증 스키마 */
+export const reviewTagSchema = z.enum(REVIEW_TAGS);
+
+/** POST `/gatherings/:gatheringId/reviews` — 팀원 1명에 대한 리뷰 항목 */
+export const reviewItemSchema = z.object({
+  targetUserId: z.number(),
+  tags: z.array(reviewTagSchema).min(1, '태그를 최소 1개 선택해주세요.'),
+  comment: z.string().max(200, '코멘트는 최대 200자까지 입력 가능합니다.').optional(),
+});
+
+/** POST `/gatherings/:gatheringId/reviews` — 전체 폼 스키마 */
+export const createReviewsSchema = z.object({
+  reviews: z.array(reviewItemSchema),
+});

--- a/src/api/reviews/types.ts
+++ b/src/api/reviews/types.ts
@@ -1,0 +1,44 @@
+import type { z } from 'zod';
+
+import type { reviewTagSchema, reviewItemSchema, createReviewsSchema } from './schemas';
+
+/** 리뷰 태그 유니온 타입 */
+export type ReviewTag = z.infer<typeof reviewTagSchema>;
+
+/** POST `/gatherings/:gatheringId/reviews` — 팀원 1명에 대한 리뷰 항목 타입 */
+export type ReviewItem = z.infer<typeof reviewItemSchema>;
+
+/** POST `/gatherings/:gatheringId/reviews` — 전체 폼 타입 */
+export type CreateReviewsForm = z.infer<typeof createReviewsSchema>;
+
+/** POST `/gatherings/:gatheringId/reviews` 응답 */
+export interface CreateReviewsResponse {
+  success: boolean;
+}
+
+/** GET `/users/:userId/reviews` 쿼리 파라미터 */
+export interface UserReviewsParams {
+  page?: number;
+}
+
+/** GET `/users/:userId/reviews` 응답 내 리뷰어 정보 */
+export interface ReviewerInfo {
+  id: number;
+  nickname: string;
+}
+
+/** GET `/users/:userId/reviews` 응답 내 리뷰 항목 */
+export interface Review {
+  id: number;
+  reviewer: ReviewerInfo;
+  gatheringTitle: string;
+  tags: ReviewTag[];
+  comment?: string;
+  createdAt: string;
+}
+
+/** GET `/users/:userId/reviews` 응답 */
+export interface UserReviewListResponse {
+  reviews: Review[];
+  totalCount: number;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #55 

## ✍️ Description

Reviews 도메인의 API 타입 및 Zod 유효성 검사 스키마를 선언합니다.

**`schemas.ts`**
- `REVIEW_TAGS`: 선택 가능한 리뷰 태그 상수 배열 (`as const`)
- `reviewTagSchema`: 태그 단일 값 enum 검증 스키마
- `reviewItemSchema`: 팀원 1명에 대한 리뷰 항목 스키마 (태그 최소 1개, 코멘트 최대 200자)
- `createReviewsSchema`: 전체 리뷰 제출 폼 스키마

**`types.ts`**
- `ReviewTag` / `ReviewItem` / `CreateReviewsForm`: 스키마에서 추론된 타입 (`z.infer<>`)
- `CreateReviewsResponse`: `POST /gatherings/:gatheringId/reviews` 응답
- `UserReviewsParams`: `GET /users/:userId/reviews` 쿼리 파라미터
- `ReviewerInfo` / `Review` / `UserReviewListResponse`: `GET /users/:userId/reviews` 응답 타입

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

