### PR TITLE
[SM-91] feat: Likes 도메인 API 함수 및 쿼리 훅, MSW 핸들러 작성

### DIFF
--- a/src/api/likes/index.ts
+++ b/src/api/likes/index.ts
@@ -1,0 +1,21 @@
+import { axiosClient } from '@/lib/axiosClient';
+import { unwrapResponse } from '@/api/common/utils';
+
+import type { ApiResponse } from '@/api/common/types';
+import type { GetMyLikesParams, GetMyLikesResponse } from './types';
+
+/** POST /v1/gatherings/:gatheringId/likes — 찜 추가 */
+export const addLike = async (gatheringId: number): Promise<void> => {
+  await axiosClient.post(`/v1/gatherings/${gatheringId}/likes`);
+};
+
+/** DELETE /v1/gatherings/:gatheringId/likes — 찜 취소 */
+export const removeLike = async (gatheringId: number): Promise<void> => {
+  await axiosClient.delete(`/v1/gatherings/${gatheringId}/likes`);
+};
+
+/** GET /v1/users/me/likes — 내 찜 목록 */
+export const getMyLikes = async (params?: GetMyLikesParams): Promise<GetMyLikesResponse> => {
+  const { data } = await axiosClient.get<ApiResponse<GetMyLikesResponse>>('/v1/users/me/likes', { params });
+  return unwrapResponse(data);
+};

--- a/src/api/likes/queries.ts
+++ b/src/api/likes/queries.ts
@@ -1,0 +1,48 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { getMyLikes, addLike, removeLike } from './index';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { GetMyLikesParams } from './types';
+
+export const likeKeys = {
+  all: ['likes'] as const,
+  my: (params?: GetMyLikesParams) => [...likeKeys.all, 'my', params ?? {}] as const,
+};
+
+export const likeQueries = {
+  /** GET /users/me/likes — 내 찜 목록 */
+  my: (params?: GetMyLikesParams) =>
+    queryOptions({
+      queryKey: likeKeys.my(params),
+      queryFn: () => getMyLikes(params),
+    }),
+};
+
+/** POST /gatherings/:gatheringId/likes — 찜 추가 */
+export const useAddLike = (options?: UseMutationOptions<void, Error, number, unknown>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (gatheringId: number) => addLike(gatheringId),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: likeKeys.all });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};
+
+/** DELETE /gatherings/:gatheringId/likes — 찜 취소 */
+export const useRemoveLike = (options?: UseMutationOptions<void, Error, number, unknown>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (gatheringId: number) => removeLike(gatheringId),
+    ...options,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: likeKeys.all });
+      options?.onSuccess?.(data, variables, onMutateResult, context);
+    },
+  });
+};

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -6,6 +6,7 @@ import { membershipsHandlers } from './memberships';
 import { applicationsHandlers } from './applications';
 import { achievementsHandlers } from './achievements';
 import { reviewsHandlers } from './reviews';
+import { likesHandlers } from './likes';
 
 export const handlers = [
   ...todosHandlers,
@@ -16,4 +17,5 @@ export const handlers = [
   ...achievementsHandlers,
   ...applicationsHandlers,
   ...reviewsHandlers,
+  ...likesHandlers,
 ];

--- a/src/mocks/handlers/likes.ts
+++ b/src/mocks/handlers/likes.ts
@@ -1,0 +1,67 @@
+import { HttpResponse, http, delay } from 'msw';
+
+import { createApiResponse } from '../utils';
+
+import type { GetMyLikesResponse } from '@/api/likes/types';
+
+const MOCK_DELAY = 300;
+
+const mockMyLikesResponse: GetMyLikesResponse = {
+  gatherings: [
+    {
+      id: 1,
+      type: '스터디',
+      category: '개발',
+      title: 'React 완전 정복 스터디',
+      shortDescription: 'React 심화 학습을 함께해요',
+      tags: ['React', 'Frontend'],
+      maxMembers: 10,
+      currentMembers: 6,
+      recruitDeadline: '2025-05-01',
+      startDate: '2025-05-10',
+      endDate: '2025-07-10',
+      status: 'RECRUITING',
+      isLiked: true,
+      leader: { id: 2, nickname: '항해사', profileImage: null },
+    },
+    {
+      id: 2,
+      type: '프로젝트',
+      category: '개발',
+      title: 'TypeScript 딥다이브',
+      shortDescription: 'TypeScript를 깊게 파봐요',
+      tags: ['TypeScript', 'Backend'],
+      maxMembers: 8,
+      currentMembers: 3,
+      recruitDeadline: '2025-05-15',
+      startDate: '2025-05-20',
+      endDate: '2025-08-20',
+      status: 'RECRUITING',
+      isLiked: true,
+      leader: { id: 3, nickname: '마감왕', profileImage: null },
+    },
+  ],
+  totalCount: 2,
+  totalPages: 1,
+  currentPage: 1,
+};
+
+export const likesHandlers = [
+  /** POST v1/gatherings/:gatheringId/likes — 찜 추가 */
+  http.post('/api/v1/gatherings/:gatheringId/likes', async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse({ success: true }), { status: 201 });
+  }),
+
+  /** DELETE v1/gatherings/:gatheringId/likes — 찜 취소 */
+  http.delete('/api/v1/gatherings/:gatheringId/likes', async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse({ success: true }));
+  }),
+
+  /** GET v1/users/me/likes — 내 찜 목록 */
+  http.get('/api/v1/users/me/likes', async () => {
+    await delay(MOCK_DELAY);
+    return HttpResponse.json(createApiResponse(mockMyLikesResponse));
+  }),
+];


### PR DESCRIPTION
## ❓ 이슈

- close #126 

## ✍️ Description


`src/api/likes/`에 선언된 타입을 기반으로 Likes 도메인 API 함수, 쿼리 훅, MSW 핸들러를 작성

- `src/api/likes/index.ts` — `addLike`, `removeLike`, `getMyLikes` API 함수
- `src/api/likes/queries.ts` — `likeKeys`, `likeQueries.my`, `useAddLike`, `useRemoveLike`
- `src/mocks/handlers/likes.ts` — POST / DELETE / GET 핸들러 작성 및 `handlers/index.ts` 등록
- `src/mocks/handlers/index.ts`: 핸들러 등록

## 📸 스크린샷 (UI 변경 시)
<img width="890" height="282" alt="화면 캡처 2026-03-30 142742" src="https://github.com/user-attachments/assets/f225bcec-3d50-42dd-8afc-68d529d77414" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

