### PR TITLE
[SM-88] feat: Card 기반 GatheringCard 공통 컴포넌트 구현

### DIFF
--- a/src/components/ui/GatheringCard/index.tsx
+++ b/src/components/ui/GatheringCard/index.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/cn';
+import { Card } from '../Card';
+
+interface GatheringCardHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function GatheringCardHeader({ children, className }: GatheringCardHeaderProps) {
+  return <div className={cn('mb-6 flex justify-between', className)}>{children}</div>;
+}
+
+interface GatheringCardBodyProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function GatheringCardBody({ children, className }: GatheringCardBodyProps) {
+  return <div className={cn('flex flex-col gap-3', className)}>{children}</div>;
+}
+
+interface GatheringCardFooterProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function GatheringCardFooter({ children, className }: GatheringCardFooterProps) {
+  return <div className={cn('flex gap-2', className)}>{children}</div>;
+}
+
+interface GatheringCardRootProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+function GatheringCardRoot({ children, className }: GatheringCardRootProps) {
+  return <Card className={cn('p-7', className)}>{children}</Card>;
+}
+
+export const GatheringCard = Object.assign(GatheringCardRoot, {
+  Header: GatheringCardHeader,
+  Body: GatheringCardBody,
+  Footer: GatheringCardFooter,
+});

--- a/src/components/ui/GatheringCard/index.tsx
+++ b/src/components/ui/GatheringCard/index.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/cn';
+
 import { Card } from '../Card';
 
 interface GatheringCardHeaderProps {


### PR DESCRIPTION
## ❓ 이슈

- close #121 

## ✍️ Description

- 기존 원자 Card 기반으로 분자 GatheringCard로 구현
- 추후 다른 도메인의 카드 등장 시 기존 원자 Card를 재활용 가능

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- 스토리북은 GatheringCard에서 쓰이는 모든 모임카드 관련 컴포넌트(avatarGroup, Progress 등) 구현한 뒤 생성 예정
