### PR TITLE
[SM-85] feat: Pagination 공통 컴포넌트 구현

### DIFF
--- a/src/components/ui/Pagination/index.stories.tsx
+++ b/src/components/ui/Pagination/index.stories.tsx
@@ -43,6 +43,57 @@ export const NumberedLast: Story = {
   },
 };
 
+// ─── Numbered (많은 페이지 / 말줄임) ────────────────────────
+export const NumberedEllipsisFirst: Story = {
+  name: '[Numbered] 말줄임 - 첫 페이지',
+  args: {
+    variant: 'numbered',
+    currentPage: 1,
+    totalPages: 10,
+    onPageChange: () => {},
+  },
+};
+
+export const NumberedEllipsisMiddle: Story = {
+  name: '[Numbered] 말줄임 - 중간 페이지',
+  args: {
+    variant: 'numbered',
+    currentPage: 5,
+    totalPages: 10,
+    onPageChange: () => {},
+  },
+};
+
+export const NumberedEllipsisNearStart: Story = {
+  name: '[Numbered] 말줄임 - 시작 근처',
+  args: {
+    variant: 'numbered',
+    currentPage: 3,
+    totalPages: 8,
+    onPageChange: () => {},
+  },
+};
+
+export const NumberedEllipsisNearEnd: Story = {
+  name: '[Numbered] 말줄임 - 끝 근처',
+  args: {
+    variant: 'numbered',
+    currentPage: 8,
+    totalPages: 10,
+    onPageChange: () => {},
+  },
+};
+
+export const NumberedEllipsisLast: Story = {
+  name: '[Numbered] 말줄임 - 마지막 페이지',
+  args: {
+    variant: 'numbered',
+    currentPage: 10,
+    totalPages: 10,
+    onPageChange: () => {},
+  },
+};
+
 // ─── Simple ─────────────────────────────────────────────────
 export const SimpleDefault: Story = {
   name: '[Simple] 기본',

--- a/src/components/ui/Pagination/index.stories.tsx
+++ b/src/components/ui/Pagination/index.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Pagination } from '.';
+
+const meta = {
+  title: 'components/Pagination',
+  component: Pagination,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// ─── Numbered ───────────────────────────────────────────────
+export const NumberedFirst: Story = {
+  name: '[Numbered] 첫 페이지',
+  args: {
+    variant: 'numbered',
+    currentPage: 1,
+    totalPages: 5,
+    onPageChange: () => {},
+  },
+};
+
+export const NumberedMiddle: Story = {
+  name: '[Numbered] 중간 페이지',
+  args: {
+    variant: 'numbered',
+    currentPage: 3,
+    totalPages: 5,
+    onPageChange: () => {},
+  },
+};
+
+export const NumberedLast: Story = {
+  name: '[Numbered] 마지막 페이지',
+  args: {
+    variant: 'numbered',
+    currentPage: 5,
+    totalPages: 5,
+    onPageChange: () => {},
+  },
+};
+
+// ─── Simple ─────────────────────────────────────────────────
+export const SimpleDefault: Story = {
+  name: '[Simple] 기본',
+  args: {
+    variant: 'simple',
+    currentPage: 2,
+    totalPages: 5,
+    onPageChange: () => {},
+  },
+};
+
+export const SimpleFirst: Story = {
+  name: '[Simple] 첫 페이지',
+  args: {
+    variant: 'simple',
+    currentPage: 1,
+    totalPages: 5,
+    onPageChange: () => {},
+  },
+};
+
+export const SimpleLast: Story = {
+  name: '[Simple] 마지막 페이지',
+  args: {
+    variant: 'simple',
+    currentPage: 5,
+    totalPages: 5,
+    onPageChange: () => {},
+  },
+};

--- a/src/components/ui/Pagination/index.tsx
+++ b/src/components/ui/Pagination/index.tsx
@@ -1,26 +1,8 @@
+'use client';
+
 import { cn } from '@/lib/cn';
+import { getPageRange } from '@/lib/getPageRange';
 import { PaginationIcon } from '@/components/ui/Icon/PaginationIcon';
-
-const ELLIPSIS_THRESHOLD = 7; // 이 값 이하면 전체 페이지 표시, 초과하면 ... 사용
-const DELTA = 1; // 현재 페이지 앞뒤로 보여줄 페이지 수
-
-// 페이지가 많을 때 ... 포함한 번호 배열 반환
-const getPageRange = (currentPage: number, totalPages: number): (number | '...')[] => {
-  if (totalPages <= ELLIPSIS_THRESHOLD) {
-    return Array.from({ length: totalPages }, (_, i) => i + 1);
-  }
-
-  const left = Math.max(2, currentPage - DELTA);
-  const right = Math.min(totalPages - 1, currentPage + DELTA);
-  const pages: (number | '...')[] = [1];
-
-  if (left > 2) pages.push('...');
-  for (let i = left; i <= right; i++) pages.push(i);
-  if (right < totalPages - 1) pages.push('...');
-  pages.push(totalPages);
-
-  return pages;
-};
 
 interface PaginationBaseProps {
   currentPage: number;

--- a/src/components/ui/Pagination/index.tsx
+++ b/src/components/ui/Pagination/index.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/lib/cn';
+import { PaginationIcon } from '@/components/ui/Icon/PaginationIcon';
+
+interface PaginationBaseProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+}
+
+type NumberedPaginationProps = PaginationBaseProps & { variant: 'numbered' };
+type SimplePaginationProps = PaginationBaseProps & { variant: 'simple' };
+type PaginationProps = NumberedPaginationProps | SimplePaginationProps;
+
+export function Pagination({ variant, currentPage, totalPages, onPageChange, className }: PaginationProps) {
+  const isFirst = currentPage === 1;
+  const isLast = currentPage === totalPages;
+
+  return (
+    <div className={cn('flex items-center justify-center', variant === 'numbered' ? 'gap-10' : 'gap-3', className)}>
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={isFirst}
+        aria-label='이전 페이지'
+        className='cursor-pointer transition-colors enabled:hover:text-gray-500 disabled:cursor-not-allowed'
+      >
+        <PaginationIcon variant='prev' className={cn('size-12', isFirst && 'text-gray-300')} />
+      </button>
+
+      {variant === 'numbered' && (
+        <div className='flex items-center justify-center gap-6'>
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              aria-label={`${page}페이지`}
+              aria-current={page === currentPage ? 'page' : undefined}
+              className={cn(
+                'text-body-02-m cursor-pointer transition-colors',
+                page === currentPage ? 'text-gray-700' : 'text-gray-300 hover:text-gray-500',
+              )}
+            >
+              {page}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={isLast}
+        aria-label='다음 페이지'
+        className='cursor-pointer transition-colors enabled:hover:text-gray-500 disabled:cursor-not-allowed'
+      >
+        <PaginationIcon variant='next' className={cn('size-12', isLast && 'text-gray-300')} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/Pagination/index.tsx
+++ b/src/components/ui/Pagination/index.tsx
@@ -1,6 +1,27 @@
 import { cn } from '@/lib/cn';
 import { PaginationIcon } from '@/components/ui/Icon/PaginationIcon';
 
+const ELLIPSIS_THRESHOLD = 7; // 이 값 이하면 전체 페이지 표시, 초과하면 ... 사용
+const DELTA = 1; // 현재 페이지 앞뒤로 보여줄 페이지 수
+
+// 페이지가 많을 때 ... 포함한 번호 배열 반환
+const getPageRange = (currentPage: number, totalPages: number): (number | '...')[] => {
+  if (totalPages <= ELLIPSIS_THRESHOLD) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const left = Math.max(2, currentPage - DELTA);
+  const right = Math.min(totalPages - 1, currentPage + DELTA);
+  const pages: (number | '...')[] = [1];
+
+  if (left > 2) pages.push('...');
+  for (let i = left; i <= right; i++) pages.push(i);
+  if (right < totalPages - 1) pages.push('...');
+  pages.push(totalPages);
+
+  return pages;
+};
+
 interface PaginationBaseProps {
   currentPage: number;
   totalPages: number;
@@ -29,20 +50,26 @@ export function Pagination({ variant, currentPage, totalPages, onPageChange, cla
 
       {variant === 'numbered' && (
         <div className='flex items-center justify-center gap-6'>
-          {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-            <button
-              key={page}
-              onClick={() => onPageChange(page)}
-              aria-label={`${page}페이지`}
-              aria-current={page === currentPage ? 'page' : undefined}
-              className={cn(
-                'text-body-02-m cursor-pointer transition-colors',
-                page === currentPage ? 'text-gray-700' : 'text-gray-300 hover:text-gray-500',
-              )}
-            >
-              {page}
-            </button>
-          ))}
+          {getPageRange(currentPage, totalPages).map((item, index) =>
+            item === '...' ? (
+              <span key={`ellipsis-${index}`} className='text-body-02-m text-gray-300'>
+                ...
+              </span>
+            ) : (
+              <button
+                key={item}
+                onClick={() => onPageChange(item)}
+                aria-label={`${item}페이지`}
+                aria-current={item === currentPage ? 'page' : undefined}
+                className={cn(
+                  'text-body-02-m cursor-pointer transition-colors',
+                  item === currentPage ? 'text-gray-700' : 'text-gray-300 hover:text-gray-500',
+                )}
+              >
+                {item}
+              </button>
+            ),
+          )}
         </div>
       )}
 

--- a/src/lib/getPageRange.ts
+++ b/src/lib/getPageRange.ts
@@ -2,7 +2,13 @@
  * 페이지네이션에 표시할 페이지 번호 배열을 반환합니다.
  * 페이지 수가 많을 때 현재 페이지 주변만 보여주고 나머지는 '...'로 축약합니다.
  */
+const ELLIPSIS_THRESHOLD = 7; // 이 값 이하면 전체 페이지 표시, 초과하면 ... 사용
+
 export const getPageRange = (currentPage: number, totalPages: number): (number | '...')[] => {
+  if (totalPages <= ELLIPSIS_THRESHOLD) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
   // 현재 페이지 기준 양쪽으로 보여줄 페이지 수
   // delta=1 → currentPage ±1 (ex. 10이면 9, 10, 11)
   const delta = 1;

--- a/src/lib/getPageRange.ts
+++ b/src/lib/getPageRange.ts
@@ -1,0 +1,33 @@
+/**
+ * 페이지네이션에 표시할 페이지 번호 배열을 반환합니다.
+ * 페이지 수가 많을 때 현재 페이지 주변만 보여주고 나머지는 '...'로 축약합니다.
+ */
+export const getPageRange = (currentPage: number, totalPages: number): (number | '...')[] => {
+  // 현재 페이지 기준 양쪽으로 보여줄 페이지 수
+  // delta=1 → currentPage ±1 (ex. 10이면 9, 10, 11)
+  const delta = 1;
+
+  // 항상 포함할 페이지: 첫 페이지(1), 마지막 페이지, 현재 페이지 ±delta
+  // filter로 1~totalPages 범위를 벗어난 값 제거, Set으로 중복 제거
+  const rangeSet = new Set(
+    [1, totalPages, ...Array.from({ length: delta * 2 + 1 }, (_, i) => currentPage - delta + i)].filter(
+      (p) => p >= 1 && p <= totalPages,
+    ),
+  );
+
+  const sorted = Array.from(rangeSet).sort((a, b) => a - b);
+  const result: (number | '...')[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0) {
+      const gap = sorted[i] - sorted[i - 1];
+      // 갭이 정확히 2면 '...' 대신 중간 숫자를 채움 (ex. 3→5이면 4 삽입)
+      if (gap === 2) result.push(sorted[i] - 1);
+      // 갭이 3 이상이면 '...' 삽입
+      else if (gap > 2) result.push('...');
+    }
+    result.push(sorted[i]);
+  }
+
+  return result;
+};


### PR DESCRIPTION
## ❓ 이슈

- close #118 

## ✍️ Description

Pagination 공통 컴포넌트 구현

- `numbered` / `simple` 두 가지 variant 지원
- 총 페이지 수가 7 초과 시 현재 페이지 앞뒤 1개 + `...` 말줄임 처리
- 이전/다음 버튼 첫/마지막 페이지에서 비활성화, 접근성 aria 속성 포함
- Storybook 스토리 추가 (numbered 기본/말줄임 케이스, simple 기본 케이스)

## 📸 스크린샷 (UI 변경 시)
<img width="652" height="162" alt="image" src="https://github.com/user-attachments/assets/8c11654f-3c9d-4abe-9985-0dcca4f45ae1" />
<img width="698" height="160" alt="image" src="https://github.com/user-attachments/assets/4277e3e7-65ee-46f6-928b-e1b4baf2aa06" />
<img width="256" height="124" alt="image" src="https://github.com/user-attachments/assets/68c38580-da4d-4fab-89f2-5b895593e95c" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

