### PR TITLE
[SM-65] chore: 렌더링 & TanStack Query & 코드 스타일 규칙 업데이트

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -31,6 +31,12 @@ paths:
 - interface 우선 (type은 유니온, 교차 타입 시만)
 - Props interface는 같은 파일, 컴포넌트 바로 위에 선언
 
+## 가독성
+
+- 매직 넘버와 복잡한 조건식에 명명된 상수/변수 사용
+- 예: `if (members.length >= 5)` → `const MAX_MEMBERS = 5; if (members.length >= MAX_MEMBERS)`
+- 예: `if (a && b || c)` → `const isEligible = a && b || c; if (isEligible)`
+
 ## 컴포넌트 구조
 
 - `'use client'`는 파일 최상단, 첫 줄에만

--- a/.claude/rules/rendering.md
+++ b/.claude/rules/rendering.md
@@ -9,14 +9,14 @@ paths:
 
 ## 페이지별 렌더링 전략
 
-| 페이지       | 렌더링 | 캐시                                            | 비고                                     |
-| ------------ | ------ | ----------------------------------------------- | ---------------------------------------- |
-| 랜딩         | Static | 없음                                            | 정적 페이지                              |
-| 로그인       | Static | 없음                                            | 폼은 클라이언트 컴포넌트                 |
-| 회원가입     | Static | 없음                                            | 폼은 클라이언트 컴포넌트                 |
-| 메인         | ISR    | 온디맨드(revalidateTag) + revalidate: 3600 보험 | prefetchQuery + HydrationBoundary        |
-| 모임 상세    | ISR    | 온디맨드(revalidateTag) + revalidate: 3600 보험 | 모임 설명, 주차별 계획 등 정적 정보 캐시 |
-| 그 외 페이지 | 미정   | 미정                                            | 추후 확정                                |
+| 페이지       | 렌더링 | 캐시                                        | 비고                                     |
+| ------------ | ------ | ------------------------------------------- | ---------------------------------------- |
+| 랜딩         | Static | 없음                                        | 정적 페이지                              |
+| 로그인       | Static | 없음                                        | 폼은 클라이언트 컴포넌트                 |
+| 회원가입     | Static | 없음                                        | 폼은 클라이언트 컴포넌트                 |
+| 메인         | ISR    | 온디맨드(updateTag) + revalidate: 3600 보험 | prefetchQuery + HydrationBoundary        |
+| 모임 상세    | ISR    | 온디맨드(updateTag) + revalidate: 3600 보험 | 모임 설명, 주차별 계획 등 정적 정보 캐시 |
+| 그 외 페이지 | 미정   | 미정                                        | 추후 확정                                |
 
 ## 서버/클라이언트 컴포넌트 분리
 
@@ -36,15 +36,26 @@ paths:
 
 ## 데이터 페칭 패턴
 
-### 공개 데이터 (인증 불필요)
+### 공개 데이터 + SEO 필요 (메인, 모임 상세 등 외부 노출 페이지)
 
 - page.tsx에서 getQueryClient() → prefetchQuery (queryFn에 fetch + next.tags 지정) → HydrationBoundary로 감싸기
 - 클라이언트 컴포넌트에서 동일한 queryKey로 useQuery → 캐시 히트
+
+### 공개 데이터 + SEO 불필요 (로그인 후 내부 페이지)
+
+- 서버 prefetch 불필요. SuspenseBoundary + useSuspenseQuery 사용
+- 예: 유저 프로필 내 리뷰 목록, 검색 결과 등
 
 ### 유저별 데이터 (인증 필요)
 
 - page.tsx에서 SuspenseBoundary로 감싸기 (fallback: Skeleton, errorFallback: ErrorFallback)
 - 클라이언트 컴포넌트에서 useSuspenseQuery → Suspense 연동 자동 로딩 처리
+
+## 컴포넌트는 성공 상태만 렌더
+
+- 컴포넌트 내부에서 `isLoading`, `isError` 분기 작성 금지
+- 로딩 처리는 Suspense (또는 prefetch), 에러 처리는 ErrorBoundary에 위임
+- 컴포넌트는 데이터가 있는 상태만 가정하고 렌더링 로직에 집중
 
 ## ErrorBoundary / SuspenseBoundary 사용 규칙
 
@@ -60,4 +71,4 @@ paths:
 
 - **MUST**: 서버에서 axios 사용 금지 (Next.js Data Cache 연동 불가, fetch만 사용)
 - **MUST**: page.tsx에서 직접 useQuery 금지 (서버 컴포넌트)
-- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + revalidateTag
+- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + updateTag

--- a/.claude/rules/tanstack-query.md
+++ b/.claude/rules/tanstack-query.md
@@ -36,14 +36,36 @@ paths:
 
 - mutation 성공 시 반드시 클라이언트 + 서버 캐시 둘 다 무효화
 - `invalidateQueries` → 현재 유저 화면 즉시 갱신
-- `revalidateTag` (Server Action) → 서버 Data Cache 무효화, 다른 유저도 최신 데이터
-- invalidateQueries만 → 새로고침 시 옛날 데이터 / revalidateTag만 → 현재 유저는 새로고침 필요
+- `updateTag` (Server Action) → 서버 Data Cache 무효화, 다른 유저도 최신 데이터
+- invalidateQueries만 → 새로고침 시 옛날 데이터 / updateTag만 → 현재 유저는 새로고침 필요
+
+## Mutation 콜백 분리 패턴
+
+| 위치                            | 담당                       | 이유                                   |
+| ------------------------------- | -------------------------- | -------------------------------------- |
+| `useMutation` 레벨 (훅 내부)    | 캐시 무효화, 데이터 동기화 | unmount 여부와 관계없이 항상 실행      |
+| `mutate()` 호출 레벨 (컴포넌트) | toast, redirect 등 UI 콜백 | unmount 시 실행 안 됨 → UI 콜백에 적합 |
+
+- 훅 내부 onSuccess에는 이중 캐시 무효화만 포함
+- UI 부수효과(toast, navigate)를 훅 내부에 하드코딩 금지
+- `UseMutationOptions` 파라미터로 소비자 콜백 주입 가능하도록 설계
+
+## mutate vs mutateAsync
+
+- 기본은 `mutate` 사용 (에러를 콜백으로 처리, 별도 try-catch 불필요)
+- `mutateAsync`는 여러 mutation을 `Promise.all`로 병렬 실행할 때만 사용
+
+## startTransition으로 Suspense fallback 깜빡임 방지
+
+- `useSuspenseQuery`의 queryKey가 변경될 때 `startTransition`으로 감싸서 이전 UI 유지
+- 필터/정렬/탭 전환 시 스켈레톤이 매번 깜빡이는 것을 방지
+- `startTransition` 없이 queryKey 변경 → Suspense fallback 재노출 → UX 저하
 
 ## 낙관적 업데이트 (찜 등 즉각 반응 필요 시)
 
 - onMutate: cancelQueries → getQueryData(이전값 저장) → setQueryData(낙관적 변경)
 - onError: 이전값으로 롤백
-- onSettled: invalidateQueries + revalidateTag로 서버/클라이언트 둘 다 최종 동기화
+- onSettled: invalidateQueries + updateTag로 서버/클라이언트 둘 다 최종 동기화
 
 ## 주의사항
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@
 - 공개 데이터: 서버 prefetchQuery + HydrationBoundary + 클라이언트 useQuery
 - 유저별 데이터: 클라이언트 useSuspenseQuery + Suspense 경계
 - API 호출 있는 컴포넌트: ErrorBoundary로 에러 격리
-- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + revalidateTag
+- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + updateTag
 
 ## TanStack Query
 


### PR DESCRIPTION
## ❓ 이슈

- close #80 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
 ### rendering.md
  - 데이터 페칭 패턴 2단계 → 3단계 분류 (공개+SEO필요 /
  공개+SEO불필요 / 유저별)
  - 공개+SEO 불필요 → `useSuspenseQuery`로 통일 (기존 `useQuery`
  → `useSuspenseQuery`)
  - "컴포넌트는 성공 상태만 렌더" 규칙 추가
  (`isLoading`/`isError` 분기 금지)
  - `revalidateTag` → `updateTag` 용어 변경 (Next.js 16)

  ### tanstack-query.md
  - mutation 콜백 분리 패턴 추가 (훅=캐시무효화, 컴포넌트=UI콜백)
  - `mutate` vs `mutateAsync` 규칙 추가
  - `startTransition`으로 Suspense fallback 깜빡임 방지 규칙 추
  - `revalidateTag` → `updateTag` 용어 변경

  ### code-style.md
  - 매직 넘버/조건식 명명 규칙 추가

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

