### PR TITLE
[SM-58] feat: Auth 도메인 API 함수, 쿼리 훅, MSW 핸들러 작성

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,0 +1,38 @@
+import { axiosClient } from '@/lib/axiosClient';
+import { unwrapResponse } from '@/api/common/utils';
+
+import type { ApiResponse } from '@/api/common/types';
+import type { LoginForm, LoginResponse, SignupForm, RegisterResponse, CheckAvailabilityResponse } from './types';
+
+/** POST /v1/auth/register — 이메일 회원가입 */
+export const register = async ({ passwordConfirmation, ...body }: SignupForm): Promise<RegisterResponse> => {
+  const { data } = await axiosClient.post<ApiResponse<RegisterResponse>>('/v1/auth/register', body);
+  return unwrapResponse(data);
+};
+
+/** POST /v1/auth/login — 이메일 로그인 */
+export const login = async (body: LoginForm): Promise<LoginResponse> => {
+  const { data } = await axiosClient.post<ApiResponse<LoginResponse>>('/v1/auth/login', body);
+  return unwrapResponse(data);
+};
+
+/** POST /v1/auth/logout — 로그아웃 */
+export const logout = async (): Promise<void> => {
+  await axiosClient.post('/v1/auth/logout');
+};
+
+/** GET /v1/auth/check/email — 이메일 중복 확인 */
+export const checkEmail = async (email: string): Promise<CheckAvailabilityResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<CheckAvailabilityResponse>>('/v1/auth/check/email', {
+    params: { email },
+  });
+  return unwrapResponse(data);
+};
+
+/** GET /v1/auth/check/nickname — 닉네임 중복 확인 */
+export const checkNickname = async (nickname: string): Promise<CheckAvailabilityResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<CheckAvailabilityResponse>>('/v1/auth/check/nickname', {
+    params: { nickname },
+  });
+  return unwrapResponse(data);
+};

--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -6,8 +6,10 @@ import type { UseMutationOptions } from '@tanstack/react-query';
 import type { LoginForm, LoginResponse, RegisterResponse, SignupForm } from './types';
 
 export const authKeys = {
-  checkEmail: (email: string) => ['auth', 'check', 'email', email] as const,
-  checkNickname: (nickname: string) => ['auth', 'check', 'nickname', nickname] as const,
+  all: ['auth'] as const,
+  checks: () => [...authKeys.all, 'check'] as const,
+  checkEmail: (email: string) => [...authKeys.checks(), 'email', email] as const,
+  checkNickname: (nickname: string) => [...authKeys.checks(), 'nickname', nickname] as const,
 };
 
 export const authQueries = {
@@ -31,6 +33,7 @@ export const authQueries = {
 export const useRegister = (options?: UseMutationOptions<RegisterResponse, Error, SignupForm, unknown>) => {
   return useMutation({
     mutationFn: register,
+    // NOTE: 신규 가입이므로 무효화할 기존 캐시 없음
     ...options,
   });
 };
@@ -39,6 +42,8 @@ export const useRegister = (options?: UseMutationOptions<RegisterResponse, Error
 export const useLogin = (options?: UseMutationOptions<LoginResponse, Error, LoginForm, unknown>) => {
   return useMutation({
     mutationFn: login,
+    // NOTE: 로그인 성공 시 GET /api/v1/users/me 캐시 무효화 필요
+    // users 도메인 구현 후 userKeys.me() invalidateQueries 추가 예정
     ...options,
   });
 };
@@ -47,6 +52,9 @@ export const useLogin = (options?: UseMutationOptions<LoginResponse, Error, Logi
 export const useLogout = (options?: UseMutationOptions<void, Error, void, unknown>) => {
   return useMutation({
     mutationFn: logout,
+    // NOTE: 로그아웃 성공 시 GET /api/v1/users/me 캐시 제거 필요
+    // invalidate가 아닌 remove — 세션 종료이므로 데이터 자체를 삭제해야 함
+    // users 도메인 구현 후 userKeys.me() removeQueries 추가 예정
     ...options,
   });
 };

--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -1,0 +1,52 @@
+import { queryOptions, useMutation } from '@tanstack/react-query';
+
+import { checkEmail, checkNickname, login, logout, register } from './index';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { LoginForm, LoginResponse, RegisterResponse, SignupForm } from './types';
+
+export const authKeys = {
+  checkEmail: (email: string) => ['auth', 'check', 'email', email] as const,
+  checkNickname: (nickname: string) => ['auth', 'check', 'nickname', nickname] as const,
+};
+
+export const authQueries = {
+  /** GET /auth/check/email — 이메일 중복 확인 */
+  checkEmail: (email: string) =>
+    queryOptions({
+      queryKey: authKeys.checkEmail(email),
+      queryFn: () => checkEmail(email),
+      enabled: !!email,
+    }),
+  /** GET /auth/check/nickname — 닉네임 중복 확인 */
+  checkNickname: (nickname: string) =>
+    queryOptions({
+      queryKey: authKeys.checkNickname(nickname),
+      queryFn: () => checkNickname(nickname),
+      enabled: !!nickname,
+    }),
+};
+
+/** POST /auth/register — 이메일 회원가입 */
+export const useRegister = (options?: UseMutationOptions<RegisterResponse, Error, SignupForm, unknown>) => {
+  return useMutation({
+    mutationFn: register,
+    ...options,
+  });
+};
+
+/** POST /auth/login — 이메일 로그인 */
+export const useLogin = (options?: UseMutationOptions<LoginResponse, Error, LoginForm, unknown>) => {
+  return useMutation({
+    mutationFn: login,
+    ...options,
+  });
+};
+
+/** POST /auth/logout — 로그아웃 */
+export const useLogout = (options?: UseMutationOptions<void, Error, void, unknown>) => {
+  return useMutation({
+    mutationFn: logout,
+    ...options,
+  });
+};

--- a/src/api/auth/types.ts
+++ b/src/api/auth/types.ts
@@ -27,7 +27,7 @@ export interface RegisterResponse {
 }
 
 export interface OAuthCallbackResponse {
-  isNewUser: boolean;
+  newUser: boolean;
 }
 
 export interface CheckAvailabilityResponse {

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -3,8 +3,19 @@ import { http, HttpResponse, delay } from 'msw';
 import { createApiResponse } from '../utils';
 
 import type { RegisterResponse, LoginResponse, CheckAvailabilityResponse } from '@/api/auth/types';
+import type { ApiError } from '@/api/common/types';
 
 const BASE = '/api/v1/auth';
+
+const TAKEN_EMAILS = ['taken@test.com'];
+const TAKEN_NICKNAMES = ['마감왕'];
+
+const createApiError = (message: string, errorCode: string): ApiError => ({
+  success: false,
+  data: null,
+  message,
+  errorCode,
+});
 
 export const authHandlers = [
   /** POST /api/v1/auth/register — 이메일 회원가입 */
@@ -12,6 +23,12 @@ export const authHandlers = [
     await delay(300);
 
     const body = (await request.json()) as { email: string; password: string; nickname: string };
+
+    if (TAKEN_EMAILS.includes(body.email) || TAKEN_NICKNAMES.includes(body.nickname)) {
+      return HttpResponse.json(createApiError('이미 사용 중인 이메일 또는 닉네임입니다.', 'DUPLICATE'), {
+        status: 409,
+      });
+    }
 
     return HttpResponse.json(
       createApiResponse<RegisterResponse>({
@@ -50,16 +67,24 @@ export const authHandlers = [
   }),
 
   /** GET /api/v1/auth/check/email — 이메일 중복 확인 */
-  http.get(`${BASE}/check/email`, async () => {
+  http.get(`${BASE}/check/email`, async ({ request }) => {
     await delay(300);
 
-    return HttpResponse.json(createApiResponse<CheckAvailabilityResponse>({ available: true }));
+    const email = new URL(request.url).searchParams.get('email') ?? '';
+
+    return HttpResponse.json(
+      createApiResponse<CheckAvailabilityResponse>({ available: !TAKEN_EMAILS.includes(email) }),
+    );
   }),
 
   /** GET /api/v1/auth/check/nickname — 닉네임 중복 확인 */
-  http.get(`${BASE}/check/nickname`, async () => {
+  http.get(`${BASE}/check/nickname`, async ({ request }) => {
     await delay(300);
 
-    return HttpResponse.json(createApiResponse<CheckAvailabilityResponse>({ available: true }));
+    const nickname = new URL(request.url).searchParams.get('nickname') ?? '';
+
+    return HttpResponse.json(
+      createApiResponse<CheckAvailabilityResponse>({ available: !TAKEN_NICKNAMES.includes(nickname) }),
+    );
   }),
 ];

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,0 +1,65 @@
+import { http, HttpResponse, delay } from 'msw';
+
+import { createApiResponse } from '../utils';
+
+import type { RegisterResponse, LoginResponse, CheckAvailabilityResponse } from '@/api/auth/types';
+
+const BASE = '/api/v1/auth';
+
+export const authHandlers = [
+  /** POST /api/v1/auth/register — 이메일 회원가입 */
+  http.post(`${BASE}/register`, async ({ request }) => {
+    await delay(300);
+
+    const body = (await request.json()) as { email: string; password: string; nickname: string };
+
+    return HttpResponse.json(
+      createApiResponse<RegisterResponse>({
+        userId: Date.now(),
+        email: body.email,
+        nickname: body.nickname,
+      }),
+      { status: 201 },
+    );
+  }),
+
+  /** POST /api/v1/auth/login — 이메일 로그인 */
+  http.post(`${BASE}/login`, async ({ request }) => {
+    await delay(300);
+
+    const body = (await request.json()) as { email: string; password: string };
+
+    return HttpResponse.json(
+      createApiResponse<LoginResponse>({
+        user: {
+          id: 1,
+          email: body.email,
+          nickname: '테스터',
+          profileImage: '',
+          reputationScore: 0,
+        },
+      }),
+    );
+  }),
+
+  /** POST /api/v1/auth/logout — 로그아웃 */
+  http.post(`${BASE}/logout`, async () => {
+    await delay(300);
+
+    return new HttpResponse(null, { status: 200 });
+  }),
+
+  /** GET /api/v1/auth/check/email — 이메일 중복 확인 */
+  http.get(`${BASE}/check/email`, async () => {
+    await delay(300);
+
+    return HttpResponse.json(createApiResponse<CheckAvailabilityResponse>({ available: true }));
+  }),
+
+  /** GET /api/v1/auth/check/nickname — 닉네임 중복 확인 */
+  http.get(`${BASE}/check/nickname`, async () => {
+    await delay(300);
+
+    return HttpResponse.json(createApiResponse<CheckAvailabilityResponse>({ available: true }));
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { todosHandlers } from './todos';
+import { authHandlers } from './auth';
 
-export const handlers = [...todosHandlers];
+export const handlers = [...todosHandlers, ...authHandlers];


### PR DESCRIPTION
## ❓ 이슈

- close #72 

## ✍️ Description

Auth 도메인 API 함수, 쿼리 훅, MSW 핸들러를 구현했습니다.

### 구현 내용
- `src/api/auth/index.ts` — register, login, logout, checkEmail, checkNickname API 함수
- `src/api/auth/queries.ts` — authKeys 팩토리, authQueries(queryOptions), useRegister/useLogin/useLogout mutation 훅
- `src/mocks/handlers/auth.ts` — Auth 도메인 MSW 핸들러 5개 (register 201/409, login/logout 200, checkEmail/checkNickname 중복 시나리오 포함)
- `src/mocks/handlers/index.ts` — authHandlers 등록

**타입 수정**
- `src/api/auth/types.ts` — `OAuthCallbackResponse.isNewUser` → `newUser` (Swagger 실제 응답 필드명 기준으로 수정, 이슈 명세와 상이)

## 📸 스크린샷 (UI 변경 시)
<img width="966" height="76" alt="화면 캡처 2026-03-24 100406" src="https://github.com/user-attachments/assets/9328cd79-3ed5-4675-87b0-e19e1b1e8d24" />

<img width="970" height="178" alt="화면 캡처 2026-03-24 100303" src="https://github.com/user-attachments/assets/9ec1ed96-5b81-4cfd-8441-8cbc35dd853c" />

<img width="980" height="132" alt="화면 캡처 2026-03-24 112206" src="https://github.com/user-attachments/assets/5879a5d3-ef98-4872-b128-61ec263bd6ae" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes
