### PR TITLE
[SM-80] style: Card 공통 컴포넌트 스타일 적용 및 스토리북 업데이트

### DIFF
--- a/src/components/ui/Card/index.stories.tsx
+++ b/src/components/ui/Card/index.stories.tsx
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button } from '@/components/ui/Button';
+import { HeartIcon, PeopleIcon, ProjectIcon, StudyIcon } from '@/components/ui/Icon';
+import { Tag } from '@/components/ui/Tag';
+
 import { Card } from '.';
 
 const meta = {
   title: 'components/Card',
   component: Card,
-  args: {
-    children: 'Card',
-  },
   parameters: {
     layout: 'centered',
   },
@@ -17,4 +19,99 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  name: '내 모임 카드 (Card 컴포넌트 사용 예시)',
+  args: {
+    className: 'w-[300px]',
+    children: (
+      <div className='flex flex-col gap-3 p-5'>
+        <div className='flex items-center justify-between'>
+          <Tag
+            variant='category'
+            icon={<ProjectIcon size={14} className='text-blue-300' />}
+            label='프로젝트'
+            sublabel='개발'
+          />
+          <div className='flex -space-x-2'>
+            <div className='border-gray-0 h-7 w-7 rounded-full border-2 bg-gray-300' />
+            <div className='border-gray-0 h-7 w-7 rounded-full border-2 bg-gray-400' />
+            <div className='border-gray-0 h-7 w-7 rounded-full border-2 bg-gray-500' />
+          </div>
+        </div>
+
+        <div className='flex flex-col gap-1'>
+          <div className='flex gap-1'>
+            <span className='text-small-02-m text-gray-500'>#디자인</span>
+            <span className='text-small-02-m text-gray-500'>#기획</span>
+          </div>
+          <p className='text-body-01-sb text-gray-900'>피그마 기초 스터디</p>
+        </div>
+
+        <div className='flex gap-2'>
+          <Tag variant='duration'>총 9주</Tag>
+          <Tag variant='deadline' state='goal'>
+            목표 D-14
+          </Tag>
+        </div>
+
+        <div className='flex flex-col gap-1'>
+          <div className='text-small-02-m flex items-center justify-between'>
+            <span className='text-gray-500'>달성률</span>
+            <span className='text-blue-300'>80%</span>
+          </div>
+          <div className='bg-gray-150 h-1.5 w-full rounded-full'>
+            <div className='bg-gradient-primary h-full w-4/5 rounded-full' />
+          </div>
+        </div>
+      </div>
+    ),
+  },
+};
+
+export const GatheringCardExample: Story = {
+  name: '모임 리스트 카드 (Card 컴포넌트 사용 예시)',
+  args: {
+    className: 'w-[300px]',
+    children: (
+      <div className='flex flex-col gap-3 p-5'>
+        <div className='flex items-center justify-between'>
+          <Tag
+            variant='category'
+            icon={<StudyIcon size={14} className='text-blue-300' />}
+            label='스터디'
+            sublabel='기타'
+          />
+          <div className='text-small-02-m flex items-center gap-1 text-gray-600'>
+            <PeopleIcon size={16} />
+            <span>3/12</span>
+          </div>
+        </div>
+
+        <div className='flex flex-col gap-1'>
+          <div className='flex gap-1'>
+            <span className='text-small-02-m text-gray-500'>#디자인</span>
+            <span className='text-small-02-m text-gray-500'>#기획</span>
+          </div>
+          <p className='text-body-01-sb text-gray-900'>커뮤니티 서비스 구축</p>
+          <p className='text-small-01-r text-gray-500'>서비스 기획부터 개발까지</p>
+        </div>
+
+        <div className='flex gap-2'>
+          <Tag variant='duration'>총 9주</Tag>
+          <Tag variant='deadline' state='goal'>
+            모집 마감 D-14
+          </Tag>
+        </div>
+
+        <div className='flex items-center gap-2'>
+          <Button variant='bookmark' size='bookmark-sm'>
+            <HeartIcon size={20} />
+          </Button>
+          <Button variant='participation-outline-sm' size='participation-sm'>
+            참여하기
+          </Button>
+        </div>
+      </div>
+    ),
+  },
+};

--- a/src/components/ui/Card/index.tsx
+++ b/src/components/ui/Card/index.tsx
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/cn';
 
 const cardVariants = cva(
-  'rounded-2xl border border-gray-150 bg-gray-0 shadow-01 transition-all hover:border-focus-100 hover:shadow-02',
+  'rounded-2xl border border-gray-150 bg-gray-0 shadow-01 transition-all hover:border-focus-100 hover:shadow-03',
 );
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {

--- a/src/components/ui/Card/index.tsx
+++ b/src/components/ui/Card/index.tsx
@@ -1,22 +1,17 @@
 import React, { HTMLAttributes } from 'react';
-import { cva, VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/cn';
 
-const cardVariants = cva('', {
-  variants: {
-    variant: {},
-    size: {},
-    interactive: {},
-  },
-  defaultVariants: {},
-});
+const cardVariants = cva(
+  'rounded-2xl border border-gray-150 bg-gray-0 shadow-01 transition-all hover:border-focus-100 hover:shadow-02',
+);
 
-interface CardProps extends HTMLAttributes<HTMLDivElement>, VariantProps<typeof cardVariants> {
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
-export function Card({ children, variant, size, interactive, className, ...props }: CardProps) {
-  const cardClasses = cn(cardVariants({ variant, size, interactive }), className);
+export function Card({ children, className, ...props }: CardProps) {
+  const cardClasses = cn(cardVariants(), className);
   return (
     <div className={cardClasses} {...props}>
       {children}


### PR DESCRIPTION
## ❓ 이슈

- close #110 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
 Card 공통 컴포넌트에 디자인 시안 기반 스타일을 적용하고 스토리북을 업데이트했습니다.

  - base 스타일 정의 (rounded-2xl, border-gray-150, bg-gray-0, shadow-01)
  - hover 스타일 정의 (border-focus-100, shadow-03, transition-all)
  - 불필요한 CVA variant 제거 (variant, size, interactive)
  - 스토리북에 내 모임 카드 / 모임 리스트 카드 사용 예시 추가


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
