### PR TITLE
[SM-52] feat: Likes 도메인 타입 선언

### DIFF
--- a/src/api/likes/types.ts
+++ b/src/api/likes/types.ts
@@ -1,0 +1,20 @@
+import type { GatheringListItem } from '@/api/gatherings/types';
+
+/** POST/DELETE `/gatherings/:gatheringId/likes` 응답 */
+export interface LikeToggleResponse {
+  success: boolean;
+}
+
+/** GET `/users/me/likes` — 쿼리 파라미터 */
+export interface GetMyLikesParams {
+  page?: number;
+  limit?: number;
+}
+
+/** GET `/users/me/likes` — 응답 */
+export interface GetMyLikesResponse {
+  gatherings: GatheringListItem[];
+  totalCount: number;
+  totalPages: number;
+  currentPage: number;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #56 

## ✍️ Description

`src/api/likes/types.ts` 신규 생성 — Likes 도메인 API 응답 타입 선언

- `LikeToggleResponse` — POST/DELETE `/gatherings/:gatheringId/likes` 공용 응답
- `GetMyLikesParams` — GET `/users/me/likes` 쿼리 파라미터
- `GetMyLikesResponse` — GET `/users/me/likes` 응답 (`GatheringListItem` 재사용)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes
