### PR TITLE
[SM-94] feat: 모임 만들기 페이지 레이아웃 및 폼 기본 구조 (반응형)

### DIFF
--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -16,14 +16,11 @@ export const gatheringFormSchema = z.object({
     message: '모임 유형을 지정해 주세요.',
   }),
   category: z.string().min(1, '카테고리를 선택해 주세요.'),
-  title: z.string().min(1, '모임 제목을 입력해 주세요.').max(50, '제목은 최대 50자까지 가능합니다.'),
-  shortDescription: z
-    .string()
-    .min(1, '한 줄 소개를 입력해 주세요.')
-    .max(100, '한 줄 소개는 최대 100자까지 가능합니다.'),
-  description: z.string().min(1, '상세 소개를 입력해 주세요.'),
+  title: z.string().min(1, '모임 제목을 입력해 주세요. ').max(30, '제목은 최대 30자까지 가능합니다.'),
+  shortDescription: z.string().min(1, '한 줄 소개를 입력해 주세요.').max(50, '한 줄 소개는 최대 50자까지 가능합니다.'),
+  description: z.string().min(1, '상세 소개를 입력해 주세요.').max(1000, '상세 설명은 최대 1000자까지 가능합니다.'),
   tags: z.array(z.string()).min(1, '최소 1개의 태그를 입력해 주세요.').max(5, '태그는 최대 5개까지 가능합니다.'),
-  goal: z.string().min(1, '모임 목표를 입력해 주세요.'),
+  goal: z.string().min(1, '모임 목표를 입력해 주세요.').max(200, '모임 목표는 최대 200자까지 가능합니다.'),
   maxMembers: z.number().min(2, '최소 2명 이상이어야 합니다.').max(20, '최대 20명 이하이어야 합니다.'),
   recruitDeadline: dateStringSchema,
   startDate: dateStringSchema,

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -34,3 +34,13 @@ export const gatheringFormSchema = z.object({
 
 /** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (모든 필드 optional) */
 export const gatheringUpdateFormSchema = gatheringFormSchema.partial();
+
+/** POST `/gatherings` — 모임 생성 폼 (부분 구현용) */
+export const gatheringFormPartialSchema = z.object({
+  type: z.enum(['스터디', '프로젝트'], { message: '모임 유형을 지정해 주세요.' }),
+  category: z.string().min(1, '카테고리를 선택해 주세요.'),
+  title: z.string().min(1, '모임 제목을 입력해 주세요. ').max(30, '제목은 최대 30자까지 가능합니다.'),
+  shortDescription: z.string().min(1, '한 줄 소개를 입력해 주세요.').max(50, '한 줄 소개는 최대 50자까지 가능합니다.'),
+  description: z.string().min(1, '상세 소개를 입력해 주세요.').max(1000, '상세 설명은 최대 1000자까지 가능합니다.'),
+  goal: z.string().min(1, '모임 목표를 입력해 주세요.').max(200, '모임 목표는 최대 200자까지 가능합니다.'),
+});

--- a/src/api/gatherings/types.ts
+++ b/src/api/gatherings/types.ts
@@ -1,6 +1,6 @@
 import type { z } from 'zod';
 
-import type { gatheringFormSchema, gatheringUpdateFormSchema } from './schemas';
+import type { gatheringFormPartialSchema, gatheringFormSchema, gatheringUpdateFormSchema } from './schemas';
 
 /** 모임 유형 */
 export type GatheringType = '스터디' | '프로젝트';
@@ -132,3 +132,6 @@ export interface UpdateGatheringResponse {
 export interface DeleteGatheringResponse {
   success: boolean;
 }
+
+/** POST `/gatherings` — 모임 생성 폼 (부분 구현용) */
+export type GatheringFormPartial = z.infer<typeof gatheringFormPartialSchema>;

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -82,6 +82,7 @@ export function CreateGatheringForm() {
     mutate(data, {
       onSuccess: () => {
         showToast({ variant: 'success', title: '모임이 생성되었습니다.' });
+        // 리다이렉트
       },
       onError: () => {
         showToast({ variant: 'error', title: '모임 생성에 실패했습니다.' });

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
 import { Dropdown } from '@/components/ui/Dropdown';
 import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
+import { StudyIcon, ProjectIcon, CategoryIcon, ArrowIcon } from '@/components/ui/Icon';
+import { useDropdown } from '@/components/ui/Dropdown/context';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
@@ -17,8 +19,17 @@ import { cn } from '@/lib/cn';
 
 import type { GatheringForm } from '@/api/gatherings/types';
 
+const RotatingArrow = () => {
+  const { isOpen } = useDropdown();
+  return <ArrowIcon className={cn('rotate-90 transition-transform duration-200', isOpen ? '-rotate-90' : '')} />;
+};
+
+const TYPE_META = {
+  스터디: { subtitle: '함께 학습하고 성장해요', Icon: StudyIcon },
+  프로젝트: { subtitle: '함께 만들고 완성해요', Icon: ProjectIcon },
+} as const;
+
 export function CreateGatheringForm() {
-  const router = useRouter();
   const showToast = useToastStore((state) => state.showToast);
 
   const {
@@ -34,16 +45,20 @@ export function CreateGatheringForm() {
 
   const { mutate, isPending } = useCreateGathering();
 
+  const typeValue = watch('type');
+  const categoryValue = watch('category');
   const titleValue = watch('title') ?? '';
   const shortDescValue = watch('shortDescription') ?? '';
   const descValue = watch('description') ?? '';
   const goalValue = watch('goal') ?? '';
 
+  const isFormComplete =
+    !!typeValue && !!categoryValue && !!titleValue && !!shortDescValue && !!descValue && !!goalValue;
+
   const onSubmit = (data: GatheringForm) => {
     mutate(data, {
-      onSuccess: (response) => {
+      onSuccess: () => {
         showToast({ variant: 'success', title: '모임이 생성되었습니다.' });
-        router.push(`/gatherings/${response.gathering.id}`);
       },
       onError: () => {
         showToast({ variant: 'error', title: '모임 생성에 실패했습니다.' });
@@ -55,7 +70,7 @@ export function CreateGatheringForm() {
     <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
       {/* 모임 유형 */}
       <section className='flex flex-col gap-3'>
-        <p className='text-sm font-bold text-gray-900'>
+        <p className='text-h5-b text-gray-800'>
           모임 유형 <span className='text-blue-400'>*</span>
         </p>
         <Controller
@@ -65,21 +80,25 @@ export function CreateGatheringForm() {
             <div className='flex gap-4'>
               {GATHERING_TYPES.map((type) => {
                 const isSelected = field.value === type;
+                const { subtitle, Icon } = TYPE_META[type];
                 return (
-                  <button
+                  <Card
                     key={type}
-                    type='button'
-                    onClick={() => field.onChange(type)}
                     className={cn(
-                      'flex items-center gap-2 rounded-xl border px-6 py-4 text-sm font-semibold transition-colors',
-                      isSelected
-                        ? 'border-blue-400 text-blue-400'
-                        : 'border-gray-200 text-gray-600 hover:border-gray-300',
+                      'flex h-40 flex-1 cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none',
+                      isSelected ? 'border-focus-100 bg-blue-50' : 'border-gray-300 bg-gray-100',
                     )}
+                    onClick={() => field.onChange(type)}
                   >
-                    {isSelected && <CheckIcon size={20} />}
-                    {type}
-                  </button>
+                    <CheckIcon size={56} className={isSelected ? 'text-blue-300' : 'text-gray-300'} />
+                    <div className='flex flex-1 flex-col gap-1'>
+                      <span className={cn('text-h4-b', isSelected ? 'text-blue-300' : 'text-gray-600')}>{type}</span>
+                      <span className={cn('text-body-01-r', isSelected ? 'text-blue-300' : 'text-gray-300')}>
+                        {subtitle}
+                      </span>
+                    </div>
+                    {isSelected && <Icon size={56} className='text-blue-300' />}
+                  </Card>
                 );
               })}
             </div>
@@ -94,111 +113,135 @@ export function CreateGatheringForm() {
 
       {/* 기본 정보 */}
       <section className='flex flex-col gap-4'>
-        <p className='text-sm font-bold text-gray-900'>
+        <p className='text-h5-b text-gray-800'>
           기본 정보 <span className='text-blue-400'>*</span>
         </p>
-        <div className='flex flex-col gap-1'>
-          <Input
-            label={<>모임 제목</>}
-            maxLength={30}
-            placeholder='제목을 입력하세요'
-            error={errors.title?.message}
-            {...register('title')}
-          />
-          <p className='self-end text-xs text-gray-400'>{titleValue.length}/30</p>
-        </div>
-        <Controller
-          name='category'
-          control={control}
-          render={({ field }) => (
-            <div className='flex flex-col gap-1.5'>
-              <p className='text-sm font-bold text-gray-900'>
-                카테고리 <span className='text-blue-400'>*</span>
-              </p>
-              <Dropdown className='w-full **:[[role=listbox]]:w-full *:[button]:w-full'>
-                <Dropdown.Trigger>
-                  <div className='flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm'>
-                    <span className={cn(field.value ? 'text-gray-900' : 'text-gray-400')}>
-                      {field.value ?? '카테고리를 선택해 주세요'}
-                    </span>
-                  </div>
-                </Dropdown.Trigger>
-                <Dropdown.Menu className='w-full p-2'>
-                  {GATHERING_CATEGORIES.map((cat) => (
-                    <Dropdown.Item
-                      key={cat}
-                      onClick={() => field.onChange(cat)}
+        <div className='flex gap-4'>
+          <div className='flex flex-1 flex-col gap-1'>
+            <Input
+              label={<span className='text-body-01-m text-gray-800'>모임 제목</span>}
+              maxLength={30}
+              placeholder='제목을 입력하세요'
+              error={errors.title?.message}
+              {...register('title')}
+              className='text-body-01-r'
+            />
+            <p className='text-small-02-r self-end text-gray-400'>{titleValue.length}/30</p>
+          </div>
+          <Controller
+            name='category'
+            control={control}
+            render={({ field }) => (
+              <div className='flex flex-1 flex-col gap-1.5'>
+                <p className='text-body-01-m text-gray-800'>카테고리</p>
+                <Dropdown className='flex w-full flex-col'>
+                  <Dropdown.Trigger>
+                    <div
                       className={cn(
-                        'cursor-pointer rounded-lg px-4 py-3 text-sm hover:bg-blue-100 hover:text-blue-400',
-                        field.value === cat && 'bg-blue-100 text-blue-400',
+                        'flex w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3',
+                        field.value ? 'border-gradient-primary' : 'border border-gray-200',
                       )}
                     >
-                      {cat}
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Menu>
-              </Dropdown>
-              {errors.category && (
-                <p className='text-xs text-red-200' role='alert'>
-                  {errors.category.message}
-                </p>
-              )}
-            </div>
-          )}
-        />
+                      <div className='flex items-center gap-2'>
+                        <CategoryIcon size={28} />
+                        <span className={cn('text-body-01-r', field.value ? 'text-gray-900' : 'text-gray-400')}>
+                          {field.value ?? '카테고리를 선택해주세요'}
+                        </span>
+                      </div>
+                      <RotatingArrow />
+                    </div>
+                  </Dropdown.Trigger>
+                  <Dropdown.Menu
+                    containerClassName='w-full'
+                    className='custom-scrollbar max-h-[240px] w-full overflow-y-auto rounded-lg border border-blue-100 bg-white p-2'
+                  >
+                    {GATHERING_CATEGORIES.map((cat) => (
+                      <Dropdown.Item
+                        key={cat}
+                        onClick={() => field.onChange(cat)}
+                        className={cn(
+                          'cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+                          field.value === cat && 'bg-blue-100 text-blue-400',
+                        )}
+                      >
+                        {cat}
+                      </Dropdown.Item>
+                    ))}
+                  </Dropdown.Menu>
+                </Dropdown>
+                {errors.category && (
+                  <p className='text-xs text-red-200' role='alert'>
+                    {errors.category.message}
+                  </p>
+                )}
+              </div>
+            )}
+          />
+        </div>
       </section>
 
       {/* 한 줄 소개 */}
       <div className='flex flex-col gap-1'>
-        <p className='text-sm font-bold text-gray-900'>한 줄 소개</p>
-        <Textarea
-          maxLength={50}
-          placeholder='소개를 적어주세요'
-          error={errors.shortDescription?.message}
-          {...register('shortDescription')}
-        />
-        <p className='self-end text-xs text-gray-400'>{shortDescValue.length}/50</p>
+        <div className='flex flex-1 flex-col gap-1'>
+          <Input
+            label={<span className='text-body-01-m text-gray-800'>한 줄 소개</span>}
+            maxLength={50}
+            placeholder='소개를 적어주세요'
+            error={errors.shortDescription?.message}
+            {...register('shortDescription')}
+            className='text-body-01-r'
+          />
+          <p className='text-small-02-r self-end text-gray-400'>{shortDescValue.length}/50</p>
+        </div>
       </div>
 
       {/* 상세 설명 */}
       <div className='flex flex-col gap-1'>
-        <p className='text-sm font-bold text-gray-900'>상세 설명</p>
+        <p className='text-body-01-m text-gray-800'>상세 설명</p>
         <Textarea
           maxLength={1000}
           rows={8}
           placeholder='모임을 설명을 상세히 적어주세요'
           error={errors.description?.message}
           {...register('description')}
+          className='text-body-01-r'
         />
-        <p className='self-end text-xs text-gray-400'>{descValue.length}/1000</p>
+        <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
       </div>
 
       {/* 모임 최종 목표 */}
       <div className='flex flex-col gap-1'>
         <Input
           label={
-            <>
+            <span className='text-h5-b text-gray-800'>
               모임 최종 목표 <span className='text-blue-400'>*</span>
-            </>
+            </span>
           }
           maxLength={200}
           placeholder='모임의 최종 목표를 적어주세요'
           error={errors.goal?.message}
           {...register('goal')}
+          className='text-body-01-r'
         />
-        <p className='self-end text-xs text-gray-400'>{goalValue.length}/200</p>
+        <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
       </div>
 
-      {/* 태그 — 후속 이슈 (SM-95~97) */}
+      {/* 태그 */}
       <div />
 
-      {/* 이미지 — 후속 이슈 (SM-95~97) */}
+      {/* 이미지 */}
       <div />
 
-      {/* 날짜/일정 — 후속 이슈 (SM-95~97) */}
+      {/* 날짜/일정 */}
       <div />
 
-      <Button type='submit' variant='action' size='action' disabled={isPending} className='w-full'>
+      <Button
+        type='submit'
+        variant='action'
+        size='action-sm'
+        disabled={isPending || !isFormComplete}
+        className='self-end'
+      >
         작성 완료
       </Button>
     </form>

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Button } from '@/components/ui/Button';
+import { Dropdown } from '@/components/ui/Dropdown';
+import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { useCreateGathering } from '@/api/gatherings/queries';
+import { gatheringFormSchema } from '@/api/gatherings/schemas';
+import { GATHERING_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
+import { cn } from '@/lib/cn';
+
+import type { GatheringForm } from '@/api/gatherings/types';
+
+export function CreateGatheringForm() {
+  const router = useRouter();
+  const showToast = useToastStore((state) => state.showToast);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors },
+  } = useForm<GatheringForm>({
+    resolver: zodResolver(gatheringFormSchema),
+    mode: 'onBlur',
+  });
+
+  const { mutate, isPending } = useCreateGathering();
+
+  const titleValue = watch('title') ?? '';
+  const shortDescValue = watch('shortDescription') ?? '';
+  const descValue = watch('description') ?? '';
+  const goalValue = watch('goal') ?? '';
+
+  const onSubmit = (data: GatheringForm) => {
+    mutate(data, {
+      onSuccess: (response) => {
+        showToast({ variant: 'success', title: '모임이 생성되었습니다.' });
+        router.push(`/gatherings/${response.gathering.id}`);
+      },
+      onError: () => {
+        showToast({ variant: 'error', title: '모임 생성에 실패했습니다.' });
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
+      {/* 모임 유형 */}
+      <section className='flex flex-col gap-3'>
+        <p className='text-sm font-bold text-gray-900'>
+          모임 유형 <span className='text-blue-400'>*</span>
+        </p>
+        <Controller
+          name='type'
+          control={control}
+          render={({ field }) => (
+            <div className='flex gap-4'>
+              {GATHERING_TYPES.map((type) => {
+                const isSelected = field.value === type;
+                return (
+                  <button
+                    key={type}
+                    type='button'
+                    onClick={() => field.onChange(type)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-xl border px-6 py-4 text-sm font-semibold transition-colors',
+                      isSelected
+                        ? 'border-blue-400 text-blue-400'
+                        : 'border-gray-200 text-gray-600 hover:border-gray-300',
+                    )}
+                  >
+                    {isSelected && <CheckIcon size={20} />}
+                    {type}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        />
+        {errors.type && (
+          <p className='text-xs text-red-200' role='alert'>
+            {errors.type.message}
+          </p>
+        )}
+      </section>
+
+      {/* 기본 정보 */}
+      <section className='flex flex-col gap-4'>
+        <p className='text-sm font-bold text-gray-900'>
+          기본 정보 <span className='text-blue-400'>*</span>
+        </p>
+        <div className='flex flex-col gap-1'>
+          <Input
+            label={<>모임 제목</>}
+            maxLength={30}
+            placeholder='제목을 입력하세요'
+            error={errors.title?.message}
+            {...register('title')}
+          />
+          <p className='self-end text-xs text-gray-400'>{titleValue.length}/30</p>
+        </div>
+        <Controller
+          name='category'
+          control={control}
+          render={({ field }) => (
+            <div className='flex flex-col gap-1.5'>
+              <p className='text-sm font-bold text-gray-900'>
+                카테고리 <span className='text-blue-400'>*</span>
+              </p>
+              <Dropdown className='w-full **:[[role=listbox]]:w-full *:[button]:w-full'>
+                <Dropdown.Trigger>
+                  <div className='flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm'>
+                    <span className={cn(field.value ? 'text-gray-900' : 'text-gray-400')}>
+                      {field.value ?? '카테고리를 선택해 주세요'}
+                    </span>
+                  </div>
+                </Dropdown.Trigger>
+                <Dropdown.Menu className='w-full p-2'>
+                  {GATHERING_CATEGORIES.map((cat) => (
+                    <Dropdown.Item
+                      key={cat}
+                      onClick={() => field.onChange(cat)}
+                      className={cn(
+                        'cursor-pointer rounded-lg px-4 py-3 text-sm hover:bg-blue-100 hover:text-blue-400',
+                        field.value === cat && 'bg-blue-100 text-blue-400',
+                      )}
+                    >
+                      {cat}
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+              </Dropdown>
+              {errors.category && (
+                <p className='text-xs text-red-200' role='alert'>
+                  {errors.category.message}
+                </p>
+              )}
+            </div>
+          )}
+        />
+      </section>
+
+      {/* 한 줄 소개 */}
+      <div className='flex flex-col gap-1'>
+        <p className='text-sm font-bold text-gray-900'>한 줄 소개</p>
+        <Textarea
+          maxLength={50}
+          placeholder='소개를 적어주세요'
+          error={errors.shortDescription?.message}
+          {...register('shortDescription')}
+        />
+        <p className='self-end text-xs text-gray-400'>{shortDescValue.length}/50</p>
+      </div>
+
+      {/* 상세 설명 */}
+      <div className='flex flex-col gap-1'>
+        <p className='text-sm font-bold text-gray-900'>상세 설명</p>
+        <Textarea
+          maxLength={1000}
+          rows={8}
+          placeholder='모임을 설명을 상세히 적어주세요'
+          error={errors.description?.message}
+          {...register('description')}
+        />
+        <p className='self-end text-xs text-gray-400'>{descValue.length}/1000</p>
+      </div>
+
+      {/* 모임 최종 목표 */}
+      <div className='flex flex-col gap-1'>
+        <Input
+          label={
+            <>
+              모임 최종 목표 <span className='text-blue-400'>*</span>
+            </>
+          }
+          maxLength={200}
+          placeholder='모임의 최종 목표를 적어주세요'
+          error={errors.goal?.message}
+          {...register('goal')}
+        />
+        <p className='self-end text-xs text-gray-400'>{goalValue.length}/200</p>
+      </div>
+
+      {/* 태그 — 후속 이슈 (SM-95~97) */}
+      <div />
+
+      {/* 이미지 — 후속 이슈 (SM-95~97) */}
+      <div />
+
+      {/* 날짜/일정 — 후속 이슈 (SM-95~97) */}
+      <div />
+
+      <Button type='submit' variant='action' size='action' disabled={isPending} className='w-full'>
+        작성 완료
+      </Button>
+    </form>
+  );
+}

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { type ReactNode } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -21,7 +22,29 @@ import type { GatheringForm } from '@/api/gatherings/types';
 
 const RotatingArrow = () => {
   const { isOpen } = useDropdown();
-  return <ArrowIcon className={cn('rotate-90 transition-transform duration-200', isOpen ? '-rotate-90' : '')} />;
+  return (
+    <ArrowIcon
+      className={cn(
+        'size-4 rotate-90 transition-transform duration-200 md:size-6 lg:size-7',
+        isOpen ? '-rotate-90' : '',
+      )}
+    />
+  );
+};
+
+// 드롭다운이 열려있을 때만 gradient 테두리, 닫히면 grayscale로 복귀
+const CategoryTriggerBorder = ({ children }: { children: ReactNode }) => {
+  const { isOpen } = useDropdown();
+  return (
+    <div
+      className={cn(
+        'flex w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3 transition-colors duration-200',
+        isOpen ? 'border-gradient-primary' : 'border border-gray-200',
+      )}
+    >
+      {children}
+    </div>
+  );
 };
 
 const TYPE_META = {
@@ -70,14 +93,14 @@ export function CreateGatheringForm() {
     <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
       {/* 모임 유형 */}
       <section className='flex flex-col gap-3'>
-        <p className='text-h5-b text-gray-800'>
+        <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
           모임 유형 <span className='text-blue-400'>*</span>
         </p>
         <Controller
           name='type'
           control={control}
           render={({ field }) => (
-            <div className='flex gap-4'>
+            <div className='flex flex-col gap-4 md:flex-row'>
               {GATHERING_TYPES.map((type) => {
                 const isSelected = field.value === type;
                 const { subtitle, Icon } = TYPE_META[type];
@@ -85,19 +108,35 @@ export function CreateGatheringForm() {
                   <Card
                     key={type}
                     className={cn(
-                      'flex h-40 flex-1 cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none',
+                      'flex h-40 cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none',
+                      'h-[85px]',
+                      'md:h-40 md:w-auto md:flex-1 md:gap-6 md:px-8',
                       isSelected ? 'border-focus-100 bg-blue-50' : 'border-gray-300 bg-gray-100',
                     )}
                     onClick={() => field.onChange(type)}
                   >
-                    <CheckIcon size={56} className={isSelected ? 'text-blue-300' : 'text-gray-300'} />
+                    <CheckIcon
+                      className={cn('size-8 md:size-10 lg:size-14', isSelected ? 'text-blue-300' : 'text-gray-300')}
+                    />
                     <div className='flex flex-1 flex-col gap-1'>
-                      <span className={cn('text-h4-b', isSelected ? 'text-blue-300' : 'text-gray-600')}>{type}</span>
-                      <span className={cn('text-body-01-r', isSelected ? 'text-blue-300' : 'text-gray-300')}>
+                      <span
+                        className={cn(
+                          'text-body-02-sb md:text-h5-b lg:text-h4-b',
+                          isSelected ? 'text-blue-300' : 'text-gray-600',
+                        )}
+                      >
+                        {type}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-small-02-r md:text-body-02-r lg:text-body-01-r',
+                          isSelected ? 'text-blue-300' : 'text-gray-300',
+                        )}
+                      >
                         {subtitle}
                       </span>
                     </div>
-                    {isSelected && <Icon size={56} className='text-blue-300' />}
+                    {isSelected && <Icon className='size-9 text-blue-300 md:size-12 lg:size-14' />}
                   </Card>
                 );
               })}
@@ -113,18 +152,20 @@ export function CreateGatheringForm() {
 
       {/* 기본 정보 */}
       <section className='flex flex-col gap-4'>
-        <p className='text-h5-b text-gray-800'>
+        <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
           기본 정보 <span className='text-blue-400'>*</span>
         </p>
-        <div className='flex gap-4'>
-          <div className='flex flex-1 flex-col gap-1'>
+        <div className='flex flex-col gap-4 lg:flex-row'>
+          <div className='flex w-full flex-col gap-1 lg:flex-1'>
             <Input
-              label={<span className='text-body-01-m text-gray-800'>모임 제목</span>}
+              label={
+                <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 제목</span>
+              }
               maxLength={30}
               placeholder='제목을 입력하세요'
               error={errors.title?.message}
               {...register('title')}
-              className='text-body-01-r'
+              className='text-small-02-rmd:text-body-02-r lg:text-body-01-r'
             />
             <p className='text-small-02-r self-end text-gray-400'>{titleValue.length}/30</p>
           </div>
@@ -132,24 +173,24 @@ export function CreateGatheringForm() {
             name='category'
             control={control}
             render={({ field }) => (
-              <div className='flex flex-1 flex-col gap-1.5'>
-                <p className='text-body-01-m text-gray-800'>카테고리</p>
+              <div className='flex w-full flex-col gap-1.5 lg:flex-1'>
+                <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>카테고리</p>
                 <Dropdown className='flex w-full flex-col'>
                   <Dropdown.Trigger>
-                    <div
-                      className={cn(
-                        'flex w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3',
-                        field.value ? 'border-gradient-primary' : 'border border-gray-200',
-                      )}
-                    >
+                    <CategoryTriggerBorder>
                       <div className='flex items-center gap-2'>
-                        <CategoryIcon size={28} />
-                        <span className={cn('text-body-01-r', field.value ? 'text-gray-900' : 'text-gray-400')}>
+                        <CategoryIcon className='size-4 md:size-6 lg:size-7' />
+                        <span
+                          className={cn(
+                            'text-small-02-r md:text-body-02-r lg:text-body-01-r',
+                            field.value ? 'text-gray-900' : 'text-gray-400',
+                          )}
+                        >
                           {field.value ?? '카테고리를 선택해주세요'}
                         </span>
                       </div>
                       <RotatingArrow />
-                    </div>
+                    </CategoryTriggerBorder>
                   </Dropdown.Trigger>
                   <Dropdown.Menu
                     containerClassName='w-full'
@@ -184,12 +225,14 @@ export function CreateGatheringForm() {
       <div className='flex flex-col gap-1'>
         <div className='flex flex-1 flex-col gap-1'>
           <Input
-            label={<span className='text-body-01-m text-gray-800'>한 줄 소개</span>}
+            label={
+              <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>한 줄 소개</span>
+            }
             maxLength={50}
             placeholder='소개를 적어주세요'
             error={errors.shortDescription?.message}
             {...register('shortDescription')}
-            className='text-body-01-r'
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
           />
           <p className='text-small-02-r self-end text-gray-400'>{shortDescValue.length}/50</p>
         </div>
@@ -197,14 +240,14 @@ export function CreateGatheringForm() {
 
       {/* 상세 설명 */}
       <div className='flex flex-col gap-1'>
-        <p className='text-body-01-m text-gray-800'>상세 설명</p>
+        <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>상세 설명</p>
         <Textarea
           maxLength={1000}
           rows={8}
           placeholder='모임을 설명을 상세히 적어주세요'
           error={errors.description?.message}
           {...register('description')}
-          className='text-body-01-r'
+          className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-4 py-3'
         />
         <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
       </div>
@@ -213,7 +256,7 @@ export function CreateGatheringForm() {
       <div className='flex flex-col gap-1'>
         <Input
           label={
-            <span className='text-h5-b text-gray-800'>
+            <span className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
               모임 최종 목표 <span className='text-blue-400'>*</span>
             </span>
           }
@@ -221,7 +264,7 @@ export function CreateGatheringForm() {
           placeholder='모임의 최종 목표를 적어주세요'
           error={errors.goal?.message}
           {...register('goal')}
-          className='text-body-01-r'
+          className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
         />
         <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
       </div>
@@ -240,7 +283,7 @@ export function CreateGatheringForm() {
         variant='action'
         size='action-sm'
         disabled={isPending || !isFormComplete}
-        className='self-end'
+        className='text-small-01-sb md:text-body-01-sb h-12 w-[164px] self-end md:h-[72px] md:w-75 lg:h-20'
       >
         작성 완료
       </Button>

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -14,11 +14,11 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { useCreateGathering } from '@/api/gatherings/queries';
-import { gatheringFormSchema } from '@/api/gatherings/schemas';
+import { gatheringFormPartialSchema, gatheringFormSchema } from '@/api/gatherings/schemas';
 import { GATHERING_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 
-import type { GatheringForm } from '@/api/gatherings/types';
+import type { GatheringForm, GatheringFormPartial } from '@/api/gatherings/types';
 
 const RotatingArrow = () => {
   const { isOpen } = useDropdown();
@@ -61,8 +61,8 @@ export function CreateGatheringForm() {
     control,
     watch,
     formState: { errors },
-  } = useForm<GatheringForm>({
-    resolver: zodResolver(gatheringFormSchema),
+  } = useForm<GatheringFormPartial>({
+    resolver: zodResolver(gatheringFormPartialSchema),
     mode: 'onBlur',
   });
 
@@ -78,8 +78,8 @@ export function CreateGatheringForm() {
   const isFormComplete =
     !!typeValue && !!categoryValue && !!titleValue && !!shortDescValue && !!descValue && !!goalValue;
 
-  const onSubmit = (data: GatheringForm) => {
-    mutate(data, {
+  const onSubmit = (data: GatheringFormPartial) => {
+    mutate(data as GatheringForm, {
       onSuccess: () => {
         showToast({ variant: 'success', title: '모임이 생성되었습니다.' });
         // 리다이렉트
@@ -166,7 +166,7 @@ export function CreateGatheringForm() {
               placeholder='제목을 입력하세요'
               error={errors.title?.message}
               {...register('title')}
-              className='text-small-02-rmd:text-body-02-r lg:text-body-01-r'
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
             />
             <p className='text-small-02-r self-end text-gray-400'>{titleValue.length}/30</p>
           </div>

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -3,7 +3,7 @@ import { CreateGatheringForm } from './CreateGatheringForm';
 export default function CreateGatheringPage() {
   return (
     <main className='mx-auto max-w-[1000px] px-4 py-20'>
-      <h1 className='text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
+      <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
       <CreateGatheringForm />
     </main>
   );

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -2,7 +2,7 @@ import { CreateGatheringForm } from './CreateGatheringForm';
 
 export default function CreateGatheringPage() {
   return (
-    <main className='mx-auto max-w-[800px] px-4 py-10'>
+    <main className='mx-auto max-w-[1000px] px-4 py-20'>
       <h1 className='text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
       <CreateGatheringForm />
     </main>

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -1,0 +1,10 @@
+import { CreateGatheringForm } from './CreateGatheringForm';
+
+export default function CreateGatheringPage() {
+  return (
+    <main className='mx-auto max-w-[800px] px-4 py-10'>
+      <h1 className='text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
+      <CreateGatheringForm />
+    </main>
+  );
+}

--- a/src/components/ui/Card/index.stories.tsx
+++ b/src/components/ui/Card/index.stories.tsx
@@ -1,8 +1,12 @@
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 import { Button } from '@/components/ui/Button';
+import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
 import { HeartIcon, PeopleIcon, ProjectIcon, StudyIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
+import { cn } from '@/lib/cn';
 
 import { Card } from '.';
 
@@ -113,5 +117,58 @@ export const GatheringCardExample: Story = {
         </div>
       </div>
     ),
+  },
+};
+
+export const GatheringTypeSelect: Story = {
+  name: '모임 유형 선택 카드',
+  args: { children: null },
+  render: () => {
+    const [selected, setSelected] = useState<'study' | 'project' | null>(null);
+
+    const toggle = (type: 'study' | 'project') => {
+      setSelected((prev) => (prev === type ? null : type));
+    };
+
+    const isStudySelected = selected === 'study';
+    const isProjectSelected = selected === 'project';
+
+    return (
+      <div className='flex flex-col gap-4'>
+        <Card
+          className={cn(
+            'flex h-[160px] w-[828px] cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none',
+            isStudySelected ? 'border-focus-100 bg-blue-50' : 'border-gray-300 bg-gray-100',
+          )}
+          onClick={() => toggle('study')}
+        >
+          <CheckIcon size={56} className={isStudySelected ? 'text-blue-300' : 'text-gray-300'} />
+          <div className='flex flex-1 flex-col gap-1'>
+            <span className={cn('text-h4-b', isStudySelected ? 'text-blue-300' : 'text-gray-600')}>스터디</span>
+            <span className={cn('text-body-01-r', isStudySelected ? 'text-blue-300' : 'text-gray-300')}>
+              함께 학습하고 성장해요
+            </span>
+          </div>
+          {isStudySelected && <StudyIcon size={56} className='text-blue-300' />}
+        </Card>
+
+        <Card
+          className={cn(
+            'flex h-[160px] w-[828px] cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none',
+            isProjectSelected ? 'border-focus-100 bg-blue-50' : 'border-gray-300 bg-gray-100',
+          )}
+          onClick={() => toggle('project')}
+        >
+          <CheckIcon size={56} className={isProjectSelected ? 'text-blue-300' : 'text-gray-300'} />
+          <div className='flex flex-1 flex-col gap-1'>
+            <span className={cn('text-h4-b', isProjectSelected ? 'text-blue-300' : 'text-gray-600')}>프로젝트</span>
+            <span className={cn('text-body-01-r', isProjectSelected ? 'text-blue-300' : 'text-gray-300')}>
+              함께 만들고 완성해요
+            </span>
+          </div>
+          {isProjectSelected && <ProjectIcon size={56} className='text-blue-300' />}
+        </Card>
+      </div>
+    );
   },
 };

--- a/src/components/ui/Dropdown/Menu.tsx
+++ b/src/components/ui/Dropdown/Menu.tsx
@@ -11,9 +11,10 @@ import { useDropdown } from './context';
 interface MenuProps {
   children: ReactNode;
   className?: string;
+  containerClassName?: string;
 }
 
-export function Menu({ children, className }: MenuProps) {
+export function Menu({ children, className, containerClassName }: MenuProps) {
   const menuRef = useRef<HTMLUListElement>(null);
   const { isOpen, close } = useDropdown();
   const [shouldRender, setShouldRender] = useState(isOpen);
@@ -50,7 +51,11 @@ export function Menu({ children, className }: MenuProps) {
     <div
       role='listbox'
       onKeyDown={handleKeyDown}
-      className={cn('absolute z-50 mt-2', isOpen ? 'animate-modal-fade-in' : 'animate-modal-fade-out')}
+      className={cn(
+        'absolute top-full z-50 mt-2',
+        containerClassName,
+        isOpen ? 'animate-modal-fade-in' : 'animate-modal-fade-out',
+      )}
     >
       <ul ref={menuRef} className={cn('shadow-01 rounded-lg border border-blue-100 bg-white', className)}>
         {children}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const PROTECTED_ROUTES = ['/my', '/gathering/create', '/gathering/dashboard'];
+const PROTECTED_ROUTES = ['/my', '/gatherings/new', '/gathering/dashboard'];
 const AUTH_ROUTES = ['/login', '/register'];
 
 export const proxy = (request: NextRequest) => {


### PR DESCRIPTION
## ❓ 이슈

- close #133 

## ✍️ Description
`/gatherings/new` 페이지의 기본 폼 골격을 구현했습니다.
후속 이슈에서 추가될 컴포넌트(태그, 이미지, 날짜/일정)들이 조립될 수 있도록 섹션 구조를 잡았습니다.
### 작업 내용
**`src/app/gatherings/new/page.tsx`**
- 서버 컴포넌트로 구성
**`CreateGatheringForm/index.tsx`**
- `react-hook-form` + `zodResolver` 기반 폼 설정 (`gatheringFormSchema` 활용)
- `useCreateGathering` mutation 연결 — 제출 시 Toast 메시지 표시 및 리다이렉트 처리
**모임 유형 선택 (TypeSelector)**
- 스터디 / 프로젝트 카드 UI 구현 (`CheckIcon` 활용)
**기본 정보 섹션**
- 모임 제목 (Input, 최대 30자)
- 카테고리 (Dropdown)
**소개 / 설명 섹션**
- 한 줄 소개 (Textarea, 최대 50자)
- 상세 설명 (Textarea, 최대 1000자)
**모임 최종 목표**
- Input, 최대 200자
**공통 UX**
- 글자 수 카운터 표시
- 필수 필드 파란색 라벨 표시
- 작성 완료 버튼 (`Button` variant: `'action'`)
**`src/proxy.ts`**
- `PROTECTED_ROUTES`에 `/gatherings/new` 경로 추가
> ⚠️ 태그, 이미지, 날짜/일정 섹션은 자리만 비워뒀으며 후속 이슈에서 구현 예정입니다.


## 📸 스크린샷 (UI 변경 시)
### PC
<img width="1276" height="1476" alt="화면 캡처 2026-03-31 171456" src="https://github.com/user-attachments/assets/2e5fb26a-07c9-4fc9-9c3a-a5ea9bbf3237" />

### Tablet
<img width="990" height="1380" alt="화면 캡처 2026-03-31 171616" src="https://github.com/user-attachments/assets/b64241d8-4086-4446-8462-304f4a4cafea" />

### Mobile
<img width="442" height="1146" alt="화면 캡처 2026-03-31 171815" src="https://github.com/user-attachments/assets/53782942-c944-45b3-af51-15f3211a501c" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

