### PR TITLE
[SM-70] chore: Claude Code PR 리뷰 워크플로우 개선

### DIFF
--- a/.claude/rules/tanstack-query.md
+++ b/.claude/rules/tanstack-query.md
@@ -32,12 +32,19 @@ paths:
 - **유저별 데이터 (prefetch 없음)**: useSuspenseQuery 사용 → Suspense 연동 자동 로딩 처리
 - 클라이언트 queryFn에서는 axios 인스턴스 사용 가능
 
-## Mutation + 이중 캐시 무효화
+## Mutation + 캐시 무효화
 
-- mutation 성공 시 반드시 클라이언트 + 서버 캐시 둘 다 무효화
+- 무효화 전략은 해당 데이터의 **서버 캐시 존재 여부**에 따라 결정
+
+| 데이터 유형                                           | 서버 캐시 | 필요한 무효화                                   |
+| ----------------------------------------------------- | --------- | ----------------------------------------------- |
+| 공개 데이터 (prefetchQuery + next.tags로 서버 캐시됨) | O         | `invalidateQueries` + `updateTag` (이중 무효화) |
+| 유저별 데이터 (useSuspenseQuery로 클라이언트만 페칭)  | X         | `invalidateQueries`만                           |
+
 - `invalidateQueries` → 현재 유저 화면 즉시 갱신
 - `updateTag` (Server Action) → 서버 Data Cache 무효화, 다른 유저도 최신 데이터
-- invalidateQueries만 → 새로고침 시 옛날 데이터 / updateTag만 → 현재 유저는 새로고침 필요
+- 서버 캐시 데이터에 invalidateQueries만 → 새로고침 시 옛날 데이터 / updateTag만 → 현재 유저는 새로고침 필요
+- 클라이언트 전용 데이터에 updateTag → 무효화할 서버 캐시 자체가 없으므로 무의미
 
 ## Mutation 콜백 분리 패턴
 

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -27,7 +27,7 @@ allowed-tools: Read, Grep, Glob, Bash(gh *)
 ### 3. 캐싱 & 무효화 (HIGH)
 
 - 서버 fetch에 next: { tags } 지정했는지
-- mutation 시 이중 무효화 (invalidateQueries + revalidateTag) 하는지
+- 서버 캐시 데이터(prefetch + next.tags) mutation 시 이중 무효화 (invalidateQueries + updateTag) 하는지. 클라이언트 전용 데이터는 invalidateQueries만으로 충분
 - staleTime > 0 설정했는지
 - queryKey가 서버/클라이언트에서 일치하는지
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,10 +10,14 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     if: |
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
@@ -33,15 +37,32 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           track_progress: true
           claude_args: |
             --model claude-sonnet-4-5-20250929
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
           prompt: |
+            EVENT_ACTION: ${{ github.event.action }}
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
 
             이 PR을 프로젝트 규칙(CLAUDE.md, .claude/rules/)에 따라 리뷰해줘.
+
+            ## 리뷰 모드
+
+            EVENT_ACTION 값에 따라 리뷰 방식을 달리해줘:
+
+            ### opened (전체 리뷰)
+            - PR 전체 diff를 리뷰
+            - 아래 리뷰 기준에 따라 이슈를 찾아줘
+
+            ### synchronize (증분 리뷰)
+            - `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` 로 이전 리뷰 코멘트를 확인
+            - 이전에 지적한 이슈가 해결되었는지 확인
+            - 새로 변경된 코드에서만 이슈를 검토
+            - 이전 리뷰와 동일한 내용을 반복하지 않기
+            - 이전 지적 해결 여부 + 새 이슈를 종합해서 작성
 
             ## 리뷰 기준 (심각도 순)
 
@@ -49,7 +70,7 @@ jobs:
             - page.tsx에 'use client' 사용 여부
             - 서버 컴포넌트에서 React 훅(useQuery, useState 등) 사용 여부
             - 서버에서 axios 사용 여부 (fetch만 허용)
-            - mutation 시 이중 캐시 무효화 누락 (invalidateQueries + revalidateTag)
+            - 서버 캐시 데이터(prefetch + next.tags)의 mutation 시 이중 캐시 무효화 누락. 클라이언트 전용 데이터는 invalidateQueries만으로 충분
 
             ### HIGH
             - 공개 데이터에 prefetchQuery + HydrationBoundary 패턴 사용 여부
@@ -64,11 +85,9 @@ jobs:
             - any 타입 사용
             - Promise.all 누락 (순차 fetch)
 
-            ## 코멘트 방식
-            - 구체적인 코드 이슈는 인라인 코멘트(mcp__github_inline_comment__create_inline_comment, confirmed: true)로 남겨줘
-            - 수정이 필요한 코드는 GitHub Suggestion 블록으로 제안해줘:
-              ```suggestion
-              수정된 코드
-              ```
-            - 전체적인 피드백과 요약은 `gh pr comment`로 PR 탑레벨 코멘트로 남겨줘
-            - 잘 작성된 부분도 언급해줘
+            ## 출력 규칙
+            - 발견된 이슈만 심각도별로 정리 (이슈가 없는 카테고리는 생략)
+            - 해당 PR과 무관한 규칙은 체크하지 않기 (예: API 코드만 변경된 PR에서 컴포넌트 규칙 스킵)
+            - 구체적인 코드 이슈는 인라인 코멘트(mcp__github_inline_comment__create_inline_comment, confirmed: true)로 남기고, 수정이 필요한 코드는 GitHub Suggestion 블록으로 제안
+            - PR 전체 코멘트(`gh pr comment`)는 요약 + 결론만 20줄 이내로 간결하게
+            - "잘 작성된 점"은 정말 돋보이는 패턴만 1-2줄로

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,9 @@
 - 공개 데이터: 서버 prefetchQuery + HydrationBoundary + 클라이언트 useQuery
 - 유저별 데이터: 클라이언트 useSuspenseQuery + Suspense 경계
 - API 호출 있는 컴포넌트: ErrorBoundary로 에러 격리
-- Mutation 성공 시 이중 캐시 무효화: invalidateQueries + updateTag
+- Mutation 성공 시 캐시 무효화:
+  - 서버 캐시 데이터(prefetchQuery + next.tags로 캐시된 공개 데이터) 변경 시: invalidateQueries + updateTag 이중 무효화
+  - 클라이언트 전용 데이터(useSuspenseQuery만으로 페칭하는 유저별 데이터) 변경 시: invalidateQueries만으로 충분
 
 ## TanStack Query
 


### PR DESCRIPTION
## ❓ 이슈

- close #93 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
Claude Code PR 리뷰 자동화의 비효율적인 부분 3가지를 개선.

### 1. 반복 리뷰 방지
- concurrency 그룹 추가: 같은 PR에 빠른 연속 푸시 시 이전 리뷰 취소
- use_sticky_comment: true: 새 코멘트 대신 기존 코멘트 업데이트
- Draft PR 스킵 조건 추가

### 2. 증분 리뷰 프롬프트 분기
- opened → 전체 리뷰, synchronize → 증분 리뷰
- 증분 리뷰 시 gh api로 이전 코멘트 확인 후 해결 여부 + 새 이슈만 작성
- 출력 규칙 개선 (이슈 없는 항목 생략, PR 코멘트 20줄 이내)

### 3. 이중 캐시 무효화 규칙 조건부 적용
- 서버 캐시 데이터(prefetch + next.tags) → invalidateQueries + updateTag 이중 무효화
- 클라이언트 전용 데이터(useSuspenseQuery) → invalidateQueries만으로 충분
- CLAUDE.md, tanstack-query.md, local-review/SKILL.md, 워크플로우 프롬프트 일괄 수정

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
