### PR TITLE
[SM-103] feat: 모임 만들기 페이지 태그 입력 섹션 구현

### DIFF
--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -42,5 +42,6 @@ export const gatheringFormPartialSchema = z.object({
   title: z.string().min(1, '모임 제목을 입력해 주세요. ').max(30, '제목은 최대 30자까지 가능합니다.'),
   shortDescription: z.string().min(1, '한 줄 소개를 입력해 주세요.').max(50, '한 줄 소개는 최대 50자까지 가능합니다.'),
   description: z.string().min(1, '상세 소개를 입력해 주세요.').max(1000, '상세 설명은 최대 1000자까지 가능합니다.'),
+  tags: z.array(z.string()).min(1, '최소 1개의 태그를 입력해 주세요.').max(5, '태그는 최대 5개까지 가능합니다.'),
   goal: z.string().min(1, '모임 목표를 입력해 주세요.').max(200, '모임 목표는 최대 200자까지 가능합니다.'),
 });

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -2,19 +2,22 @@
 
 import { useState } from 'react';
 
-import { Input } from '@/components/ui/Input';
+import { fieldGradientFocusWrapperClass } from '@/components/ui/fieldControlVariants';
 import { Tag } from '@/components/ui/Tag';
+import { cn } from '@/lib/cn';
 
 const MAX_TAGS = 5;
 
 interface TagInputProps {
   value: string[];
   onChange: (tags: string[]) => void;
+  onBlur?: () => void;
   error?: string;
 }
 
-export function TagInput({ value, onChange, error }: TagInputProps) {
+export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
   const [inputValue, setInputValue] = useState('');
+  const hasError = !!error;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Enter') return;
@@ -24,6 +27,7 @@ export function TagInput({ value, onChange, error }: TagInputProps) {
     const isDuplicate = value.includes(trimmed);
     const isAtLimit = value.length >= MAX_TAGS;
 
+    // 빈 값, 중복, 최대 개수 초과 시 silently 무시
     if (!trimmed || isDuplicate || isAtLimit) return;
 
     onChange([...value, trimmed]);
@@ -35,18 +39,14 @@ export function TagInput({ value, onChange, error }: TagInputProps) {
   };
 
   return (
-    <div className='flex flex-col gap-2'>
-      <Input
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder='태그를 입력하고 Enter를 누르세요'
-        disabled={value.length >= MAX_TAGS}
-        error={error}
-        className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
-      />
-      {value.length > 0 && (
-        <div className='flex flex-wrap gap-2'>
+    <div className='flex flex-col gap-1.5'>
+      <div className={hasError ? 'bg-gray-0 rounded-md border border-red-200' : fieldGradientFocusWrapperClass}>
+        <div
+          className={cn(
+            'flex flex-wrap items-center gap-2 px-3 py-2',
+            !hasError && 'rounded-[calc(0.375rem-1px)] bg-gray-50',
+          )}
+        >
           {value.map((tag) => (
             <Tag
               key={tag}
@@ -57,7 +57,21 @@ export function TagInput({ value, onChange, error }: TagInputProps) {
               #{tag}
             </Tag>
           ))}
+          <input
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={value.length === 0 ? '태그를 입력해주세요 (최대 5개)' : ''}
+            disabled={value.length >= MAX_TAGS}
+            onBlur={onBlur}
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r min-w-0 flex-1 bg-transparent outline-none placeholder:text-gray-400'
+          />
         </div>
+      </div>
+      {error && (
+        <p className='text-xs text-red-200' role='alert'>
+          {error}
+        </p>
       )}
     </div>
   );

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Input } from '@/components/ui/Input';
+import { Tag } from '@/components/ui/Tag';
+
+const MAX_TAGS = 5;
+
+interface TagInputProps {
+  value: string[];
+  onChange: (tags: string[]) => void;
+  error?: string;
+}
+
+export function TagInput({ value, onChange, error }: TagInputProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+
+    const trimmed = inputValue.trim();
+    const isDuplicate = value.includes(trimmed);
+    const isAtLimit = value.length >= MAX_TAGS;
+
+    if (!trimmed || isDuplicate || isAtLimit) return;
+
+    onChange([...value, trimmed]);
+    setInputValue('');
+  };
+
+  const handleRemove = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <Input
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder='태그를 입력하고 Enter를 누르세요'
+        disabled={value.length >= MAX_TAGS}
+        error={error}
+        className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
+      />
+      {value.length > 0 && (
+        <div className='flex flex-wrap gap-2'>
+          {value.map((tag) => (
+            <Tag key={tag} variant='hashtag' onRemove={() => handleRemove(tag)}>
+              #{tag}
+            </Tag>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -48,7 +48,12 @@ export function TagInput({ value, onChange, error }: TagInputProps) {
       {value.length > 0 && (
         <div className='flex flex-wrap gap-2'>
           {value.map((tag) => (
-            <Tag key={tag} variant='hashtag' onRemove={() => handleRemove(tag)}>
+            <Tag
+              key={tag}
+              variant='hashtag'
+              onRemove={() => handleRemove(tag)}
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-2 py-0.5 md:px-2.5 md:py-1 lg:px-3 lg:py-1'
+            >
               #{tag}
             </Tag>
           ))}

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { useCreateGathering } from '@/api/gatherings/queries';
-import { gatheringFormPartialSchema, gatheringFormSchema } from '@/api/gatherings/schemas';
+import { gatheringFormPartialSchema } from '@/api/gatherings/schemas';
 import { GATHERING_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 
@@ -66,6 +66,9 @@ export function CreateGatheringForm() {
   } = useForm<GatheringFormPartial>({
     resolver: zodResolver(gatheringFormPartialSchema),
     mode: 'onBlur',
+    defaultValues: {
+      tags: [],
+    },
   });
 
   const { mutate, isPending } = useCreateGathering();
@@ -269,7 +272,12 @@ export function CreateGatheringForm() {
           name='tags'
           control={control}
           render={({ field }) => (
-            <TagInput value={field.value ?? []} onChange={field.onChange} error={errors.tags?.message} />
+            <TagInput
+              value={field.value ?? []}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              error={errors.tags?.root?.message ?? errors.tags?.message}
+            />
           )}
         />
       </div>

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -18,6 +18,8 @@ import { gatheringFormPartialSchema, gatheringFormSchema } from '@/api/gathering
 import { GATHERING_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 
+import { TagInput } from './TagInput';
+
 import type { GatheringForm, GatheringFormPartial } from '@/api/gatherings/types';
 
 const RotatingArrow = () => {
@@ -74,9 +76,16 @@ export function CreateGatheringForm() {
   const shortDescValue = watch('shortDescription') ?? '';
   const descValue = watch('description') ?? '';
   const goalValue = watch('goal') ?? '';
+  const tagsValue = watch('tags') ?? [];
 
   const isFormComplete =
-    !!typeValue && !!categoryValue && !!titleValue && !!shortDescValue && !!descValue && !!goalValue;
+    !!typeValue &&
+    !!categoryValue &&
+    !!titleValue &&
+    !!shortDescValue &&
+    !!descValue &&
+    !!goalValue &&
+    tagsValue.length > 0;
 
   const onSubmit = (data: GatheringFormPartial) => {
     mutate(data as GatheringForm, {
@@ -253,6 +262,18 @@ export function CreateGatheringForm() {
         <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
       </div>
 
+      {/* 태그 */}
+      <div className='flex flex-col gap-1'>
+        <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>태그</p>
+        <Controller
+          name='tags'
+          control={control}
+          render={({ field }) => (
+            <TagInput value={field.value ?? []} onChange={field.onChange} error={errors.tags?.message} />
+          )}
+        />
+      </div>
+
       {/* 모임 최종 목표 */}
       <div className='flex flex-col gap-1'>
         <Input
@@ -270,9 +291,6 @@ export function CreateGatheringForm() {
         <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
       </div>
 
-      {/* 태그 */}
-      <div />
-
       {/* 이미지 */}
       <div />
 
@@ -284,7 +302,7 @@ export function CreateGatheringForm() {
         variant='action'
         size='action-sm'
         disabled={isPending || !isFormComplete}
-        className='text-small-01-sb md:text-body-01-sb h-12 w-[164px] self-end md:h-[72px] md:w-75 lg:h-20'
+        className='text-small-01-sb md:text-body-01-sb lg:text-h5-b h-12 w-[164px] self-end md:h-[72px] md:w-75 lg:h-20'
       >
         작성 완료
       </Button>

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -2,7 +2,7 @@ import { CreateGatheringForm } from './CreateGatheringForm';
 
 export default function CreateGatheringPage() {
   return (
-    <main className='mx-auto max-w-[1000px] px-4 py-20'>
+    <main className='mx-auto max-w-[1680px] px-5 py-20'>
       <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
       <CreateGatheringForm />
     </main>


### PR DESCRIPTION
## ❓ 이슈

- close #145 

## ✍️ Description

모임 만들기 폼에 태그 입력 섹션을 구현했습니다.

- `TagInput` 컴포넌트 신규 구현
  - Enter 키로 태그 추가, X 버튼으로 삭제
  - 최대 5개 제한, 중복 입력 silently 무시
  - `Tag variant='hashtag'` + `Input` 활용
  - 해시태그 반응형 크기 적용 (sm/md/lg)
  - 태그 목록을 input 박스 내부에 함께 표시 (피그마 시안 반영)
  - `onBlur` 연결로 포커스 이탈 시 에러 메시지 노출
- `gatheringFormPartialSchema`에 `tags` 필드 추가
- `CreateGatheringForm`에 `Controller`로 `TagInput` 연동
- `isFormComplete` 조건에 태그 추가

## 📸 스크린샷 (UI 변경 시)
<img width="770" height="184" alt="화면 캡처 2026-04-01 111754" src="https://github.com/user-attachments/assets/250a2158-75df-483e-8d08-5ec3ea3f9621" />

<img width="908" height="902" alt="화면 캡처 2026-04-01 111658" src="https://github.com/user-attachments/assets/839c3374-e01e-4604-9070-dcb9c3189360" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [x] ~구현한 태그 부분 섹션을 피그마 디자인과 조금 다르게 구현했는데 일단 태그 입력하는 곳을 비워두고 input 아래에 해시태그가 위치하도록 했습니다(placeholder 내용도 조금 다르게 했습니다!). 피그마 디자인대로 다시 수정하는 게 좋을까요?~
피그마 시안대로 수정 완료

