### PR TITLE
[SM-62] feat: Memberships 도메인 API 함수 및 쿼리 훅, MSW 핸들러 작성

### DIFF
--- a/src/api/memberships/index.ts
+++ b/src/api/memberships/index.ts
@@ -1,0 +1,33 @@
+import { axiosClient } from '@/lib/axiosClient';
+import { unwrapResponse } from '@/api/common/utils';
+
+import type { ApiResponse } from '@/api/common/types';
+import type { MyGatheringsParams, MyGatheringList, GatheringMembersList, DeleteMember } from './types';
+
+/** GET /v1/users/me/gatherings — 내 모임 목록 */
+export const getMyGatherings = async (params?: MyGatheringsParams): Promise<MyGatheringList> => {
+  const { data } = await axiosClient.get<ApiResponse<MyGatheringList>>('/v1/users/me/gatherings', {
+    params,
+  });
+  return unwrapResponse(data);
+};
+
+/** GET /v1/gatherings/:gatheringId/members — 모임 멤버 목록 */
+export const getGatheringMembers = async (gatheringId: number): Promise<GatheringMembersList> => {
+  const { data } = await axiosClient.get<ApiResponse<GatheringMembersList>>(`/v1/gatherings/${gatheringId}/members`);
+  return unwrapResponse(data);
+};
+
+/** DELETE /v1/gatherings/:gatheringId/members/:userId — 멤버 강퇴 (모임장 전용) */
+export const removeMember = async (gatheringId: number, userId: number): Promise<DeleteMember> => {
+  const { data } = await axiosClient.delete<ApiResponse<DeleteMember>>(
+    `/v1/gatherings/${gatheringId}/members/${userId}`,
+  );
+  return unwrapResponse(data);
+};
+
+/** DELETE /v1/gatherings/:gatheringId/members/me — 모임 탈퇴 (본인) */
+export const leaveGathering = async (gatheringId: number): Promise<DeleteMember> => {
+  const { data } = await axiosClient.delete<ApiResponse<DeleteMember>>(`/v1/gatherings/${gatheringId}/members/me`);
+  return unwrapResponse(data);
+};

--- a/src/api/memberships/queries.ts
+++ b/src/api/memberships/queries.ts
@@ -1,0 +1,61 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { getMyGatherings, getGatheringMembers, removeMember, leaveGathering } from './index';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { MyGatheringsParams, DeleteMember } from './types';
+
+export const membershipKeys = {
+  all: ['memberships'] as const,
+  my: (params?: MyGatheringsParams) => [...membershipKeys.all, 'my', params ?? {}] as const,
+  members: (gatheringId: number) => [...membershipKeys.all, 'members', gatheringId] as const,
+};
+
+export const membershipQueries = {
+  /** GET /users/me/gatherings — 내 모임 목록 */
+  my: (params?: MyGatheringsParams) =>
+    queryOptions({
+      queryKey: membershipKeys.my(params),
+      queryFn: () => getMyGatherings(params),
+    }),
+  /** GET /gatherings/:gatheringId/members — 모임 멤버 목록 */
+  members: (gatheringId: number) =>
+    queryOptions({
+      queryKey: membershipKeys.members(gatheringId),
+      queryFn: () => getGatheringMembers(gatheringId),
+    }),
+};
+
+/** DELETE /gatherings/:gatheringId/members/:userId — 멤버 강퇴 (모임장 전용) */
+export const useRemoveMember = (
+  gatheringId: number,
+  options?: UseMutationOptions<DeleteMember, Error, number, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) => removeMember(gatheringId, userId),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: membershipKeys.all });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** DELETE /gatherings/:gatheringId/members/me — 모임 탈퇴 (본인) */
+export const useLeaveGathering = (
+  gatheringId: number,
+  options?: UseMutationOptions<DeleteMember, Error, void, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => leaveGathering(gatheringId),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: membershipKeys.all });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,6 @@
 import { todosHandlers } from './todos';
 import { authHandlers } from './auth';
 import { usersHandlers } from './users';
+import { membershipsHandlers } from './memberships';
 
-export const handlers = [...todosHandlers, ...authHandlers, ...usersHandlers];
+export const handlers = [...todosHandlers, ...authHandlers, ...usersHandlers, ...membershipsHandlers];

--- a/src/mocks/handlers/memberships.ts
+++ b/src/mocks/handlers/memberships.ts
@@ -1,0 +1,185 @@
+import { http, HttpResponse, delay } from 'msw';
+
+import { createApiResponse } from '../utils';
+
+import type { ApiError } from '@/api/common/types';
+import type {
+  MembershipGathering,
+  MyGatheringList,
+  Member,
+  GatheringMembersList,
+  DeleteMember,
+  GatheringStatus,
+} from '@/api/memberships/types';
+
+const CURRENT_USER_ID = 1;
+
+const STATUS_FILTER_MAP: Record<string, GatheringStatus> = {
+  recruiting: 'RECRUITING',
+  in_progress: 'IN_PROGRESS',
+  completed: 'COMPLETED',
+};
+
+const mockGatherings: MembershipGathering[] = [
+  {
+    id: 1,
+    type: '스터디',
+    category: '개발',
+    title: 'React 완전 정복 스터디',
+    shortDescription: '리액트 공식문서를 같이 읽어요',
+    tags: ['React', '프론트엔드'],
+    maxMembers: 6,
+    currentMembers: 3,
+    startDate: '2025-03-22',
+    endDate: '2025-04-19',
+    status: 'IN_PROGRESS',
+    myRole: 'LEADER',
+    isLiked: true,
+  },
+  {
+    id: 2,
+    type: '프로젝트',
+    category: '개발',
+    title: '사이드 프로젝트 팀원 모집',
+    shortDescription: 'Spring Boot 기반 협업 프로젝트',
+    tags: ['Spring', '백엔드'],
+    maxMembers: 5,
+    currentMembers: 4,
+    startDate: '2025-04-01',
+    endDate: '2025-05-30',
+    status: 'RECRUITING',
+    myRole: 'MEMBER',
+    isLiked: false,
+  },
+  {
+    id: 3,
+    type: '스터디',
+    category: '디자인',
+    title: 'Figma 마스터 클래스',
+    shortDescription: 'Figma 기초부터 실전까지',
+    tags: ['Figma', 'UI/UX'],
+    maxMembers: 8,
+    currentMembers: 8,
+    startDate: '2025-01-10',
+    endDate: '2025-02-28',
+    status: 'COMPLETED',
+    myRole: 'MEMBER',
+    isLiked: true,
+  },
+];
+
+const mockMembers: Record<number, Member[]> = {
+  1: [
+    {
+      userId: 1,
+      nickname: '마감왕',
+      profileImage: 'https://picsum.photos/seed/user1/200',
+      role: 'LEADER',
+      overallAchievementRate: 85.0,
+      isActive: true,
+    },
+    {
+      userId: 2,
+      nickname: '이개발',
+      profileImage: 'https://picsum.photos/seed/user2/200',
+      role: 'MEMBER',
+      overallAchievementRate: 72.5,
+      isActive: true,
+    },
+    {
+      userId: 3,
+      nickname: '박디자인',
+      profileImage: 'https://picsum.photos/seed/user3/200',
+      role: 'MEMBER',
+      overallAchievementRate: 90.0,
+      isActive: true,
+    },
+  ],
+  2: [
+    {
+      userId: 4,
+      nickname: '최백엔드',
+      profileImage: 'https://picsum.photos/seed/user4/200',
+      role: 'LEADER',
+      overallAchievementRate: 88.0,
+      isActive: true,
+    },
+    {
+      userId: 1,
+      nickname: '마감왕',
+      profileImage: 'https://picsum.photos/seed/user1/200',
+      role: 'MEMBER',
+      overallAchievementRate: 65.0,
+      isActive: true,
+    },
+  ],
+};
+
+const MEMBERS_BASE = '/api/v1/gatherings/:gatheringId/members';
+
+export const membershipsHandlers = [
+  /** GET /api/v1/users/me/gatherings — 내 모임 목록 */
+  http.get('/api/v1/users/me/gatherings', async ({ request }) => {
+    await delay(300);
+
+    const url = new URL(request.url);
+    const status = url.searchParams.get('status') ?? 'all';
+    const page = Number(url.searchParams.get('page') ?? '1');
+    const limit = Number(url.searchParams.get('limit') ?? '12');
+
+    const filtered =
+      status === 'all' ? mockGatherings : mockGatherings.filter((g) => g.status === STATUS_FILTER_MAP[status]);
+
+    const totalCount = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / limit));
+    const start = (page - 1) * limit;
+    const paged = filtered.slice(start, start + limit);
+
+    return HttpResponse.json(
+      createApiResponse<MyGatheringList>({
+        gatherings: paged,
+        totalCount,
+        totalPages,
+        currentPage: page,
+      }),
+    );
+  }),
+
+  /** GET /api/v1/gatherings/:gatheringId/members — 모임 멤버 목록 */
+  http.get(MEMBERS_BASE, async ({ params }) => {
+    await delay(300);
+
+    const gatheringId = Number(params.gatheringId);
+    const members = mockMembers[gatheringId] ?? [];
+
+    return HttpResponse.json(createApiResponse<GatheringMembersList>({ members }));
+  }),
+
+  /** DELETE /api/v1/gatherings/:gatheringId/members/me — 모임 탈퇴 (본인) */
+  http.delete(`${MEMBERS_BASE}/me`, async () => {
+    await delay(200);
+
+    return HttpResponse.json(createApiResponse<DeleteMember>({ success: true }));
+  }),
+
+  /** DELETE /api/v1/gatherings/:gatheringId/members/:userId — 멤버 강퇴 (모임장 전용) */
+  http.delete(`${MEMBERS_BASE}/:userId`, async ({ params }) => {
+    await delay(200);
+
+    const userId = Number(params.userId);
+
+    if (userId === CURRENT_USER_ID) {
+      return HttpResponse.json(
+        {
+          success: false,
+          data: null,
+          message: '모임장 본인은 퇴출할 수 없습니다.',
+          errorCode: 'CANNOT_REMOVE_LEADER',
+        } satisfies ApiError,
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json(createApiResponse<DeleteMember>({ success: true }));
+  }),
+];


### PR DESCRIPTION
## ❓ 이슈

- close #77 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
Memberships 도메인의 API 함수, TanStack Query 쿼리 훅, MSW 핸들러를 작성

  ### API 함수 (`src/api/memberships/index.ts`)

  | 함수 | 메서드 | 엔드포인트 |
  |------|--------|-----------|
  | `getMyGatherings` | GET | `/v1/users/me/gatherings` |
  | `getGatheringMembers` | GET | `/v1/gatherings/:gatheringId/members` |
  | `removeMember` | DELETE | `/v1/gatherings/:gatheringId/members/:userId` |
  | `leaveGathering` | DELETE | `/v1/gatherings/:gatheringId/members/me` |

  ### 쿼리 훅 (`src/api/memberships/queries.ts`)

  - **queryKeys**: `all → my(params) / members(gatheringId)` 계층 구조
  - **queryOptions**: `membershipQueries.my()`, `membershipQueries.members()`
  - **mutation 훅**: `useRemoveMember`, `useLeaveGathering`

  ### MSW 핸들러 (`src/mocks/handlers/memberships.ts`)

  - 4개 엔드포인트 전체 목 핸들러
  - 내 모임 목록: status 필터링 + 페이지네이션 처리
  - 모임장 본인 강퇴 시 `400` 에러 응답

### 서버 캐시 무효화(`updateTag`) 미적용 사유

  Memberships 도메인의 4개 API는 **전부 인증 필요 → 클라이언트 전용
  fetch(`axiosClient`)** 입니다.
  서버 Data Cache(`fetch` + `next: { tags }`)로 캐싱되는 데이터가 없으므로,
  mutation 성공 시 `invalidateQueries`만 적용했습니다.
  `updateTag`는 서버 `prefetchQuery`로 캐싱된 데이터가 존재할 때만 의미가 있기
  때문에 이 도메인에서는 불필요합니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)


