### PR TITLE
[SM-72] fix: Claude Code Review 워크플로우 concurrency 설정 수정

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,12 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   review:
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
## ❓ 이슈

- close #97 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
Claude Code Review 워크플로우의 `concurrency` 설정을 workflow 레벨에서 job 레벨로 이동하여, Claude 봇의 인라인 코멘트가 진행 중인 리뷰를 취소하는 문제를 수정.

### 문제

  - Claude가 리뷰 중 인라인 코멘트를 달면 `pull_request_review` 이벤트 발생
  - Workflow 레벨 `cancel-in-progress: true`가 job `if` 조건 평가 전에 동작하여 기존 리뷰 run을 취소
  - 실패 사례: https://github.com/sunhang-team/SailMate/actions/runs/23531457010/job/68496049250

### 해결
  - `concurrency`를 job 레벨로 이동
  - Job 레벨에서는 `if` 조건이 먼저 평가되어, `@claude`가 없는 이벤트는 skip → concurrency group 미진입 → 기존 run 유지


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
