### PR TITLE
[SM-59] feat: users 도메인 API 통신 로직 및 MSW 모킹 구현

### DIFF
--- a/src/api/users/index.ts
+++ b/src/api/users/index.ts
@@ -1,0 +1,43 @@
+import { axiosClient } from '@/lib/axiosClient';
+import { unwrapResponse } from '@/api/common/utils';
+
+import type {
+  GetMeResponse,
+  User,
+  UpdateProfileForm,
+  PatchMeResponse,
+  UpdatePasswordForm,
+  PatchPasswordResponse,
+  UpdatePasswordResponseData,
+  GetUserByIdResponse,
+  UserPublicProfile,
+} from './types';
+
+/** GET /v1/users/me - 내 프로필 조회*/
+export const getUsersMe = async (): Promise<User> => {
+  const { data } = await axiosClient.get<GetMeResponse>(`/v1/users/me`);
+  return unwrapResponse(data);
+};
+
+/** PATCH /v1/users/me - 내 프로필 수정*/
+export const updateProfile = async (body: UpdateProfileForm): Promise<User> => {
+  const { data } = await axiosClient.patch<PatchMeResponse>(`/v1/users/me`, body);
+  return unwrapResponse(data);
+};
+
+/** PATCH /v1/users/me/password - 비밀번호 변경*/
+export const updatePassword = async (body: UpdatePasswordForm): Promise<UpdatePasswordResponseData> => {
+  const { data } = await axiosClient.patch<PatchPasswordResponse>(`/v1/users/me/password`, body);
+  return unwrapResponse(data);
+};
+
+/** DELETE /v1/users/me - 회원 탈퇴*/
+export const deleteUser = async (): Promise<void> => {
+  await axiosClient.delete(`/v1/users/me`);
+};
+
+/** GET /v1/users/:userId - 다른 사람 프로필 조회*/
+export const getUsersUserId = async (userId: number): Promise<UserPublicProfile> => {
+  const { data } = await axiosClient.get<GetUserByIdResponse>(`/v1/users/${userId}`);
+  return unwrapResponse(data);
+};

--- a/src/api/users/queries.ts
+++ b/src/api/users/queries.ts
@@ -1,0 +1,71 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { getUsersMe, getUsersUserId, updateProfile, updatePassword, deleteUser } from '.';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { User, UpdateProfileForm, UpdatePasswordForm, UpdatePasswordResponseData } from './types';
+
+export const userKeys = {
+  all: ['users'] as const,
+  me: () => [...userKeys.all, 'me'] as const,
+  userId: (userId: number) => [...userKeys.all, userId] as const,
+};
+
+export const userQueries = {
+  /** GET /v1/users/me - 내 프로필 조회*/
+  me: () =>
+    queryOptions({
+      queryKey: userKeys.me(),
+      queryFn: () => getUsersMe(),
+    }),
+  /** GET /v1/users/:userId - 다른 사람 프로필 조회*/
+  userId: (userId: number) =>
+    queryOptions({
+      queryKey: userKeys.userId(userId),
+      queryFn: () => getUsersUserId(userId),
+    }),
+};
+
+/** PATCH /v1/users/me - 내 프로필 수정*/
+export const useUpdateProfile = (options?: UseMutationOptions<User, Error, UpdateProfileForm, unknown>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdateProfileForm) => updateProfile(body),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: userKeys.me() });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** PATCH /v1/users/me/password - 비밀번호 변경*/
+export const useUpdatePassword = (
+  options?: UseMutationOptions<UpdatePasswordResponseData, Error, UpdatePasswordForm, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdatePasswordForm) => updatePassword(body),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: userKeys.me() });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** DELETE /v1/users/me - 회원 탈퇴*/
+export const useDeleteUser = (options?: UseMutationOptions<void, Error, void, unknown>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deleteUser(),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.removeQueries({ queryKey: userKeys.me() });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { todosHandlers } from './todos';
 import { authHandlers } from './auth';
+import { usersHandlers } from './users';
 
-export const handlers = [...todosHandlers, ...authHandlers];
+export const handlers = [...todosHandlers, ...authHandlers, ...usersHandlers];

--- a/src/mocks/handlers/users.ts
+++ b/src/mocks/handlers/users.ts
@@ -1,0 +1,72 @@
+import { http, HttpResponse, delay } from 'msw';
+
+import { createApiResponse } from '../utils';
+
+import type { User, UserPublicProfile, UpdateProfileForm, UpdatePasswordResponseData } from '@/api/users/types';
+
+const BASE = '/api/v1/users';
+
+// 가짜 유저 데이터를 외부에 선언하여 PATCH 호출 시 상태가 유지되도록 합니다.
+const mockUser: User = {
+  id: 1,
+  email: 'user@example.com',
+  nickname: '마감왕',
+  profileImage: 'https://avatars.githubusercontent.com/u/1?v=4',
+  provider: 'EMAIL',
+  reputationScore: 36.5,
+  reputationLabel: '신뢰 메이트',
+};
+
+// 다른 유저(Public) 데이터 모의 생성
+const getPublicUser = (userId: number): UserPublicProfile => ({
+  id: userId,
+  nickname: userId === 1 ? mockUser.nickname : `마감요정${userId}`,
+  profileImage: userId === 1 ? mockUser.profileImage : 'https://avatars.githubusercontent.com/u/2?v=4',
+  reputationScore: userId === 1 ? mockUser.reputationScore : 42.0,
+  reputationLabel: userId === 1 ? mockUser.reputationLabel : '친절한 메이트',
+});
+
+export const usersHandlers = [
+  /** GET /api/v1/users/me - 내 프로필 조회*/
+  http.get(`${BASE}/me`, async () => {
+    await delay(300);
+    return HttpResponse.json(createApiResponse<User>(mockUser));
+  }),
+
+  /** PATCH /api/v1/users/me - 내 프로필 수정*/
+  http.patch(`${BASE}/me`, async ({ request }) => {
+    await delay(400); // 폼 제출 액션이므로 조금 더 길게 지연
+    const body = (await request.json()) as UpdateProfileForm;
+
+    // 임의의 프로필 데이터 업데이트
+    if (body.nickname) mockUser.nickname = body.nickname;
+    if (body.profileImage) mockUser.profileImage = body.profileImage;
+
+    return HttpResponse.json(createApiResponse<User>(mockUser));
+  }),
+
+  /** PATCH /api/v1/users/me/password - 비밀번호 변경*/
+  http.patch(`${BASE}/me/password`, async () => {
+    await delay(400);
+
+    // 성공 시 빈 객체 리턴
+    return HttpResponse.json(createApiResponse<UpdatePasswordResponseData>({}));
+  }),
+
+  /** DELETE /api/v1/users/me - 회원 탈퇴*/
+  http.delete(`${BASE}/me`, async () => {
+    await delay(300);
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  /** GET /api/v1/users/:userId - 다른 사람 프로필 조회*/
+  http.get(`${BASE}/:userId`, async ({ params }) => {
+    await delay(300);
+    const userId = Number(params.userId);
+
+    const publicProfile = getPublicUser(userId);
+
+    return HttpResponse.json(createApiResponse<UserPublicProfile>(publicProfile));
+  }),
+];


### PR DESCRIPTION
## ❓ 이슈

- close #73 

## ✍️ Description

Users 도메인(유저 프로필 및 계정 설정)과 관련된 클라이언트 측 API 통신 로직과 React Query 커스텀 훅, 그리고 모의 테스트를 위한 MSW 모킹 핸들러를 신규 구현했습니다.

## ✅ Checklist

- [x] Axios 통신 로직(index.ts) 구현: 내 프로필 조회/수정, 비밀번호 변경, 탈퇴, 타 유저 프로필 조회 API 엔드포인트 세팅
- [x] Query / Mutation 훅(queries.ts) 추가:
  - [x] GET 방식: 서버 컴포넌트와 클라이언트 양쪽에서 유연하게 쓸 수 있는 queryOptions 팩토리 패턴 적용 (userQueries.me(), userQueries.userId())
  - [x] PATCH / DELETE 방식: useUpdateProfile(), useUpdatePassword(), useDeleteUser() 등 컴포넌트에서 호출 가능한 useMutation 커스텀 훅 작성
- [x] 개발 및 UI 작업을 위해 5개 API에 대한 모의 응답 핸들러 구현
- [x] 프로필 변경 시 실제 서버처럼 `mockUser` 데이터가 갱신 유지되도록 구성
- [x] 실제 네트워크 상태를 흉내 내기 위해 300~400ms의 딜레이 추가

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- Mutation 훅의 경우 호출부에서 options를 주입할 수 있도록 열어두었습니다. 추후 Next.js의 Server Action(updateTag 호출 등)을 필요에 따라 유연하게 주입해 사용할 계획입니다.
