### PR TITLE
[SM-63] feat: reviews 도메인 API 함수 및 쿼리 훅, MSW 모킹 구현

### DIFF
--- a/src/api/reviews/index.ts
+++ b/src/api/reviews/index.ts
@@ -1,0 +1,22 @@
+import { axiosClient } from '@/lib/axiosClient';
+import { unwrapResponse } from '../common/utils';
+import { CreateReviewsForm, CreateReviewsResponse, UserReviewListResponse, UserReviewsParams } from './types';
+import { ApiResponse } from '../common/types';
+
+/** POST v1/gatherings/:gatheringId/reviews — 리뷰 작성 */
+export const createReviews = async (gatheringId: number, body: CreateReviewsForm): Promise<CreateReviewsResponse> => {
+  const { data } = await axiosClient.post<ApiResponse<CreateReviewsResponse>>(
+    `/gatherings/${gatheringId}/reviews`,
+    body,
+  );
+  return unwrapResponse(data);
+};
+
+/** GET v1/users/:userId/reviews — 리뷰 목록 조회 */
+export const getUserReviewList = async (
+  userId: number,
+  params?: UserReviewsParams,
+): Promise<UserReviewListResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<UserReviewListResponse>>(`/users/${userId}/reviews`, { params });
+  return unwrapResponse(data);
+};

--- a/src/api/reviews/queries.ts
+++ b/src/api/reviews/queries.ts
@@ -1,0 +1,37 @@
+import { queryOptions, useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import { CreateReviewsForm, CreateReviewsResponse, UserReviewsParams } from './types';
+import { createReviews, getUserReviewList } from '.';
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
+
+export const reviewKeys = {
+  all: ['reviews'] as const,
+  list: (userId: number, params?: UserReviewsParams) => [...reviewKeys.all, 'list', userId, params] as const,
+  detail: (reviewId: number) => [...reviewKeys.all, 'detail', reviewId] as const,
+};
+
+export const reviewQueries = {
+  /** GET v1/users/:userId/reviews — 리뷰 목록 조회 */
+  list: (userId: number, params?: UserReviewsParams) =>
+    queryOptions({
+      queryKey: reviewKeys.list(userId, params),
+      queryFn: () => getUserReviewList(userId, params),
+    }),
+};
+
+/** POST v1/gatherings/:gatheringId/reviews — 리뷰 작성 */
+export const useReviewMutations = (
+  options?: UseMutationOptions<CreateReviewsResponse, Error, { gatheringId: number; body: CreateReviewsForm }>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { gatheringId: number; body: CreateReviewsForm }) =>
+      createReviews(params.gatheringId, params.body),
+    ...options,
+    onSuccess: (data, variable, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: reviewKeys.all });
+      invalidateServerCache(reviewKeys.all[0]);
+      options?.onSuccess?.(data, variable, onMutateResult, context);
+    },
+  });
+};

--- a/src/api/users/queries.ts
+++ b/src/api/users/queries.ts
@@ -4,6 +4,7 @@ import { getUsersMe, getUsersUserId, updateProfile, updatePassword, deleteUser }
 
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { User, UpdateProfileForm, UpdatePasswordForm, UpdatePasswordResponseData } from './types';
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
 
 export const userKeys = {
   all: ['users'] as const,
@@ -35,6 +36,7 @@ export const useUpdateProfile = (options?: UseMutationOptions<User, Error, Updat
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: userKeys.me() });
+      invalidateServerCache(userKeys.all[0]);
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -5,6 +5,7 @@ import { usersHandlers } from './users';
 import { membershipsHandlers } from './memberships';
 import { applicationsHandlers } from './applications';
 import { achievementsHandlers } from './achievements';
+import { reviewsHandlers } from './reviews';
 
 export const handlers = [
   ...todosHandlers,
@@ -13,4 +14,6 @@ export const handlers = [
   ...membershipsHandlers,
   ...gatheringsHandlers,
   ...achievementsHandlers,
+  ...applicationsHandlers,
+  ...reviewsHandlers,
 ];

--- a/src/mocks/handlers/reviews.ts
+++ b/src/mocks/handlers/reviews.ts
@@ -1,0 +1,43 @@
+import { HttpResponse, http, delay } from 'msw';
+
+import { createApiResponse } from '../utils';
+
+import type { UserReviewListResponse } from '@/api/reviews/types';
+
+const MOCK_DELAY = 300;
+
+const mockUserReviewListResponse: UserReviewListResponse = {
+  reviews: [
+    {
+      id: 30,
+      reviewer: { id: 1, nickname: '마감왕' },
+      gatheringTitle: 'React 완전 정복 스터디',
+      tags: ['성실해요', '소통이 좋아요'],
+      comment: '항상 열심히 참여해주셨어요!',
+      createdAt: '2025-04-20T10:00:00Z',
+    },
+    {
+      id: 31,
+      reviewer: { id: 2, nickname: '항해사' },
+      gatheringTitle: 'JavaScript 딥다이브',
+      tags: ['시간을 잘 지켜요', '잘 도와줘요'],
+      comment: '시간 약속도 잘 지키고 많이 도와주셨습니다.',
+      createdAt: '2025-04-22T14:30:00Z',
+    },
+  ],
+  totalCount: 12,
+};
+
+export const reviewsHandlers = [
+  /** POST v1/gatherings/:gatheringId/reviews — 리뷰 작성 */
+  http.post('/api/v1/gatherings/:gatheringId/reviews', async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse({ success: true }), { status: 201 });
+  }),
+
+  /** GET v1/users/:userId/reviews — 리뷰 목록 조회 */
+  http.get('/api/v1/users/:userId/reviews', async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse(mockUserReviewListResponse));
+  }),
+];


### PR DESCRIPTION
## ❓ 이슈

- close #78 

## ✍️ Description
reviews 도메인의 API 레이어 기본 세팅, TanStack Query 훅 연동, 그리고 로컬 테스트를 위한 MSW 모킹 핸들러 구현을 진행했습니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist
- [x] Axios 통신 로직([index.ts]
  - 기본 세팅: 팀원 리뷰 작성, 유저가 받은 리뷰 조회 API 엔드포인트 구현 및 기존 `types` 반환 매핑
- [x] Query / Mutation 훅(`queries.ts`) 추가:
  - 팩토리 객체 패턴 기반의 일관성 있는 쿼리 키 정의
  - GET 방식: 서버/클라이언트 및 prefetch 등에서 유연하게 사용할 수 있도록 `queryOptions` 팩토리 패턴 적용
  - POST / PATCH / DELETE 방식: 컴포넌트 훅 호출 시 외부에서 `options`(onSuccess, onError 등) 주입이 가능하도록 커스텀 Mutation 훅 작성, 이때 Mutation훅에서 invalidateServerCache를 통한 서버 캐시 무효화까지 구현

- [x] 개발 및 UI 작업을 위해 2개 API에 대한 리뷰 관련 모의 응답 핸들러
- [x] 실제 네트워크 통신 상태를 자연스럽게 흉내 내기 위해 `300ms`의 인위적 딜레이 추가


### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] users 도메인에서도 특정 유저 공개 프로필 조회 부분에서 서버 캐싱을 할 것으로 판단하여 훅 내부에 invalidateServerCache를 통해 무효화를 진행
- [x] 직전 PR에서 누락된 applications handler 추가
