### PR TITLE
[SM-67] style:Input/Textarea 공통 상태(State) 스타일 정의

### DIFF
--- a/src/components/ui/Input/index.stories.tsx
+++ b/src/components/ui/Input/index.stories.tsx
@@ -10,6 +10,9 @@ const meta: Meta<typeof Input> = {
       control: 'select',
       options: ['text', 'password', 'email'],
     },
+    error: {
+      control: 'text',
+    },
   },
 } satisfies Meta<typeof Input>;
 
@@ -33,11 +36,11 @@ export const Nickname: Story = {
 };
 
 // 3. 에러 발생 상태 (Error)
-export const WithError: Story = {
+export const WithEmailError: Story = {
   args: {
     label: '이메일',
     placeholder: '이메일을 입력해주세요',
-    error: '올바른 이메일 형식이 아닙니다.',
+    error: '이메일 형식이 올바르지 않습니다.',
     defaultValue: 'wrong-email@',
   },
 };
@@ -51,9 +54,29 @@ export const Password: Story = {
   },
 };
 
-// 5. 라벨 없는 상태 (No Label)
+export const WithPasswordError: Story = {
+  args: {
+    label: '비밀번호',
+    type: 'password',
+    placeholder: '영문, 숫자, 특수문자 포함 8자 이상 입력해주세요',
+    error: '영문, 숫자, 특수문자 포함 8자 이상 입력해주세요',
+    defaultValue: 'wrong-password',
+  },
+};
+
 export const NoLabel: Story = {
   args: {
     placeholder: '',
   },
+};
+
+/** default · focus · error · disabled 한 화면에서 비교 */
+export const StatesMatrix: Story = {
+  render: () => (
+    <div className='grid max-w-md grid-cols-1 gap-6'>
+      <Input label='Default' placeholder='기본 상태' />
+      <Input label='Focus' placeholder='포커스 시 링·테두리 (탭으로 포커스)' autoFocus />
+      <Input label='Error' placeholder='에러' error='필수 입력 항목입니다.' defaultValue='invalid' />
+    </div>
+  ),
 };

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,41 +1,43 @@
 'use client';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { forwardRef, useId, type InputHTMLAttributes } from 'react';
+
+import { useId, type ComponentPropsWithRef } from 'react';
+import { fieldControlVariants, fieldGradientFocusWrapperClass } from '@/components/ui/fieldControlVariants';
 import { cn } from '@/lib/cn';
 
-const inputVariants = cva('w-full border rounded px-3 py-2 outline-none', {
-  variants: {
-    hasError: {
-      true: 'border-red-500', // 에러 시 빨간 테두리만 미리 지정
-      false: 'border-gray-300', // 기본 상태
-    },
-  },
-  defaultVariants: {
-    hasError: false,
-  },
-});
-
-interface InputProps extends InputHTMLAttributes<HTMLInputElement>, VariantProps<typeof inputVariants> {
+type InputProps = ComponentPropsWithRef<'input'> & {
   label?: string;
   error?: string;
-}
+};
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { label, error, className, type, ...props },
-  ref,
-) {
-  const id = useId();
+export function Input({ label, error, className, type, id: idProp, ref, ...props }: InputProps) {
+  const uid = useId();
+  const id = idProp ?? uid;
   const hasError = !!error;
+
+  const control = (
+    <input
+      id={id}
+      type={type}
+      ref={ref}
+      aria-invalid={hasError || undefined}
+      className={cn(fieldControlVariants({ state: hasError ? 'error' : 'default' }), className)}
+      {...props}
+    />
+  );
 
   return (
     <div className='flex flex-col gap-1.5'>
       {label && (
-        <label htmlFor={id} className='text-sm font-bold'>
+        <label htmlFor={id} className='text-sm font-bold text-gray-900'>
           {label}
         </label>
       )}
-      <input id={id} type={type} ref={ref} className={cn(inputVariants({ hasError }), className)} {...props} />
-      {error && <p className='text-xs text-red-500'>{error}</p>}
+      {hasError ? control : <div className={fieldGradientFocusWrapperClass}>{control}</div>}
+      {error && (
+        <p className='text-xs text-red-200' role='alert'>
+          {error}
+        </p>
+      )}
     </div>
   );
-});
+}

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -1,15 +1,18 @@
 'use client';
 
-import { useId, type ComponentPropsWithRef } from 'react';
+import { useId, forwardRef, type ComponentPropsWithoutRef } from 'react';
 import { fieldControlVariants, fieldGradientFocusWrapperClass } from '@/components/ui/fieldControlVariants';
 import { cn } from '@/lib/cn';
 
-type InputProps = ComponentPropsWithRef<'input'> & {
+type InputProps = ComponentPropsWithoutRef<'input'> & {
   label?: string;
   error?: string;
 };
 
-export function Input({ label, error, className, type, id: idProp, ref, ...props }: InputProps) {
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { label, error, className, type, id: idProp, ...props },
+  ref,
+) {
   const uid = useId();
   const id = idProp ?? uid;
   const hasError = !!error;
@@ -40,4 +43,6 @@ export function Input({ label, error, className, type, id: idProp, ref, ...props
       )}
     </div>
   );
-}
+});
+
+Input.displayName = 'Input';

--- a/src/components/ui/Textarea/index.stories.tsx
+++ b/src/components/ui/Textarea/index.stories.tsx
@@ -5,20 +5,15 @@ const meta = {
   title: 'components/Textarea',
   component: Textarea,
   args: {
-    placeholder: 'Textarea',
+    placeholder: '내용을 입력해 주세요',
   },
   argTypes: {
     size: {
       control: 'select',
-      options: ['sm', 'md', 'lg'],
+      options: ['lg'],
     },
-    variant: {
-      control: 'select',
-      options: ['default'],
-    },
-    state: {
-      control: 'select',
-      options: ['default', 'error'],
+    error: {
+      control: 'text',
     },
   },
   parameters: {
@@ -35,12 +30,34 @@ export const Default: Story = {};
 
 export const Goal: Story = {
   args: {
-    placeholder: '이 모임에서 달성할 목표를 적어주세요.',
+    label: '나의 목표',
+    placeholder: '이 모임에서 달성할 목표를 적어주세요.(최소 5자, 최대 200자)',
   },
 };
 
 export const ShortIntro: Story = {
   args: {
-    placeholder: '모임장에게 한마디를 적어주세요.',
+    label: '한 줄 소개',
+    placeholder: '(선택) 모임장에게 한마디를 적어주세요.',
   },
+};
+
+export const WithError: Story = {
+  args: {
+    label: '나의 목표',
+    placeholder: '내용을 입력해 주세요',
+    error: '10자 이상 입력해 주세요.',
+    defaultValue: '짧음',
+  },
+};
+
+/** default · focus · error · disabled 한 화면에서 비교 */
+export const StatesMatrix: Story = {
+  render: () => (
+    <div className='grid max-w-md grid-cols-1 gap-6'>
+      <Textarea label='Default' placeholder='기본 상태' />
+      <Textarea label='Focus' placeholder='포커스 시 링·테두리 (탭으로 포커스)' autoFocus />
+      <Textarea label='Error' placeholder='에러' error='필수 입력 항목입니다.' defaultValue='invalid' />
+    </div>
+  ),
 };

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId, type ComponentPropsWithRef } from 'react';
+import { useId, forwardRef, type ComponentPropsWithoutRef } from 'react';
 import { fieldControlVariants, fieldGradientFocusWrapperClass } from '@/components/ui/fieldControlVariants';
 import { cn } from '@/lib/cn';
 
@@ -8,13 +8,16 @@ const sizeClassName = {
   lg: 'text-base min-h-[140px]',
 } as const;
 
-type TextareaProps = ComponentPropsWithRef<'textarea'> & {
+type TextareaProps = ComponentPropsWithoutRef<'textarea'> & {
   label?: string;
   error?: string;
   size?: keyof typeof sizeClassName;
 };
 
-export function Textarea({ label, error, className, id: idProp, ref, size = 'lg', rows, ...props }: TextareaProps) {
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { label, error, className, id: idProp, size = 'lg', rows, ...props },
+  ref,
+) {
   const uid = useId();
   const id = idProp ?? uid;
   const hasError = !!error;
@@ -50,4 +53,6 @@ export function Textarea({ label, error, className, id: idProp, ref, size = 'lg'
       )}
     </div>
   );
-}
+});
+
+Textarea.displayName = 'Textarea';

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,32 +1,53 @@
-import { TextareaHTMLAttributes } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
+'use client';
+
+import { useId, type ComponentPropsWithRef } from 'react';
+import { fieldControlVariants, fieldGradientFocusWrapperClass } from '@/components/ui/fieldControlVariants';
 import { cn } from '@/lib/cn';
 
-const textareaVariants = cva('w-full px-3 py-2 outline-none focus:ring-2 resize-none', {
-  variants: {
-    variant: {
-      default: 'border border-gray-300 rounded-md',
-    },
-    size: {
-      sm: 'text-sm',
-      md: 'text-base',
-      lg: 'text-base',
-    },
-    state: {
-      default: '',
-      error: 'border-red-500 focus:ring-red-500',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-    size: 'md',
-    state: 'default',
-  },
-});
+const sizeClassName = {
+  lg: 'text-base min-h-[140px]',
+} as const;
 
-interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>, VariantProps<typeof textareaVariants> {}
+type TextareaProps = ComponentPropsWithRef<'textarea'> & {
+  label?: string;
+  error?: string;
+  size?: keyof typeof sizeClassName;
+};
 
-export function Textarea({ variant, size, state, className, ...props }: TextareaProps) {
-  const textareaClasses = cn(textareaVariants({ variant, size, state }), className);
-  return <textarea className={textareaClasses} {...props} />;
+export function Textarea({ label, error, className, id: idProp, ref, size = 'lg', rows, ...props }: TextareaProps) {
+  const uid = useId();
+  const id = idProp ?? uid;
+  const hasError = !!error;
+
+  const control = (
+    <textarea
+      id={id}
+      ref={ref}
+      rows={rows ?? 4}
+      aria-invalid={hasError || undefined}
+      className={cn(
+        fieldControlVariants({ state: hasError ? 'error' : 'default' }),
+        sizeClassName[size],
+        'resize-y',
+        className,
+      )}
+      {...props}
+    />
+  );
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      {label && (
+        <label htmlFor={id} className='text-sm font-bold text-gray-900'>
+          {label}
+        </label>
+      )}
+      {hasError ? control : <div className={fieldGradientFocusWrapperClass}>{control}</div>}
+      {error && (
+        <p className='text-xs text-red-200' role='alert'>
+          {error}
+        </p>
+      )}
+    </div>
+  );
 }

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -31,7 +31,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
       className={cn(
         fieldControlVariants({ state: hasError ? 'error' : 'default' }),
         sizeClassName[size],
-        'resize-y',
+        'resize-none',
         className,
       )}
       {...props}

--- a/src/components/ui/fieldControlVariants.ts
+++ b/src/components/ui/fieldControlVariants.ts
@@ -1,13 +1,24 @@
 import { cva } from 'class-variance-authority';
 
-/** default 상태: 포커스 시 그라데이션 테두리 */
-export const fieldGradientFocusWrapperClass =
-  'w-full rounded-md p-[2px] bg-transparent transition-[background-color] duration-150 focus-within:bg-gradient-primary';
+/**
+ * default 상태: 포커스 시에만 border-gradient-primary(1px) 노출
+ * - border-gradient-primary는 ::before로 1px 그라데이션 보더를 그림(globals.css)
+ * - input/textarea는 ::before가 불안정하므로 래퍼에 적용
+ */
+export const fieldGradientFocusWrapperClass = [
+  // 항상 동일한 외곽 크기/여백 유지 (포커스 시 내부 영역이 줄어든 것처럼 보이지 않게)
+  'w-full rounded-md p-px',
+  // default는 회색 보더, focus일 때만 그라데이션 보더로 전환
+  'border border-gray-200 focus-within:border-transparent',
+  // 그라데이션 보더(1px)는 ::before로 표현, focus일 때만 노출
+  'border-gradient-primary before:opacity-0 focus-within:before:opacity-100',
+  'before:transition-opacity before:duration-150',
+].join(' ');
 
 /** Input / Textarea 내부 필드 — default · error · disabled */
 export const fieldControlVariants = cva(
   [
-    'w-full border px-3 py-2 text-sm leading-[1.6] text-gray-900',
+    'w-full px-3 py-2 text-sm leading-[1.6] text-gray-900',
     'placeholder:text-gray-400',
     'transition-[color,border-color] duration-150',
     'outline-none focus-visible:outline-none',
@@ -16,11 +27,12 @@ export const fieldControlVariants = cva(
     variants: {
       state: {
         default: [
-          'rounded-[calc(0.375rem-2px)] border-gray-200 bg-gray-50',
-          'focus:border-transparent focus:text-gray-900',
+          // wrapper가 rounded-md를 가지고 있어 내부는 한 단계 작게
+          'rounded-[calc(0.375rem-1px)] bg-gray-50',
+          'focus:text-gray-900',
         ].join(' '),
         error: [
-          'rounded-md border-red-200 bg-gray-0',
+          'rounded-md border border-red-200 bg-gray-0',
           'focus:border-red-200 focus:ring-2 focus:ring-red-100 focus:ring-offset-0',
         ].join(' '),
       },

--- a/src/components/ui/fieldControlVariants.ts
+++ b/src/components/ui/fieldControlVariants.ts
@@ -1,0 +1,32 @@
+import { cva } from 'class-variance-authority';
+
+/** default 상태: 포커스 시 그라데이션 테두리 */
+export const fieldGradientFocusWrapperClass =
+  'w-full rounded-md p-[2px] bg-transparent transition-[background-color] duration-150 focus-within:bg-gradient-primary';
+
+/** Input / Textarea 내부 필드 — default · error · disabled */
+export const fieldControlVariants = cva(
+  [
+    'w-full border px-3 py-2 text-sm leading-[1.6] text-gray-900',
+    'placeholder:text-gray-400',
+    'transition-[color,border-color] duration-150',
+    'outline-none focus-visible:outline-none',
+  ].join(' '),
+  {
+    variants: {
+      state: {
+        default: [
+          'rounded-[calc(0.375rem-2px)] border-gray-200 bg-gray-50',
+          'focus:border-transparent focus:text-gray-900',
+        ].join(' '),
+        error: [
+          'rounded-md border-red-200 bg-gray-0',
+          'focus:border-red-200 focus:ring-2 focus:ring-red-100 focus:ring-offset-0',
+        ].join(' '),
+      },
+    },
+    defaultVariants: {
+      state: 'default',
+    },
+  },
+);


### PR DESCRIPTION
## ❓ 이슈

- close #89 

## ✍️ Description

Input/Textarea 공통 상태(State) - default, focus, error 적용
## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist
기존 이슈에서 disabled 제거
[SM-66] 에서 추가된 global.css에 border-gradient 적용, textarea - resize-none 변경

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] figma 시안 중 카테고리 선택(드롭다운), 모임 마감 일정(캘린더) 전용 컴포넌트로 설계 필요
   Calendar 라이브러리 사용하는지 궁금합니다. 

현재 text-area 사이즈 고정인데, 추후에 필요하다면 내용이 늘어나면 auto-grow 방식으로 설계(JS 로직 추가)

[SM-66]: https://sailmate.atlassian.net/browse/SM-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ