### PR TITLE
[SM-78] feat: 회원가입 페이지 구현 (OAuth 미연동)

### DIFF
--- a/src/app/(auth)/components/AuthBottomLink.tsx
+++ b/src/app/(auth)/components/AuthBottomLink.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+interface AuthBottomLinkProps {
+  text: string;
+  linkText: string;
+  href: string;
+}
+
+export function AuthBottomLink({ text, linkText, href }: AuthBottomLinkProps) {
+  return (
+    <p className='text-small-01-r mt-10 text-center text-gray-800'>
+      {text}
+      <Link href={href} className='text-small-01-r ml-3 text-blue-400'>
+        {linkText}
+      </Link>
+    </p>
+  );
+}

--- a/src/app/(auth)/components/AuthDivider.tsx
+++ b/src/app/(auth)/components/AuthDivider.tsx
@@ -1,0 +1,13 @@
+interface AuthDividerProps {
+  text: string;
+}
+
+export function AuthDivider({ text }: AuthDividerProps) {
+  return (
+    <div className='mb-8 flex h-5.5 items-center gap-4'>
+      <div className='h-px flex-1 bg-gray-200' />
+      <span className='text-small-01-r text-gray-400'>{text}</span>
+      <div className='h-px flex-1 bg-gray-200' />
+    </div>
+  );
+}

--- a/src/app/(auth)/components/SocialLoginButtons.tsx
+++ b/src/app/(auth)/components/SocialLoginButtons.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@/components/ui/Button';
+import { KakaoIcon, GoogleIcon } from '@/components/ui/Icon';
+
+export function SocialLoginButtons() {
+  return (
+    <div className='mb-10 flex gap-3'>
+      <Button variant='social-kakao' size='social-kakao' className='flex-1'>
+        <KakaoIcon size={20} />
+        카카오로 시작하기
+      </Button>
+      <Button variant='social' size='social' className='flex-1'>
+        <GoogleIcon size={20} />
+        구글로 시작하기
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(auth)/components/SocialLoginButtons.tsx
+++ b/src/app/(auth)/components/SocialLoginButtons.tsx
@@ -1,16 +1,21 @@
 import { Button } from '@/components/ui/Button';
 import { KakaoIcon, GoogleIcon } from '@/components/ui/Icon';
 
-export function SocialLoginButtons() {
+interface SocialLoginButtonsProps {
+  kakaoLabel: string;
+  googleLabel: string;
+}
+
+export function SocialLoginButtons({ kakaoLabel, googleLabel }: SocialLoginButtonsProps) {
   return (
     <div className='mb-10 flex gap-3'>
       <Button variant='social-kakao' size='social-kakao' className='flex-1'>
         <KakaoIcon size={20} />
-        카카오로 시작하기
+        {kakaoLabel}
       </Button>
       <Button variant='social' size='social' className='flex-1'>
         <GoogleIcon size={20} />
-        구글로 시작하기
+        {googleLabel}
       </Button>
     </div>
   );

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -19,6 +19,7 @@ export function EmailRegisterForm() {
   const {
     register,
     handleSubmit,
+    trigger,
     formState: { errors, isValid },
   } = useForm<SignupForm>({
     resolver: zodResolver(signupFormSchema),
@@ -85,7 +86,9 @@ export function EmailRegisterForm() {
           placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요.'
           type={showPassword ? 'text' : 'password'}
           error={errors.password?.message}
-          {...register('password')}
+          {...register('password', {
+            onBlur: () => trigger('passwordConfirmation'),
+          })}
           className='h-11'
         />
         <button

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { signupFormSchema } from '@/api/auth/schemas';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { VisibilityIcon } from '@/components/ui/Icon';
+
+import type { SignupForm } from '@/api/auth/types';
+
+export function EmailRegisterForm() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<SignupForm>({
+    resolver: zodResolver(signupFormSchema),
+    mode: 'onBlur',
+  });
+
+  // OAuth 로그인 시 이메일, 닉네임 중복체크 미연동
+  const onSubmit = (data: SignupForm) => {
+    // TODO: 회원가입 API 호출
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
+      {/* 이메일 */}
+      <div className={`flex gap-2 ${errors.email ? 'items-center' : 'items-end'}`}>
+        <div className='flex-1'>
+          <Input
+            label={
+              <>
+                이메일 <span className='ml-1 text-blue-400'>*</span>
+              </>
+            }
+            placeholder='이메일을 입력해주세요.'
+            type='email'
+            error={errors.email?.message}
+            {...register('email')}
+            className='h-11'
+          />
+        </div>
+        <Button variant='check' size='check' type='button'>
+          확인
+        </Button>
+      </div>
+
+      {/* 닉네임 */}
+      <div className={`flex gap-2 ${errors.nickname ? 'items-center' : 'items-end'}`}>
+        <div className='flex-1'>
+          <Input
+            label={
+              <>
+                닉네임 <span className='ml-1 text-blue-400'>*</span>
+              </>
+            }
+            placeholder='닉네임을 입력해주세요.'
+            error={errors.nickname?.message}
+            {...register('nickname')}
+            className='h-11'
+          />
+        </div>
+        <Button variant='check' size='check' type='button'>
+          확인
+        </Button>
+      </div>
+
+      {/* 비밀번호 */}
+      <div className='relative'>
+        <Input
+          label={
+            <>
+              비밀번호 <span className='ml-1 text-blue-400'>*</span>
+            </>
+          }
+          placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요.'
+          type={showPassword ? 'text' : 'password'}
+          error={errors.password?.message}
+          {...register('password')}
+          className='h-11'
+        />
+        <button
+          type='button'
+          className='absolute top-9 right-3 cursor-pointer text-gray-400'
+          onClick={() => setShowPassword((prev) => !prev)}
+          aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+        >
+          <VisibilityIcon variant={showPassword ? 'on' : 'off'} size={20} />
+        </button>
+      </div>
+
+      {/* 비밀번호 확인 */}
+      <div className='relative'>
+        <Input
+          label={
+            <>
+              비밀번호 확인 <span className='ml-1 text-blue-400'>*</span>
+            </>
+          }
+          placeholder='비밀번호를 한번 더 입력해주세요.'
+          type={showPasswordConfirm ? 'text' : 'password'}
+          error={errors.passwordConfirmation?.message}
+          {...register('passwordConfirmation')}
+          className='h-11'
+        />
+        <button
+          type='button'
+          className='absolute top-9 right-3 cursor-pointer text-gray-400'
+          onClick={() => setShowPasswordConfirm((prev) => !prev)}
+          aria-label={showPasswordConfirm ? '비밀번호 숨기기' : '비밀번호 보기'}
+        >
+          <VisibilityIcon variant={showPasswordConfirm ? 'on' : 'off'} size={20} />
+        </button>
+      </div>
+
+      {/* 회원가입 버튼 */}
+      <Button variant='primary' size='join-login' type='submit' disabled={!isValid} className='mt-3 w-full'>
+        회원가입
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -8,7 +8,7 @@ export default function Register() {
     <main className='flex justify-center px-4 py-20'>
       <div className='w-full max-w-[496px]'>
         <h1 className='text-h5-b mb-10 text-center text-gray-900'>회원가입</h1>
-        <SocialLoginButtons />
+        <SocialLoginButtons kakaoLabel='카카오로 시작하기' googleLabel='구글로 시작하기' />
         <AuthDivider text='또는 이메일로 가입' />
         <EmailRegisterForm />
         <AuthBottomLink text='이미 계정이 있으신가요?' linkText='로그인' href='/login' />

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,18 @@
+import { AuthBottomLink } from '../components/AuthBottomLink';
+import { AuthDivider } from '../components/AuthDivider';
+import { SocialLoginButtons } from '../components/SocialLoginButtons';
+import { EmailRegisterForm } from './EmailRegisterForm';
+
+export default function Register() {
+  return (
+    <main className='flex justify-center px-4 py-20'>
+      <div className='w-full max-w-[496px]'>
+        <h1 className='text-h5-b mb-10 text-center text-gray-900'>회원가입</h1>
+        <SocialLoginButtons />
+        <AuthDivider text='또는 이메일로 가입' />
+        <EmailRegisterForm />
+        <AuthBottomLink text='이미 계정이 있으신가요?' linkText='로그인' href='/login' />
+      </div>
+    </main>
+  );
+}

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -5,7 +5,7 @@ import { fieldControlVariants, fieldGradientFocusWrapperClass } from '@/componen
 import { cn } from '@/lib/cn';
 
 type InputProps = ComponentPropsWithoutRef<'input'> & {
-  label?: string;
+  label?: React.ReactNode;
   error?: string;
 };
 


### PR DESCRIPTION
## ❓ 이슈

- close #106 

## ✍️ Description

OAuth를 제외한 회원가입 페이지 구현을 진행하였습니다.

## 📸 스크린샷 (UI 변경 시) (GNB 미적용)
<img width="976" height="626" alt="스크린샷 2026-03-26 오후 5 46 48" src="https://github.com/user-attachments/assets/bac6a3ae-f78d-4493-b131-029218ee70ef" />

## ✅ Checklist
- [x] page.tsx: 서버 컴포넌트 유지, 추상화된 컴포넌트 조합
- [x] SocialLoginButtons, AuthDivider, AuthBottomLink: 로그인과 공통 사용을 위해 auth/components로 분리
- [x] EmailRegisterForm: react-hook-form + Zod 유효성 검사 적용, 중복 확인/회원가입 API 연동은 미구현
- [x] Input 컴포넌트에서 '*' 스타일링을 위한 type 변경 (string -> React.ReactNode) (아현님께 미리 공유 뒤 진행)

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

-  github cli 설치 후 gh pr checkout (pr number) 입력하면 머지되지 않은 pr도 로컬에서 실행해볼 수 있습니다.
