### PR TITLE
[SM-79] style: 로그인 페이지 반응형 레이아웃 적용

### DIFF
--- a/src/app/(auth)/components/SocialLoginButtons.tsx
+++ b/src/app/(auth)/components/SocialLoginButtons.tsx
@@ -8,12 +8,12 @@ interface SocialLoginButtonsProps {
 
 export function SocialLoginButtons({ kakaoLabel, googleLabel }: SocialLoginButtonsProps) {
   return (
-    <div className='mb-10 flex gap-3'>
-      <Button variant='social-kakao' size='social-kakao' className='flex-1'>
+    <div className='mb-10 flex flex-col gap-3 md:flex-row'>
+      <Button variant='social-kakao' size='social-kakao' className='w-full md:flex-1'>
         <KakaoIcon size={20} />
         {kakaoLabel}
       </Button>
-      <Button variant='social' size='social' className='flex-1'>
+      <Button variant='social' size='social' className='w-full md:flex-1'>
         <GoogleIcon size={20} />
         {googleLabel}
       </Button>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import { EmailLoginForm } from './EmailLoginForm';
 
 export default function LoginPage() {
   return (
-    <main className='flex justify-center px-4 py-20'>
+    <main className='flex justify-center px-4 py-20 md:py-25'>
       <div className='w-full max-w-[496px]'>
         <h1 className='text-h5-b mb-10 text-center text-gray-900'>로그인</h1>
         <SocialLoginButtons kakaoLabel='카카오로 로그인' googleLabel='구글로 로그인' />

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -5,7 +5,7 @@ import { EmailRegisterForm } from './EmailRegisterForm';
 
 export default function Register() {
   return (
-    <main className='flex justify-center px-4 py-20'>
+    <main className='flex justify-center px-4 py-20 md:py-25'>
       <div className='w-full max-w-[496px]'>
         <h1 className='text-h5-b mb-10 text-center text-gray-900'>회원가입</h1>
         <SocialLoginButtons kakaoLabel='카카오로 시작하기' googleLabel='구글로 시작하기' />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { MSWProvider } from '@/providers/MSWProvider';
 import { QueryParamsProvider } from '@/providers/QueryParamsProvider';
 import { QueryProvider } from '@/providers/QueryProvider';
 import { OverlayProvider } from '@/providers/OverlayProvider';
-import { Footer } from '@/components/Footer';
+import { FooterWrapper } from '@/components/Footer/FooterWrapper';
 
 export default function RootLayout({
   children,
@@ -20,7 +20,7 @@ export default function RootLayout({
             <QueryParamsProvider>
               <Header />
               {children}
-              <Footer />
+              <FooterWrapper />
               <OverlayProvider />
               <div id='modal-root' />
             </QueryParamsProvider>

--- a/src/components/Footer/FooterWrapper.tsx
+++ b/src/components/Footer/FooterWrapper.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { Footer } from './index';
+
+const ROUTES_WITHOUT_FOOTER = ['/login', '/register'];
+
+export function FooterWrapper() {
+  const pathname = usePathname();
+  if (ROUTES_WITHOUT_FOOTER.includes(pathname)) return null;
+  return <Footer />;
+}

--- a/src/components/layout/Header/AuthSection.tsx
+++ b/src/components/layout/Header/AuthSection.tsx
@@ -21,7 +21,7 @@ export function AuthSection() {
   });
 
   const handleMoveLogin = () => router.push('/login');
-  const handleMoveSignup = () => router.push('/signup');
+  const handleMoveSignup = () => router.push('/register');
   const handleMoveMyPage = () => router.push('/my');
 
   if (isLoading) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 const PROTECTED_ROUTES = ['/my', '/gathering/create', '/gathering/dashboard'];
-const AUTH_ROUTES = ['/login', '/signup'];
+const AUTH_ROUTES = ['/login', '/register'];
 
 export const proxy = (request: NextRequest) => {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
## ❓ 이슈

- close #이슈번호

## ✍️ Description

1. 로그인 페이지와 회원가입 페이지 및 소셜 로그인 버튼 컴포넌트에 반응형 레이아웃을 적용했습니다.

- 모바일: 상하 패딩 `py-20`(80px), 소셜 버튼 세로 배치, 버튼 너비 `w-full`
- 태블릿: 상하 패딩 `py-25`(100px), 소셜 버튼 가로 배치, 버튼 `flex-1`로 균등 분할


2. 로그인/회원가입 페이지에서 Footer를 숨기는 `FooterWrapper` 컴포넌트를 추가하고, 회원가입 경로를 `/register`로 통일했습니다.

`usePathname`으로 현재 경로를 확인하는 `FooterWrapper` 클라이언트 컴포넌트를 추가하여 `/login`, `/register`에서 Footer를 숨깁니다.

> **참고**: `FooterWrapper`가 클라이언트 컴포넌트이므로 `Footer`도 클라이언트 번들에 포함됩니다. `Footer`는 정적 콘텐츠(`<Image>`, `<Link>`, 텍스트)만 포함하여 서버 전용 기능이 없으므로 동작상 문제없습니다.
- `FooterWrapper`: `usePathname`으로 현재 경로를 감지해 `/login`, `/register`에서 Footer를 렌더링하지 않도록 처리
- `layout.tsx`: `Footer` → `FooterWrapper`로 교체
- `AuthSection`: 회원가입 이동 경로 `/signup` → `/register` 수정

## 📸 스크린샷 (UI 변경 시)
<img width="842" height="657" alt="스크린샷 2026-03-30 092000" src="https://github.com/user-attachments/assets/97ab63dd-0bad-431f-8c60-6d1456fb6935" />

<img width="544" height="733" alt="스크린샷 2026-03-30 092104" src="https://github.com/user-attachments/assets/4355fcfa-2027-4d78-a4bb-0906f7c2ff65" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [x] `SocialLoginButtons` 컴포넌트가 회원가입 페이지(`/register`)와 공유되므로, 반응형 레이아웃 변경사항이 동일하게 적용됨 — ~~회원가입 담당자 확인 필요~~ 확인 완료
- [x] 후속 pr 올릴 때에도 제목 앞에 SM-@@ 붙여야 하나요?
