### PR TITLE
[SM-60] feat: Gatherings 도메인 API 함수 및 쿼리 훅, MSW 핸들러 작성

### DIFF
--- a/src/api/gatherings/index.ts
+++ b/src/api/gatherings/index.ts
@@ -1,0 +1,75 @@
+import { axiosClient } from '@/lib/axiosClient';
+import { unwrapResponse } from '@/api/common/utils';
+
+import type { ApiResponse } from '@/api/common/types';
+import type {
+  GetGatheringsParams,
+  GetGatheringsResponse,
+  GetMainGatheringsParams,
+  GetMainGatheringsResponse,
+  GetGatheringDetailResponse,
+  CreateGatheringRequest,
+  CreateGatheringResponse,
+  UpdateGatheringRequest,
+  UpdateGatheringResponse,
+} from './types';
+
+export const GATHERING_TAGS = {
+  all: 'gatherings',
+  main: 'gatherings-main',
+  detail: (gatheringId: number) => `gatherings-detail-${gatheringId}`,
+} as const;
+
+const getBaseUrl = () => {
+  const baseUrl = process.env.BACKEND_BASE_URL;
+  if (!baseUrl) throw new Error('BACKEND_BASE_URL is not defined');
+  return baseUrl.replace(/\/+$/, '');
+};
+
+/** GET /v1/gatherings/main — 메인 페이지 모임 목록 (서버/클라이언트 공용) */
+export const fetchMainGatherings = async (params?: GetMainGatheringsParams): Promise<GetMainGatheringsResponse> => {
+  const searchParams = new URLSearchParams();
+  if (params?.limit !== undefined) searchParams.set('limit', String(params.limit));
+  const qs = searchParams.toString();
+
+  const res = await fetch(`${getBaseUrl()}/v1/gatherings/main${qs ? `?${qs}` : ''}`, {
+    next: { tags: [GATHERING_TAGS.all, GATHERING_TAGS.main] },
+  });
+  const json: ApiResponse<GetMainGatheringsResponse> = await res.json();
+  return unwrapResponse(json);
+};
+
+/** GET /v1/gatherings/:gatheringId — 모임 상세 (서버/클라이언트 공용) */
+export const fetchGatheringDetail = async (gatheringId: number): Promise<GetGatheringDetailResponse> => {
+  const res = await fetch(`${getBaseUrl()}/v1/gatherings/${gatheringId}`, {
+    next: { tags: [GATHERING_TAGS.all, GATHERING_TAGS.detail(gatheringId)] },
+  });
+  const json: ApiResponse<GetGatheringDetailResponse> = await res.json();
+  return unwrapResponse(json);
+};
+
+/** GET /v1/gatherings — 모임 목록 검색 (클라이언트 전용) */
+export const getGatherings = async (params?: GetGatheringsParams): Promise<GetGatheringsResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<GetGatheringsResponse>>('/v1/gatherings', { params });
+  return unwrapResponse(data);
+};
+
+/** POST /v1/gatherings — 모임 생성 (이미지 업로드 시 multipart/form-data 처리 필요할 수 있음) */
+export const createGathering = async (body: CreateGatheringRequest): Promise<CreateGatheringResponse> => {
+  const { data } = await axiosClient.post<ApiResponse<CreateGatheringResponse>>('/v1/gatherings', body);
+  return unwrapResponse(data);
+};
+
+/** PUT /v1/gatherings/:gatheringId — 모임 수정 (이미지 업로드 시 multipart/form-data 처리 필요할 수 있음) */
+export const updateGathering = async (
+  gatheringId: number,
+  body: UpdateGatheringRequest,
+): Promise<UpdateGatheringResponse> => {
+  const { data } = await axiosClient.put<ApiResponse<UpdateGatheringResponse>>(`/v1/gatherings/${gatheringId}`, body);
+  return unwrapResponse(data);
+};
+
+/** DELETE /v1/gatherings/:gatheringId — 모임 삭제 */
+export const deleteGathering = async (gatheringId: number): Promise<void> => {
+  await axiosClient.delete(`/v1/gatherings/${gatheringId}`);
+};

--- a/src/api/gatherings/index.ts
+++ b/src/api/gatherings/index.ts
@@ -35,6 +35,7 @@ export const fetchMainGatherings = async (params?: GetMainGatheringsParams): Pro
   const res = await fetch(`${getBaseUrl()}/v1/gatherings/main${qs ? `?${qs}` : ''}`, {
     next: { tags: [GATHERING_TAGS.all, GATHERING_TAGS.main] },
   });
+  if (!res.ok) throw new Error(`gatherings/main fetch failed: ${res.status}`);
   const json: ApiResponse<GetMainGatheringsResponse> = await res.json();
   return unwrapResponse(json);
 };
@@ -44,6 +45,7 @@ export const fetchGatheringDetail = async (gatheringId: number): Promise<GetGath
   const res = await fetch(`${getBaseUrl()}/v1/gatherings/${gatheringId}`, {
     next: { tags: [GATHERING_TAGS.all, GATHERING_TAGS.detail(gatheringId)] },
   });
+  if (!res.ok) throw new Error(`gatherings/${gatheringId} fetch failed: ${res.status}`);
   const json: ApiResponse<GetGatheringDetailResponse> = await res.json();
   return unwrapResponse(json);
 };

--- a/src/api/gatherings/queries.ts
+++ b/src/api/gatherings/queries.ts
@@ -79,9 +79,7 @@ export const useUpdateGathering = (
     mutationFn: (body: UpdateGatheringRequest) => updateGathering(gatheringId, body),
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
-      queryClient.invalidateQueries({ queryKey: gatheringKeys.detail(gatheringId) });
       queryClient.invalidateQueries({ queryKey: gatheringKeys.all });
-      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
       invalidateServerCache(GATHERING_TAGS.all);
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },

--- a/src/api/gatherings/queries.ts
+++ b/src/api/gatherings/queries.ts
@@ -1,0 +1,104 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
+import {
+  fetchMainGatherings,
+  fetchGatheringDetail,
+  getGatherings,
+  createGathering,
+  updateGathering,
+  deleteGathering,
+  GATHERING_TAGS,
+} from './index';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type {
+  GetMainGatheringsParams,
+  GetGatheringsParams,
+  CreateGatheringRequest,
+  CreateGatheringResponse,
+  UpdateGatheringRequest,
+  UpdateGatheringResponse,
+} from './types';
+
+export const gatheringKeys = {
+  all: ['gatherings'] as const,
+  main: (params?: GetMainGatheringsParams) => [...gatheringKeys.all, 'main', params ?? {}] as const,
+  list: (params?: GetGatheringsParams) => [...gatheringKeys.all, 'list', params ?? {}] as const,
+  detail: (gatheringId: number) => [...gatheringKeys.all, 'detail', gatheringId] as const,
+};
+
+export const gatheringQueries = {
+  /** GET /gatherings/main — 메인 페이지 모임 목록 */
+  main: (params?: GetMainGatheringsParams) =>
+    queryOptions({
+      queryKey: gatheringKeys.main(params),
+      queryFn: () => fetchMainGatherings(params),
+    }),
+
+  /** GET /gatherings/:gatheringId — 모임 상세 */
+  detail: (gatheringId: number) =>
+    queryOptions({
+      queryKey: gatheringKeys.detail(gatheringId),
+      queryFn: () => fetchGatheringDetail(gatheringId),
+    }),
+
+  /** GET /gatherings — 모임 목록 검색 */
+  list: (params?: GetGatheringsParams) =>
+    queryOptions({
+      queryKey: gatheringKeys.list(params),
+      queryFn: () => getGatherings(params),
+    }),
+};
+
+/** POST /gatherings — 모임 생성 */
+export const useCreateGathering = (
+  options?: UseMutationOptions<CreateGatheringResponse, Error, CreateGatheringRequest, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: CreateGatheringRequest) => createGathering(body),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.all });
+      invalidateServerCache(GATHERING_TAGS.all);
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** PUT /gatherings/:gatheringId — 모임 수정 */
+export const useUpdateGathering = (
+  gatheringId: number,
+  options?: UseMutationOptions<UpdateGatheringResponse, Error, UpdateGatheringRequest, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdateGatheringRequest) => updateGathering(gatheringId, body),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.detail(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.all });
+      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
+      invalidateServerCache(GATHERING_TAGS.all);
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** DELETE /gatherings/:gatheringId — 모임 삭제 */
+export const useDeleteGathering = (gatheringId: number, options?: UseMutationOptions<void, Error, void, unknown>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deleteGathering(gatheringId),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.all });
+      invalidateServerCache(GATHERING_TAGS.all);
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};

--- a/src/lib/invalidateServerCache.ts
+++ b/src/lib/invalidateServerCache.ts
@@ -1,5 +1,7 @@
+'use server';
+
 import { updateTag } from 'next/cache';
 
-export function invalidateServerCache(tag: string) {
+export const invalidateServerCache = async (tag: string) => {
   updateTag(tag);
-}
+};

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -251,7 +251,8 @@ export const gatheringsHandlers = [
     if (!detail) {
       // mockDetails에 상세 데이터가 없으면 mockGatherings 기반으로 최소 상세를 즉석 생성
       const base = mockGatherings.find((g) => g.id === gatheringId);
-      if (!base) return HttpResponse.json({ success: false, message: '모임을 찾을 수 없습니다.' }, { status: 404 });
+      if (!base)
+        return HttpResponse.json({ success: false, data: null, message: '모임을 찾을 수 없습니다.' }, { status: 404 });
 
       const generated: GatheringDetail = {
         ...base,
@@ -281,20 +282,21 @@ export const gatheringsHandlers = [
     await delay(300);
 
     const parsed = createBodySchema.safeParse(await request.json());
-    if (!parsed.success) return HttpResponse.json({ success: false, message: '잘못된 요청입니다.' }, { status: 400 });
+    if (!parsed.success)
+      return HttpResponse.json({ success: false, data: null, message: '잘못된 요청입니다.' }, { status: 400 });
     const body = parsed.data;
     const newGathering: GatheringListItem = {
       id: Date.now(),
-      type: body.type ?? '스터디',
-      category: body.category ?? '기타',
-      title: body.title ?? '새 모임',
-      shortDescription: body.shortDescription ?? '',
-      tags: body.tags ?? [],
-      maxMembers: body.maxMembers ?? 10,
+      type: body.type,
+      category: body.category,
+      title: body.title,
+      shortDescription: body.shortDescription,
+      tags: body.tags,
+      maxMembers: body.maxMembers,
       currentMembers: 1,
-      recruitDeadline: body.recruitDeadline ?? new Date().toISOString(),
-      startDate: body.startDate ?? new Date().toISOString(),
-      endDate: body.endDate ?? new Date().toISOString(),
+      recruitDeadline: body.recruitDeadline,
+      startDate: body.startDate,
+      endDate: body.endDate,
       status: 'RECRUITING',
       isLiked: false,
       leader: { id: 1, nickname: '김코딩', profileImage: null },
@@ -302,9 +304,9 @@ export const gatheringsHandlers = [
 
     const detail: GatheringDetail = {
       ...newGathering,
-      description: body.description ?? '',
-      goal: body.goal ?? '',
-      totalWeeks: body.weeklyGuides?.length ?? 4,
+      description: body.description,
+      goal: body.goal,
+      totalWeeks: body.weeklyGuides.length,
       images: [],
       weeklyPlans: [],
       members: [{ userId: 1, nickname: '김코딩', profileImage: null, role: 'LEADER' }],
@@ -324,11 +326,13 @@ export const gatheringsHandlers = [
 
     const gatheringId = Number(params.gatheringId);
     const parsed = updateBodySchema.safeParse(await request.json());
-    if (!parsed.success) return HttpResponse.json({ success: false, message: '잘못된 요청입니다.' }, { status: 400 });
+    if (!parsed.success)
+      return HttpResponse.json({ success: false, data: null, message: '잘못된 요청입니다.' }, { status: 400 });
     const body = parsed.data;
 
     const idx = mockGatherings.findIndex((g) => g.id === gatheringId);
-    if (idx === -1) return HttpResponse.json({ success: false, message: '모임을 찾을 수 없습니다.' }, { status: 404 });
+    if (idx === -1)
+      return HttpResponse.json({ success: false, data: null, message: '모임을 찾을 수 없습니다.' }, { status: 404 });
 
     // 목록 아이템 업데이트
     mockGatherings[idx] = { ...mockGatherings[idx], ...body } as GatheringListItem;

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -1,0 +1,365 @@
+import { http, HttpResponse, delay } from 'msw';
+
+import { gatheringFormSchema, gatheringUpdateFormSchema } from '@/api/gatherings/schemas';
+import { createApiResponse } from '../utils';
+
+import type {
+  GatheringListItem,
+  GatheringDetail,
+  GetGatheringsResponse,
+  GetMainGatheringsResponse,
+  CreateGatheringResponse,
+  UpdateGatheringResponse,
+} from '@/api/gatherings/types';
+
+// gatheringFormSchema의 images 필드는 z.instanceof(File)로 브라우저 File 객체를 검사하지만,
+// MSW 핸들러에서 request.json()으로 받은 바디는 순수 JSON이라 File 객체가 존재하지 않음
+// → images 필드를 omit한 파생 스키마로 JSON 바디를 안전하게 파싱
+// 이미지 업로드 구현 시 multipart/form-data 파싱으로 교체 필요
+const createBodySchema = gatheringFormSchema.omit({ images: true });
+const updateBodySchema = gatheringUpdateFormSchema.omit({ images: true });
+
+// ─── 목 데이터 ────────────────────────────────────────────────────────────────
+
+let mockGatherings: GatheringListItem[] = [
+  {
+    id: 1,
+    type: '스터디',
+    category: '프론트엔드',
+    title: 'React 19 & Next.js 15 스터디',
+    shortDescription: 'React 19의 새 기능과 Next.js App Router를 함께 파헤쳐요.',
+    tags: ['React', 'Next.js', 'TypeScript'],
+    maxMembers: 6,
+    currentMembers: 4,
+    recruitDeadline: '2026-04-10',
+    startDate: '2026-04-15',
+    endDate: '2026-06-30',
+    status: 'RECRUITING',
+    isLiked: false,
+    leader: { id: 1, nickname: '김코딩', profileImage: null },
+  },
+  {
+    id: 2,
+    type: '스터디',
+    category: '백엔드',
+    title: 'Spring Boot 심화 스터디',
+    shortDescription: 'JPA, Redis, Kafka를 활용한 실전 백엔드 구축.',
+    tags: ['Java', 'Spring', 'JPA'],
+    maxMembers: 8,
+    currentMembers: 8,
+    recruitDeadline: '2026-03-30',
+    startDate: '2026-04-05',
+    endDate: '2026-07-05',
+    status: 'IN_PROGRESS',
+    isLiked: true,
+    leader: { id: 2, nickname: '이개발', profileImage: null },
+  },
+  {
+    id: 3,
+    type: '프로젝트',
+    category: '풀스택',
+    title: 'SaaS 사이드 프로젝트 팀 모집',
+    shortDescription: '구독형 SaaS 서비스를 함께 기획·개발해요.',
+    tags: ['SaaS', 'React', 'Node.js'],
+    maxMembers: 5,
+    currentMembers: 2,
+    recruitDeadline: '2026-04-20',
+    startDate: '2026-05-01',
+    endDate: '2026-09-30',
+    status: 'RECRUITING',
+    isLiked: false,
+    leader: { id: 3, nickname: '박프로', profileImage: null },
+  },
+  {
+    id: 4,
+    type: '스터디',
+    category: 'CS',
+    title: '알고리즘 & 자료구조 스터디',
+    shortDescription: '코테 대비 알고리즘 풀이 및 CS 기초 다지기.',
+    tags: ['알고리즘', '자료구조', 'Python'],
+    maxMembers: 10,
+    currentMembers: 7,
+    recruitDeadline: '2026-04-05',
+    startDate: '2026-04-12',
+    endDate: '2026-08-10',
+    status: 'RECRUITING',
+    isLiked: true,
+    leader: { id: 1, nickname: '김코딩', profileImage: null },
+  },
+  {
+    id: 5,
+    type: '프로젝트',
+    category: '모바일',
+    title: 'React Native 앱 개발 프로젝트',
+    shortDescription: '크로스 플랫폼 모바일 앱을 처음부터 배포까지.',
+    tags: ['React Native', 'Expo', 'TypeScript'],
+    maxMembers: 4,
+    currentMembers: 4,
+    recruitDeadline: '2026-03-25',
+    startDate: '2026-04-01',
+    endDate: '2026-07-31',
+    status: 'COMPLETED',
+    isLiked: false,
+    leader: { id: 4, nickname: '최모바일', profileImage: null },
+  },
+  {
+    id: 6,
+    type: '스터디',
+    category: 'AI/ML',
+    title: 'LLM 파인튜닝 실전 스터디',
+    shortDescription: 'HuggingFace와 LoRA를 활용한 LLM 파인튜닝 실습.',
+    tags: ['Python', 'LLM', 'HuggingFace'],
+    maxMembers: 6,
+    currentMembers: 1,
+    recruitDeadline: '2026-04-25',
+    startDate: '2026-05-05',
+    endDate: '2026-08-31',
+    status: 'RECRUITING',
+    isLiked: false,
+    leader: { id: 5, nickname: '정AI', profileImage: null },
+  },
+];
+
+const mockDetails: Record<number, GatheringDetail> = {
+  1: {
+    ...mockGatherings[0],
+    description:
+      'React 19의 새로운 훅과 Server Components, 그리고 Next.js 15 App Router의 심화 기능을 학습합니다. 매주 정해진 분량을 공부하고 발표하는 방식으로 진행합니다.',
+    goal: '8주 후 React 19 + Next.js 15 기반의 풀스택 프로젝트 완성',
+    totalWeeks: 8,
+    images: [{ url: 'https://placehold.co/800x400?text=React+Study', displayOrder: 0 }],
+    weeklyPlans: [
+      {
+        week: 1,
+        title: 'React 19 개요 & useTransition',
+        startDate: '2026-04-15',
+        endDate: '2026-04-21',
+      },
+      {
+        week: 2,
+        title: 'Server Components & Actions',
+        startDate: '2026-04-22',
+        endDate: '2026-04-28',
+      },
+      { week: 3, title: 'Next.js App Router 심화', startDate: '2026-04-29', endDate: '2026-05-05' },
+    ],
+    members: [
+      { userId: 1, nickname: '김코딩', profileImage: null, role: 'LEADER' },
+      { userId: 2, nickname: '이개발', profileImage: null, role: 'MEMBER' },
+      { userId: 3, nickname: '박프로', profileImage: null, role: 'MEMBER' },
+      { userId: 4, nickname: '최모바일', profileImage: null, role: 'MEMBER' },
+    ],
+    myApplicationStatus: null,
+  },
+};
+
+// ─── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+/**
+ * URL 쿼리스트링을 읽어 목록을 필터링 + 정렬한다.
+ * - 필터: type, category, status (ALL이면 스킵), query (제목·짧은설명 부분 검색)
+ * - 정렬: popular(참여자 많은 순) | deadline(마감 임박 순) | 기본값(id 내림차순 = 최신순)
+ * - 얕은 복사본에서 작업하므로 mockGatherings 원본은 변경되지 않는다.
+ */
+const applyFilters = (list: GatheringListItem[], url: URL): GatheringListItem[] => {
+  const type = url.searchParams.get('type') as GatheringListItem['type'] | null;
+  const category = url.searchParams.get('category');
+  const sort = url.searchParams.get('sort') as 'latest' | 'popular' | 'deadline' | null;
+  const status = url.searchParams.get('status') as GatheringListItem['status'] | 'ALL' | null;
+  const query = url.searchParams.get('query');
+
+  let result = [...list]; // 얕은 복사 → filter/sort가 mockGatherings 원본을 변경하지 않음
+
+  if (type) result = result.filter((g) => g.type === type);
+  if (category) result = result.filter((g) => g.category === category);
+  if (status && status !== 'ALL') result = result.filter((g) => g.status === status);
+  if (query) {
+    const q = query.toLowerCase();
+    result = result.filter((g) => g.title.toLowerCase().includes(q) || g.shortDescription.toLowerCase().includes(q));
+  }
+
+  if (sort === 'popular') result.sort((a, b) => b.currentMembers - a.currentMembers);
+  else if (sort === 'deadline')
+    result.sort((a, b) => new Date(a.recruitDeadline).getTime() - new Date(b.recruitDeadline).getTime());
+  else result.sort((a, b) => b.id - a.id); // latest
+
+  return result;
+};
+
+/**
+ * 필터링된 목록을 페이지 단위로 잘라 GetGatheringsResponse 형태로 반환한다.
+ * - page: 기본 1, 최소 1
+ * - limit: 기본 10, 최소 1 ~ 최대 50
+ * - slice 공식: (page-1)*limit ~ page*limit
+ */
+const paginate = (list: GatheringListItem[], url: URL) => {
+  const page = Math.max(1, Number(url.searchParams.get('page') ?? 1));
+  const limit = Math.min(50, Math.max(1, Number(url.searchParams.get('limit') ?? 10)));
+  const total = list.length;
+  const sliced = list.slice((page - 1) * limit, page * limit);
+
+  return {
+    gatherings: sliced,
+    totalCount: total,
+    totalPages: Math.ceil(total / limit),
+    currentPage: page,
+  };
+};
+
+// ─── 핸들러 ───────────────────────────────────────────────────────────────────
+
+const BASE = '/api/v1/gatherings';
+
+export const gatheringsHandlers = [
+  /** GET /api/v1/gatherings/main — 메인 페이지 모임 목록 */
+  http.get(`${BASE}/main`, async ({ request }) => {
+    await delay(300);
+
+    const url = new URL(request.url);
+    const limit = Math.max(1, Number(url.searchParams.get('limit') ?? 4));
+
+    const popular = [...mockGatherings].sort((a, b) => b.currentMembers - a.currentMembers).slice(0, limit);
+
+    const deadline = [...mockGatherings]
+      .filter((g) => g.status === 'RECRUITING')
+      .sort((a, b) => new Date(a.recruitDeadline).getTime() - new Date(b.recruitDeadline).getTime())
+      .slice(0, limit);
+
+    const latest = [...mockGatherings].sort((a, b) => b.id - a.id).slice(0, limit);
+
+    return HttpResponse.json(createApiResponse<GetMainGatheringsResponse>({ popular, deadline, latest }));
+  }),
+
+  /** GET /api/v1/gatherings — 모임 목록 검색 + 필터링 + 페이지네이션 */
+  http.get(BASE, async ({ request }) => {
+    await delay(300);
+
+    const url = new URL(request.url);
+    const filtered = applyFilters(mockGatherings, url);
+    const result = paginate(filtered, url);
+
+    return HttpResponse.json(createApiResponse<GetGatheringsResponse>(result));
+  }),
+
+  /** GET /api/v1/gatherings/:gatheringId — 모임 상세 */
+  http.get(`${BASE}/:gatheringId`, async ({ params }) => {
+    await delay(300);
+
+    const gatheringId = Number(params.gatheringId);
+    const detail = mockDetails[gatheringId];
+
+    if (!detail) {
+      // mockDetails에 상세 데이터가 없으면 mockGatherings 기반으로 최소 상세를 즉석 생성
+      const base = mockGatherings.find((g) => g.id === gatheringId);
+      if (!base) return HttpResponse.json({ success: false, message: '모임을 찾을 수 없습니다.' }, { status: 404 });
+
+      const generated: GatheringDetail = {
+        ...base,
+        description: `${base.title} 모임입니다.`,
+        goal: '목표를 함께 달성해요.',
+        totalWeeks: 8,
+        images: [],
+        weeklyPlans: [],
+        members: [
+          {
+            userId: base.leader.id,
+            nickname: base.leader.nickname,
+            profileImage: base.leader.profileImage,
+            role: 'LEADER',
+          },
+        ],
+        myApplicationStatus: null,
+      };
+      return HttpResponse.json(createApiResponse(generated));
+    }
+
+    return HttpResponse.json(createApiResponse(detail));
+  }),
+
+  /** POST /api/v1/gatherings — 모임 생성 */
+  http.post(BASE, async ({ request }) => {
+    await delay(300);
+
+    const parsed = createBodySchema.safeParse(await request.json());
+    if (!parsed.success) return HttpResponse.json({ success: false, message: '잘못된 요청입니다.' }, { status: 400 });
+    const body = parsed.data;
+    const newGathering: GatheringListItem = {
+      id: Date.now(),
+      type: body.type ?? '스터디',
+      category: body.category ?? '기타',
+      title: body.title ?? '새 모임',
+      shortDescription: body.shortDescription ?? '',
+      tags: body.tags ?? [],
+      maxMembers: body.maxMembers ?? 10,
+      currentMembers: 1,
+      recruitDeadline: body.recruitDeadline ?? new Date().toISOString(),
+      startDate: body.startDate ?? new Date().toISOString(),
+      endDate: body.endDate ?? new Date().toISOString(),
+      status: 'RECRUITING',
+      isLiked: false,
+      leader: { id: 1, nickname: '김코딩', profileImage: null },
+    };
+
+    const detail: GatheringDetail = {
+      ...newGathering,
+      description: body.description ?? '',
+      goal: body.goal ?? '',
+      totalWeeks: body.weeklyGuides?.length ?? 4,
+      images: [],
+      weeklyPlans: [],
+      members: [{ userId: 1, nickname: '김코딩', profileImage: null, role: 'LEADER' }],
+      myApplicationStatus: null,
+    };
+
+    // 목록 맨 앞에 추가 → 이후 latest 정렬 시 상단 노출
+    mockGatherings.unshift(newGathering);
+    mockDetails[newGathering.id] = detail;
+
+    return HttpResponse.json(createApiResponse<CreateGatheringResponse>({ gathering: detail }), { status: 201 });
+  }),
+
+  /** PUT /api/v1/gatherings/:gatheringId — 모임 수정 */
+  http.put(`${BASE}/:gatheringId`, async ({ request, params }) => {
+    await delay(300);
+
+    const gatheringId = Number(params.gatheringId);
+    const parsed = updateBodySchema.safeParse(await request.json());
+    if (!parsed.success) return HttpResponse.json({ success: false, message: '잘못된 요청입니다.' }, { status: 400 });
+    const body = parsed.data;
+
+    const idx = mockGatherings.findIndex((g) => g.id === gatheringId);
+    if (idx === -1) return HttpResponse.json({ success: false, message: '모임을 찾을 수 없습니다.' }, { status: 404 });
+
+    // 목록 아이템 업데이트
+    mockGatherings[idx] = { ...mockGatherings[idx], ...body } as GatheringListItem;
+
+    // mockDetails에 id 1번만 상세 데이터가 있고 2~6번은 없음
+    // 상세가 없는 id를 수정할 경우 mockGatherings 목록 아이템을 기반으로 빈 상세를 즉석 생성(초기화)한 뒤,
+    // 수정 요청 바디를 덮어씌워(병합) 최종 상세 데이터를 만든다
+    const existingDetail = mockDetails[gatheringId] ?? {
+      ...mockGatherings[idx],
+      description: '',
+      goal: '',
+      totalWeeks: 4,
+      images: [],
+      weeklyPlans: [],
+      members: [],
+      myApplicationStatus: null,
+    };
+    const updatedDetail: GatheringDetail = { ...existingDetail, ...mockGatherings[idx], ...body } as GatheringDetail;
+    mockDetails[gatheringId] = updatedDetail;
+
+    return HttpResponse.json(createApiResponse<UpdateGatheringResponse>({ gathering: updatedDetail }));
+  }),
+
+  /** DELETE /api/v1/gatherings/:gatheringId — 모임 삭제 */
+  http.delete(`${BASE}/:gatheringId`, async ({ params }) => {
+    await delay(300);
+
+    const gatheringId = Number(params.gatheringId);
+    mockGatherings = mockGatherings.filter((g) => g.id !== gatheringId);
+    delete mockDetails[gatheringId];
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -5,9 +5,9 @@ import { usersHandlers } from './users';
 import { membershipsHandlers } from './memberships';
 
 export const handlers = [
-  ...gatheringsHandlers,
   ...todosHandlers,
   ...authHandlers,
   ...usersHandlers,
   ...membershipsHandlers,
+  ...gatheringsHandlers,
 ];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
+import { gatheringsHandlers } from './gatherings';
 import { todosHandlers } from './todos';
 
-export const handlers = [...todosHandlers];
+export const handlers = [...gatheringsHandlers, ...todosHandlers];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,13 @@
 import { gatheringsHandlers } from './gatherings';
 import { todosHandlers } from './todos';
+import { authHandlers } from './auth';
+import { usersHandlers } from './users';
+import { membershipsHandlers } from './memberships';
 
-export const handlers = [...gatheringsHandlers, ...todosHandlers];
+export const handlers = [
+  ...gatheringsHandlers,
+  ...todosHandlers,
+  ...authHandlers,
+  ...usersHandlers,
+  ...membershipsHandlers,
+];


### PR DESCRIPTION
## ❓ 이슈

- close #75 

## ✍️ Description
Gatherings 도메인 API 함수, 쿼리 훅, MSW 핸들러를 작성합니다.

**API 함수 (`src/api/gatherings/index.ts`)**
- `fetchMainGatherings` / `fetchGatheringDetail` — 서버 캐시 연동을 위한 `fetch` + `next: { tags }` 사용
- `getGatherings` / `createGathering` / `updateGathering` / `deleteGathering` — 클라이언트 axios 사용
- 서버 fetch에 `res.ok` 가드 추가

**쿼리 훅 (`src/api/gatherings/queries.ts`)**
- `gatheringKeys` 팩토리 패턴 (`all → main/list/detail`)
- `gatheringQueries` — prefetch + useQuery 공용 queryOptions
- `useCreateGathering` / `useUpdateGathering` / `useDeleteGathering` — mutation 성공 시 `invalidateQueries` + `invalidateServerCache` 이중 무효화

**MSW 핸들러 (`src/mocks/handlers/gatherings.ts`)**
- GET `/gatherings/main` — popular / deadline / latest 섹션별 목 데이터
- GET `/gatherings` — type, category, status, query 필터링 + 페이지네이션
- GET/POST/PUT/DELETE `/gatherings/:id` — CRUD 전체
- 에러 응답 `ApiResponse` 형식 통일 (`data: null` 포함)


## 📸 스크린샷 (UI 변경 시)
<img width="604" height="350" alt="화면 캡처 2026-03-24 181255" src="https://github.com/user-attachments/assets/2ba53ca5-1867-4607-a0da-ed148a490b1b" />

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


