### PR TITLE
[SM-73] refactor: 인증 에러 처리 역할 분리

### DIFF
--- a/.claude/rules/rendering.md
+++ b/.claude/rules/rendering.md
@@ -56,6 +56,7 @@ paths:
 - 컴포넌트 내부에서 `isLoading`, `isError` 분기 작성 금지
 - 로딩 처리는 Suspense (또는 prefetch), 에러 처리는 ErrorBoundary에 위임
 - 컴포넌트는 데이터가 있는 상태만 가정하고 렌더링 로직에 집중
+- **예외 — 선택적 인증 UI 분기**: `useAuth` 훅은 로그인/비로그인 상태에 따라 다른 UI를 보여줘야 하므로 `useQuery` + `isError` 체크를 의도적으로 사용. `useSuspenseQuery`를 사용하면 비로그인 시 에러가 ErrorBoundary로 전파되어 레이아웃 전체가 깨지므로 이 패턴은 허용
 
 ## ErrorBoundary / SuspenseBoundary 사용 규칙
 

--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -1,7 +1,8 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { checkEmail, checkNickname, login, logout, register } from './index';
 import { userKeys } from '@/api/users/queries';
+
+import { checkEmail, checkNickname, login, logout, register } from './index';
 
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { LoginForm, LoginResponse, RegisterResponse, SignupForm } from './types';

--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -1,6 +1,7 @@
-import { queryOptions, useMutation } from '@tanstack/react-query';
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { checkEmail, checkNickname, login, logout, register } from './index';
+import { userKeys } from '@/api/users/queries';
 
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { LoginForm, LoginResponse, RegisterResponse, SignupForm } from './types';
@@ -40,21 +41,28 @@ export const useRegister = (options?: UseMutationOptions<RegisterResponse, Error
 
 /** POST /auth/login — 이메일 로그인 */
 export const useLogin = (options?: UseMutationOptions<LoginResponse, Error, LoginForm, unknown>) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: login,
-    // NOTE: 로그인 성공 시 GET /api/v1/users/me 캐시 무효화 필요
-    // users 도메인 구현 후 userKeys.me() invalidateQueries 추가 예정
     ...options,
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: userKeys.me() });
+      options?.onSuccess?.(...args);
+    },
   });
 };
 
 /** POST /auth/logout — 로그아웃 */
 export const useLogout = (options?: UseMutationOptions<void, Error, void, unknown>) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: logout,
-    // NOTE: 로그아웃 성공 시 GET /api/v1/users/me 캐시 제거 필요
-    // invalidate가 아닌 remove — 세션 종료이므로 데이터 자체를 삭제해야 함
-    // users 도메인 구현 후 userKeys.me() removeQueries 추가 예정
     ...options,
+    onSuccess: (...args) => {
+      queryClient.removeQueries({ queryKey: userKeys.me() });
+      options?.onSuccess?.(...args);
+    },
   });
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,8 @@
-import { userQueries } from '@/api/users/queries';
-import { User } from '@/api/users/types';
 import { useQuery } from '@tanstack/react-query';
+
+import { userQueries } from '@/api/users/queries';
+
+import type { User } from '@/api/users/types';
 
 interface AuthState {
   user: User | null;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,21 @@
+import { userQueries } from '@/api/users/queries';
+import { User } from '@/api/users/types';
+import { useQuery } from '@tanstack/react-query';
+
+interface AuthState {
+  user: User | null;
+  isLoggedIn: boolean;
+  isLoading: boolean;
+}
+
+export const useAuth = (): AuthState => {
+  const { data, isError, isLoading } = useQuery(userQueries.me());
+
+  const isLoggedIn = !isLoading && !isError && data !== undefined;
+
+  return {
+    user: isLoggedIn ? data : null,
+    isLoggedIn,
+    isLoading,
+  };
+};

--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -1,7 +1,6 @@
 import axios, { type AxiosError, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
 const REFRESH_PATH = '/auth/refresh';
-const LOGIN_PATH = '/auth/login';
 
 const refreshClient = axios.create({
   baseURL: '/api',
@@ -35,9 +34,6 @@ axiosClient.interceptors.response.use(
       await refreshClient.post(REFRESH_PATH);
       return await axiosClient.request(config);
     } catch (refreshError) {
-      if (typeof window !== 'undefined') {
-        window.location.assign(LOGIN_PATH);
-      }
       throw refreshError;
     }
   },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 const PROTECTED_ROUTES = ['/my', '/gathering/create', '/gathering/dashboard'];
 const AUTH_ROUTES = ['/login', '/signup'];
 
-export function proxy(request: NextRequest) {
+export const proxy = (request: NextRequest) => {
   const { pathname } = request.nextUrl;
   const hasAccessToken = request.cookies.has('accessToken');
   const hasRefreshToken = request.cookies.has('refreshToken');
@@ -21,7 +21,7 @@ export function proxy(request: NextRequest) {
   }
 
   return NextResponse.next();
-}
+};
 
 export const config = {
   matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PROTECTED_ROUTES = ['/my', '/gathering/create', '/gathering/dashboard'];
+const AUTH_ROUTES = ['/login', '/signup'];
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const hasAccessToken = request.cookies.has('accessToken');
+  const hasRefreshToken = request.cookies.has('refreshToken');
+  const hasAuth = hasAccessToken || hasRefreshToken;
+
+  const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+  const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
+
+  if (isProtectedRoute && !hasAuth) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (isAuthRoute && hasAuth) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],
+};


### PR DESCRIPTION
## ❓ 이슈

- close #100 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
로그인 상태 분기 UI 구현을 위한 인증 에러 처리 인프라 개선입니다.

### 배경
기존 axiosClient 인터셉터가 refresh 실패 시 `window.location.assign('/auth/login')`으로 강제 리다이렉트하여, 비로그인 유저에게 비로그인 UI를 보여줄 수 없는 구조였습니다. GNB 헤더에서 로그인/비로그인 상태에 따른 UI 분기가 필요하므로 이를 개선합니다.

### 변경 사항

  **1. axiosClient 인터셉터 — 리다이렉트 제거** (`src/lib/axiosClient.ts`)
  - refresh 실패 시 `window.location.assign` 제거, `throw refreshError`로 에러만 전파
  - TanStack Query / ErrorBoundary가 에러를 처리하도록 위임

  **2. proxy.ts — 인증 필수 페이지 보호** (`src/proxy.ts`)
  - Next.js 16의 `proxy` 함수로 경로 보호 (middleware.ts → proxy.ts)
  - `PROTECTED_ROUTES`: 비로그인 시 `/login`으로 리다이렉트
  - `AUTH_ROUTES`: 로그인 상태에서 `/login`, `/signup` 접근 시 `/`로 리다이렉트
  - accessToken OR refreshToken 쿠키 존재 여부로 인증 판단

  **3. useAuth 커스텀 훅** (`src/hooks/useAuth.ts`)
  - `useQuery(userQueries.me())` 기반 인증 상태 판별 훅
  - `{ user, isLoggedIn, isLoading }` 반환
  - `useQuery` 사용 (throwOnError: false) → 비로그인 시 에러를 throw하지 않고
  `isLoggedIn: false`로 분기

  **4. useLogin/useLogout 캐시 무효화** (`src/api/auth/queries.ts`)
  - `useLogin`: `onSuccess` → `invalidateQueries({ queryKey: userKeys.me() })` (유저
  데이터 refetch)
  - `useLogout`: `onSuccess` → `removeQueries({ queryKey: userKeys.me() })` (유저
  데이터 삭제)
  - 소비자 콜백 (`options?.onSuccess`) 전파 유지

  ### 에러 플로우

  비로그인 유저 → PROTECTED_ROUTES 접근 → proxy가 /login 리다이렉트
  비로그인 유저 → 일반 페이지 접근 → useAuth() → 401 → isLoggedIn: false → 비로그인 UI
  로그인 유저 → 토큰 만료 → 인터셉터 refresh 시도 → 성공 시 재요청 / 실패 시 에러 전파

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)


