### PR TITLE
[SM-61] feat: Applications 도메인 API 함수 및 쿼리 훅, MSW 모킹 구현

### DIFF
--- a/src/api/applications/index.ts
+++ b/src/api/applications/index.ts
@@ -1,0 +1,57 @@
+import { axiosClient } from '@/lib/axiosClient';
+
+import { unwrapResponse } from '../common/utils';
+import { ApiResponse } from '../common/types';
+
+import {
+  ApplicationListResponse,
+  ApplyGatheringForm,
+  CreateApplicationResponse,
+  MyApplicationListResponse,
+  UpdateApplicationStatusRequest,
+  UpdateApplicationStatusResponse,
+} from './types';
+
+/** POST v1/gatherings/:gatheringId/applications — 모임 참여 신청(신청자) */
+export const createApplication = async (
+  gatheringId: number,
+  body: ApplyGatheringForm,
+): Promise<CreateApplicationResponse> => {
+  const { data } = await axiosClient.post<ApiResponse<CreateApplicationResponse>>(
+    `/gatherings/${gatheringId}/applications`,
+    body,
+  );
+  return unwrapResponse(data);
+};
+
+/** GET v1/gatherings/:gatheringId/applications — 신청 목록 조회(모임장) */
+export const getApplicationList = async (gatheringId: number): Promise<ApplicationListResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<ApplicationListResponse>>(
+    `/gatherings/${gatheringId}/applications`,
+  );
+  return unwrapResponse(data);
+};
+
+/** PATCH v1/gatherings/:gatheringId/applications/:applicationId — 신청 수락 / 거절(모임장) */
+export const updateApplicationStatus = async (
+  gatheringId: number,
+  applicationId: number,
+  body: UpdateApplicationStatusRequest,
+): Promise<UpdateApplicationStatusResponse> => {
+  const { data } = await axiosClient.patch<ApiResponse<UpdateApplicationStatusResponse>>(
+    `/gatherings/${gatheringId}/applications/${applicationId}`,
+    body,
+  );
+  return unwrapResponse(data);
+};
+
+/** DELETE v1/gatherings/:gatheringId/applications/:applicationId — 신청 취소(신청자 본인) */
+export const deleteApplication = async (gatheringId: number, applicationId: number): Promise<void> => {
+  await axiosClient.delete(`/gatherings/${gatheringId}/applications/${applicationId}`);
+};
+
+/** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
+export const getMyApplicationList = async (): Promise<MyApplicationListResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<MyApplicationListResponse>>(`/users/me/applications`);
+  return unwrapResponse(data);
+};

--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -1,0 +1,90 @@
+import { queryOptions, useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import {
+  createApplication,
+  deleteApplication,
+  getApplicationList,
+  getMyApplicationList,
+  updateApplicationStatus,
+} from '.';
+import {
+  ApplyGatheringForm,
+  CreateApplicationResponse,
+  UpdateApplicationStatusRequest,
+  UpdateApplicationStatusResponse,
+} from './types';
+
+export const applicationKeys = {
+  all: ['applications'] as const,
+  list: (gatheringId: number) => [...applicationKeys.all, 'list', gatheringId] as const,
+  myList: () => [...applicationKeys.all, 'myList'] as const,
+};
+
+export const applicationQueries = {
+  /** GET /v1/gatherings/:gatheringId/applications - 신청 목록 조회(모임장)*/
+  list: (gatheringId: number) =>
+    queryOptions({
+      queryKey: applicationKeys.list(gatheringId),
+      queryFn: () => getApplicationList(gatheringId),
+    }),
+
+  /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
+  myList: () =>
+    queryOptions({
+      queryKey: applicationKeys.myList(),
+      queryFn: () => getMyApplicationList(),
+    }),
+};
+
+/** POST v1/gatherings/:gatheringId/applications — 모임 참여 신청(신청자) */
+export const useCreateApplication = (
+  gatheringId: number,
+  options?: UseMutationOptions<CreateApplicationResponse, Error, ApplyGatheringForm, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: ApplyGatheringForm) => createApplication(gatheringId, body),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: applicationKeys.list(gatheringId) });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** PATCH v1/gatherings/:gatheringId/applications/:applicationId — 신청 수락 / 거절(모임장) */
+export const useUpdateApplicationStatus = (
+  gatheringId: number,
+  applicationId: number,
+  options?: UseMutationOptions<UpdateApplicationStatusResponse, Error, UpdateApplicationStatusRequest, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdateApplicationStatusRequest) => updateApplicationStatus(gatheringId, applicationId, body),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: applicationKeys.list(gatheringId) });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** DELETE v1/gatherings/:gatheringId/applications/:applicationId — 신청 취소(신청자 본인) */
+export const useDeleteApplication = (
+  gatheringId: number,
+  applicationId: number,
+  options?: UseMutationOptions<void, Error, void, unknown>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deleteApplication(gatheringId, applicationId),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: applicationKeys.list(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: applicationKeys.myList() });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};

--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -46,7 +46,7 @@ export const useCreateApplication = (
     mutationFn: (body: ApplyGatheringForm) => createApplication(gatheringId, body),
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
-      queryClient.invalidateQueries({ queryKey: applicationKeys.list(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: applicationKeys.all });
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });
@@ -64,7 +64,7 @@ export const useUpdateApplicationStatus = (
     mutationFn: (body: UpdateApplicationStatusRequest) => updateApplicationStatus(gatheringId, applicationId, body),
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
-      queryClient.invalidateQueries({ queryKey: applicationKeys.list(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: applicationKeys.all });
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });
@@ -82,8 +82,7 @@ export const useDeleteApplication = (
     mutationFn: () => deleteApplication(gatheringId, applicationId),
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
-      queryClient.invalidateQueries({ queryKey: applicationKeys.list(gatheringId) });
-      queryClient.invalidateQueries({ queryKey: applicationKeys.myList() });
+      queryClient.invalidateQueries({ queryKey: applicationKeys.all });
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/mocks/handlers/applications.ts
+++ b/src/mocks/handlers/applications.ts
@@ -1,0 +1,113 @@
+import { http, HttpResponse, delay } from 'msw';
+
+import { createApiResponse } from '../utils';
+
+import type {
+  ApplicationListResponse,
+  CreateApplicationResponse,
+  UpdateApplicationStatusRequest,
+  UpdateApplicationStatusResponse,
+} from '@/api/applications/types';
+
+const MOCK_DELAY = 300;
+
+const mockApplicationListResponse: ApplicationListResponse = {
+  applications: [
+    {
+      id: 1,
+      applicant: {
+        id: 1,
+        nickname: '김선장',
+        profileImage: 'https://example.com/profile.jpg',
+        reputationScore: 36.5,
+        reviews: [
+          {
+            id: 1,
+            reviewer: { id: 2, nickname: '항해사' },
+            gatheringTitle: '리액트 스터디 1기',
+            tags: ['성실해요', '소통이 좋아요'],
+            comment: '항상 열심히 참여해주셨어요!',
+            createdAt: '2023-11-01T00:00:00Z',
+          },
+          {
+            id: 2,
+            reviewer: { id: 3, nickname: '조타수' },
+            gatheringTitle: '자바스크립트 딥다이브',
+            tags: ['시간을 잘 지켜요'],
+            comment: '시간 약속을 잘 지켜요',
+            createdAt: '2023-12-15T00:00:00Z',
+          },
+        ],
+      },
+      personalGoal: 'React 기초 완벽 이해',
+      selfIntroduction: '안녕하세요! React 기초를 배우고 싶어서 신청했습니다. 잘 부탁드립니다.',
+      status: 'PENDING', // 'PENDING' | 'ACCEPTED' | 'REJECTED'
+      createdAt: '2026-03-24T18:24:00Z',
+    },
+  ],
+};
+
+export const applicationsHandlers = [
+  /** POST v1/gatherings/:gatheringId/applications — 모임 참여 신청(신청자) */
+  http.post(`/api/v1/gatherings/:gatheringId/applications`, async ({ request }) => {
+    await delay(MOCK_DELAY);
+    const responseData: CreateApplicationResponse = {
+      application: {
+        id: Date.now(),
+        status: 'PENDING',
+        createdAt: new Date().toISOString(),
+      },
+    };
+    return HttpResponse.json(createApiResponse(responseData), { status: 201 });
+  }),
+
+  /** GET v1/gatherings/:gatheringId/applications — 신청 목록 조회(모임장) */
+  http.get(`/api/v1/gatherings/:gatheringId/applications`, async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse(mockApplicationListResponse));
+  }),
+
+  /** PATCH v1/gatherings/:gatheringId/applications/:applicationId — 신청 수락 / 거절(모임장) */
+  http.patch(`/api/v1/gatherings/:gatheringId/applications/:applicationId`, async ({ request, params }) => {
+    await delay(MOCK_DELAY);
+    const body = (await request.json()) as UpdateApplicationStatusRequest;
+    const applicationId = Number(params.applicationId);
+
+    const targetApplication = mockApplicationListResponse.applications.find((app) => app.id === applicationId);
+
+    if (targetApplication) {
+      targetApplication.status = body.status;
+    }
+
+    const responseData: UpdateApplicationStatusResponse = {
+      application: {
+        id: applicationId,
+        status: body.status,
+      },
+    };
+
+    return HttpResponse.json(createApiResponse(responseData));
+  }),
+
+  /** DELETE v1/gatherings/:gatheringId/applications/:applicationId — 신청 취소(신청자 본인) */
+  http.delete(`/api/v1/gatherings/:gatheringId/applications/:applicationId`, async ({ params }) => {
+    await delay(MOCK_DELAY);
+    const applicationId = Number(params.applicationId);
+
+    const targetApplication = mockApplicationListResponse.applications.find((app) => app.id === applicationId);
+
+    if (targetApplication) {
+      mockApplicationListResponse.applications = mockApplicationListResponse.applications.filter(
+        (app) => app.id !== applicationId,
+      );
+    }
+
+    return HttpResponse.json(createApiResponse(mockApplicationListResponse));
+  }),
+
+  /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
+  http.get(`/api/v1/users/me/applications`, async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse(mockApplicationListResponse));
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -2,5 +2,6 @@ import { todosHandlers } from './todos';
 import { authHandlers } from './auth';
 import { usersHandlers } from './users';
 import { membershipsHandlers } from './memberships';
+import { applicationsHandlers } from './applications';
 
-export const handlers = [...todosHandlers, ...authHandlers, ...usersHandlers, ...membershipsHandlers];
+export const handlers = [...todosHandlers, ...authHandlers, ...usersHandlers, ...membershipsHandlers, ...applicationsHandlers];


### PR DESCRIPTION
## ❓ 이슈

- close #76 

## ✍️ Description

Applications (모임 신청) 도메인의 API 레이어 기본 세팅, TanStack Query 훅 연동, 그리고 로컬 테스트를 위한 MSW 모킹 핸들러 구현을 진행했습니다.

## ✅ Checklist

- [x] Axios 통신 로직([index.ts]
  - 기본 세팅: 모임 참여 신청/취소, 모임장용 신청 목록 조회 및 상태 변경(수락/거절), 내 신청 목록 조회 API 엔드포인트 구현 및 기존 `types` 반환 매핑
- [x] Query / Mutation 훅(`queries.ts`) 추가:
  - 팩토리 객체 패턴 기반의 일관성 있는 쿼리 키 정의
  - GET 방식: 서버/클라이언트 및 prefetch 등에서 유연하게 사용할 수 있도록 `queryOptions` 팩토리 패턴 적용
  - POST / PATCH / DELETE 방식: 컴포넌트 훅 호출 시 외부에서 `options`(onSuccess, onError 등) 주입이 가능하도록 커스텀 Mutation 훅 작성

- [x] 개발 및 UI 작업을 위해 5개 API에 대한 모임 신청 관련 모의 응답 핸들러
- [x] 신청 수락/거절 및 취소 시 실제 서버처럼 `mockApplicationListResponse` 내부 배열의 상태(status)가 실시간으로 갱신·유지되도록 구성
- [x] 실제 네트워크 통신 상태를 자연스럽게 흉내 내기 위해 `300ms`의 인위적 딜레이 추가

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)