### PR TITLE
[SM-50] feat: Notifications 도메인 타입 선언

### DIFF
--- a/src/api/notifications/types.ts
+++ b/src/api/notifications/types.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/v1/notifications 쿼리
+ */
+export interface GetNotificationsParams {
+  page?: number;
+  limit?: number;
+}
+
+export type NotificationType =
+  | 'APPLICATION_RECEIVED'
+  | 'APPLICATION_ACCEPTED'
+  | 'APPLICATION_REJECTED'
+  | 'PENALTY_WARNING'
+  | 'GATHERING_STARTED'
+  | 'GATHERING_ENDED'
+  | 'REVIEW_REQUEST'
+  | 'POKE';
+
+/** 알림 한 건 */
+export interface NotificationItem {
+  id: number;
+  type: NotificationType;
+  content: string;
+  isRead: boolean;
+  targetUrl: string;
+  createdAt: string;
+}
+
+/**
+ * GET /api/v1/notifications 응답
+ */
+export interface GetNotificationsResponse {
+  notifications: NotificationItem[];
+  unreadCount: number;
+}
+
+/**
+ * PATCH /api/v1/notifications/:notificationId/read
+ * PATCH /api/v1/notifications/read-all
+ */
+export interface PatchNotificationReadResponse {
+  success: boolean;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #54 

## ✍️ Description

API 명세 기반으로 Notifications 도메인의 API 응답 타입을 선언
`src/api/notifications/types.ts`

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)
