### PR TITLE
[SM-97] feat: 모임 상세페이지 ApplySection(모임 신청 관련) 구현

### DIFF
--- a/src/api/reviews/index.ts
+++ b/src/api/reviews/index.ts
@@ -6,7 +6,7 @@ import { ApiResponse } from '../common/types';
 /** POST v1/gatherings/:gatheringId/reviews — 리뷰 작성 */
 export const createReviews = async (gatheringId: number, body: CreateReviewsForm): Promise<CreateReviewsResponse> => {
   const { data } = await axiosClient.post<ApiResponse<CreateReviewsResponse>>(
-    `/gatherings/${gatheringId}/reviews`,
+    `v1/gatherings/${gatheringId}/reviews`,
     body,
   );
   return unwrapResponse(data);
@@ -17,6 +17,6 @@ export const getUserReviewList = async (
   userId: number,
   params?: UserReviewsParams,
 ): Promise<UserReviewListResponse> => {
-  const { data } = await axiosClient.get<ApiResponse<UserReviewListResponse>>(`/users/${userId}/reviews`, { params });
+  const { data } = await axiosClient.get<ApiResponse<UserReviewListResponse>>(`v1/users/${userId}/reviews`, { params });
   return unwrapResponse(data);
 };

--- a/src/app/gatherings/[id]/_components/ApplySection/DeadlineLabel/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/DeadlineLabel/index.tsx
@@ -1,4 +1,4 @@
-import { formatDate, MILLISECONDS_IN_A_DAY } from '../InfoAccordion';
+import { formatDate, MILLISECONDS_IN_A_DAY } from '../utils/dateUtils';
 
 interface DeadlineLabelProps {
   recruitDeadline: string;

--- a/src/app/gatherings/[id]/_components/ApplySection/DeadlineLabel/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/DeadlineLabel/index.tsx
@@ -1,0 +1,19 @@
+import { formatDate, MILLISECONDS_IN_A_DAY } from '../InfoAccordion';
+
+interface DeadlineLabelProps {
+  recruitDeadline: string;
+}
+
+export function DeadlineLabel({ recruitDeadline }: DeadlineLabelProps) {
+  const today = new Date();
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+  const deadline = new Date(recruitDeadline);
+  if (Number.isNaN(deadline.getTime())) {
+    return <span>{formatDate(recruitDeadline)}</span>;
+  }
+  const deadlineMidnight = new Date(deadline.getFullYear(), deadline.getMonth(), deadline.getDate());
+  const diffDays = Math.ceil((deadlineMidnight.getTime() - todayMidnight.getTime()) / MILLISECONDS_IN_A_DAY);
+
+  return <span className='text-small-01-sb text-red-200'>D-{Math.max(0, diffDays)}</span>;
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { Button } from '@/components/ui/Button';
@@ -12,10 +12,8 @@ interface FloatingActionBarProps {
 }
 
 export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
-  const { data } = useQuery(gatheringQueries.detail(gatheringId));
+  const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
   const [isFavorite, setIsFavorite] = useState(false);
-
-  if (!data) return null;
 
   return (
     <div className='border-gray-150 bg-gray-0 fixed right-0 bottom-0 left-0 z-50 border-t px-5 py-4 md:px-7 md:py-6 xl:hidden'>
@@ -33,10 +31,10 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
         </Button>
         <Button
           variant='action'
-          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-          disabled={data.myApplicationStatus === 'PENDING'}
+          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data?.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+          disabled={data?.myApplicationStatus === 'PENDING'}
         >
-          {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
+          {data?.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
         </Button>
       </div>
     </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,12 +1,21 @@
 'use client';
 
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 
-export function FloatingActionBar() {
+interface FloatingActionBarProps {
+  gatheringId: number;
+}
+
+export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
+  const { data } = useQuery(gatheringQueries.detail(gatheringId));
   const [isFavorite, setIsFavorite] = useState(false);
+
+  if (!data) return null;
 
   return (
     <div className='border-gray-150 bg-gray-0 fixed right-0 bottom-0 left-0 z-50 border-t px-5 py-4 md:px-7 md:py-6 xl:hidden'>
@@ -22,8 +31,12 @@ export function FloatingActionBar() {
         >
           <HeartIcon size={24} variant={isFavorite ? 'filled' : 'outline'} />
         </Button>
-        <Button variant='action' className='text-body-01-sb h-13.5 flex-1 md:h-18'>
-          참여 신청하기
+        <Button
+          variant='action'
+          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+          disabled={data.myApplicationStatus === 'PENDING'}
+        >
+          {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
         </Button>
       </div>
     </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -31,10 +31,10 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
         </Button>
         <Button
           variant='action'
-          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data?.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-          disabled={data?.myApplicationStatus === 'PENDING'}
+          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+          disabled={data.myApplicationStatus === 'PENDING'}
         >
-          {data?.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
+          {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
         </Button>
       </div>
     </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { HeartIcon } from '@/components/ui/Icon';
+
+export function FloatingActionBar() {
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  return (
+    <div className='border-gray-150 bg-gray-0 fixed right-0 bottom-0 left-0 z-50 border-t px-5 py-4 md:px-7 md:py-6 xl:hidden'>
+      <div className='mx-auto flex items-center gap-3'>
+        <Button
+          variant='bookmark'
+          size='bookmark-lg'
+          data-selected={isFavorite}
+          aria-label='찜하기'
+          aria-pressed={isFavorite}
+          onClick={() => setIsFavorite((prev) => !prev)}
+          className='h-13.5 md:h-18'
+        >
+          <HeartIcon size={24} variant={isFavorite ? 'filled' : 'outline'} />
+        </Button>
+        <Button variant='action' className='text-body-01-sb h-13.5 flex-1 md:h-18'>
+          참여 신청하기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import type { GatheringType } from '@/api/gatherings/types';
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
-import { HeartIcon, StudyIcon, ProjectIcon, PersonIcon } from '@/components/ui/Icon';
+import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
@@ -23,10 +23,8 @@ interface GatheringInfoAsideProps {
 }
 
 export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
-  const { data } = useQuery(gatheringQueries.detail(gatheringId));
+  const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
   const [isFavorite, setIsFavorite] = useState(false);
-
-  if (!data) return null;
 
   const TypeIcon = TYPE_ICON[data.type];
 

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { Button } from '@/components/ui/Button';
+import { GatheringCard } from '@/components/ui/GatheringCard';
+import { HeartIcon, StudyIcon, ProjectIcon, PersonIcon } from '@/components/ui/Icon';
+import { Tag } from '@/components/ui/Tag';
+import { gatheringQueries } from '@/api/gatherings/queries';
+
+import { DeadlineLabel } from '../DeadlineLabel';
+import { InfoAccordion } from '../InfoAccordion';
+import { ParticipantsList } from '../ParticipantsList';
+
+import type { GatheringType } from '@/api/gatherings/types';
+
+const TYPE_ICON: Record<GatheringType, typeof StudyIcon> = {
+  스터디: StudyIcon,
+  프로젝트: ProjectIcon,
+};
+
+interface GatheringInfoAsideProps {
+  gatheringId: number;
+}
+
+export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
+  const { data } = useQuery(gatheringQueries.detail(gatheringId));
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  if (!data) return null;
+
+  const TypeIcon = TYPE_ICON[data.type];
+
+  return (
+    <div className='sticky top-24'>
+      <div className='border-focus-100 mt-15 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+        <div className='text-body-02-sb flex items-center text-blue-400'>모집중</div>
+        <div className='flex items-center gap-2'>
+          <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
+          <Tag variant='day' state='short'>
+            <DeadlineLabel recruitDeadline={data.recruitDeadline} />
+          </Tag>
+        </div>
+      </div>
+      <GatheringCard className='border-focus-100 w-full border'>
+        <GatheringCard.Header className='items-center'>
+          <Tag
+            variant='category'
+            icon={<TypeIcon size={14} className='text-blue-200' />}
+            label={data.type}
+            sublabel={data.category}
+          />
+          <Button
+            variant='bookmark'
+            size='bookmark-sm'
+            data-selected={isFavorite}
+            aria-label='찜하기'
+            aria-pressed={isFavorite}
+            onClick={() => setIsFavorite((prev) => !prev)}
+          >
+            <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+          </Button>
+        </GatheringCard.Header>
+
+        <GatheringCard.Body className='mb-10 gap-2'>
+          <div className='flex flex-wrap gap-1'>
+            {data.tags.map((tag) => (
+              <span key={tag} className='text-body-02-r text-gray-700'>
+                #{tag}
+              </span>
+            ))}
+          </div>
+          <p className='text-body-01-b text-gray-900'>{data.title}</p>
+          <p className='text-small-01-r text-gray-800'>{data.shortDescription}</p>
+        </GatheringCard.Body>
+
+        <GatheringCard.Footer className='flex-col'>
+          <InfoAccordion data={data} className='mb-7' />
+          <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
+        </GatheringCard.Footer>
+
+        <Button variant='action' className='text-h5-b h-16 w-full'>
+          참여 신청하기
+        </Button>
+      </GatheringCard>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -1,20 +1,17 @@
 'use client';
 
 import { useState } from 'react';
-
 import { useQuery } from '@tanstack/react-query';
 
+import { gatheringQueries } from '@/api/gatherings/queries';
+import type { GatheringType } from '@/api/gatherings/types';
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon, PersonIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
-import { gatheringQueries } from '@/api/gatherings/queries';
-
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
-
-import type { GatheringType } from '@/api/gatherings/types';
 
 const TYPE_ICON: Record<GatheringType, typeof StudyIcon> = {
   스터디: StudyIcon,
@@ -81,8 +78,12 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
           <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
         </GatheringCard.Footer>
 
-        <Button variant='action' className='text-h5-b h-16 w-full'>
-          참여 신청하기
+        <Button
+          variant='action'
+          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+          disabled={data.myApplicationStatus === 'PENDING'}
+        >
+          {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
         </Button>
       </GatheringCard>
     </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { Tag } from '@/components/ui/Tag';
@@ -13,9 +13,7 @@ interface GatheringInfoCardProps {
 }
 
 export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
-  const { data } = useQuery(gatheringQueries.detail(gatheringId));
-
-  if (!data) return null;
+  const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
 
   return (
     <section className='xl:hidden'>
@@ -33,7 +31,7 @@ export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
       <InfoAccordion data={data} className='mb-4' />
 
       {/* 참여자 목록 */}
-      <ParticipantsList members={data.members} maxMembers={data.maxMembers} />
+      <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-8' />
     </section>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { Tag } from '@/components/ui/Tag';
+import { gatheringQueries } from '@/api/gatherings/queries';
+
+import { InfoAccordion } from '../InfoAccordion';
+import { ParticipantsList } from '../ParticipantsList';
+import { DeadlineLabel } from '../DeadlineLabel';
+
+interface GatheringInfoCardProps {
+  gatheringId: number;
+}
+
+export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
+  const { data } = useQuery(gatheringQueries.detail(gatheringId));
+
+  if (!data) return null;
+
+  return (
+    <section className='xl:hidden'>
+      <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+        <div className='text-body-02-sb flex items-center text-blue-400'>모집중</div>
+        <div className='flex items-center gap-2'>
+          <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
+          <Tag variant='day' state='short'>
+            <DeadlineLabel recruitDeadline={data.recruitDeadline} />
+          </Tag>
+        </div>
+      </div>
+
+      {/* 모임 정보 아코디언 */}
+      <InfoAccordion data={data} className='mb-4' />
+
+      {/* 참여자 목록 */}
+      <ParticipantsList members={data.members} maxMembers={data.maxMembers} />
+    </section>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
@@ -2,9 +2,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { Tag } from '@/components/ui/Tag';
 import { gatheringQueries } from '@/api/gatherings/queries';
-
+import { Tag } from '@/components/ui/Tag';
 import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
 import { DeadlineLabel } from '../DeadlineLabel';

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/InfoRow.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/InfoRow.tsx
@@ -5,7 +5,7 @@ interface InfoRowProps {
 
 export function InfoRow({ icon, children }: InfoRowProps) {
   return (
-    <li className='text-small-01-r flex items-center gap-4 text-gray-800'>
+    <li className='text-small-01-r flex items-start gap-4 text-gray-800'>
       {icon}
       <span className='text-body-02-m text-gray-700'>{children}</span>
     </li>

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/InfoRow.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/InfoRow.tsx
@@ -1,0 +1,13 @@
+interface InfoRowProps {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function InfoRow({ icon, children }: InfoRowProps) {
+  return (
+    <li className='text-small-01-r flex items-center gap-4 text-gray-800'>
+      {icon}
+      <span className='text-body-02-m text-gray-700'>{children}</span>
+    </li>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
@@ -57,7 +57,7 @@ export function InfoAccordion({ data, defaultOpen = true, className }: InfoAccor
               {formatDate(data.startDate)} ~ {formatDate(data.endDate)} · {weeksLabel}
             </InfoRow>
             <InfoRow icon={<CalendarIcon size={24} className='text-gray-800' />}>
-              <span className='flex gap-1 text-gray-700'>
+              <span className='flex items-center gap-1 text-gray-700'>
                 마감까지 <DeadlineLabel recruitDeadline={data.recruitDeadline} />
               </span>
             </InfoRow>

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { ArrowIcon, CategoryIcon, FlagIcon, CalendarIcon, PersonIcon } from '@/components/ui/Icon';
+import { InfoRow } from './InfoRow';
+import { DeadlineLabel } from '../DeadlineLabel';
+import type { GatheringDetail } from '@/api/gatherings/types';
+
+export const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
+
+export const formatDate = (isoDate: string) => isoDate.slice(0, 10);
+
+const toWeeksLabel = (startDate: string, endDate: string) => {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const diffDays = Math.max(0, Math.ceil((end.getTime() - start.getTime()) / MILLISECONDS_IN_A_DAY));
+  const weeks = Math.max(1, Math.ceil(diffDays / 7));
+  return `${weeks}주`;
+};
+
+interface InfoAccordionProps {
+  data: GatheringDetail;
+  defaultOpen?: boolean;
+  className?: string;
+}
+
+export function InfoAccordion({ data, defaultOpen = true, className }: InfoAccordionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const weeksLabel = toWeeksLabel(data.startDate, data.endDate);
+  console.log(data);
+
+  return (
+    <div className={cn('border-gray-150 overflow-hidden rounded-xl border', className)}>
+      <button
+        type='button'
+        className='text-body-02-sb bg-gray-150 flex w-full items-center justify-between px-5 py-4 text-blue-500 transition-colors hover:bg-gray-50'
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+      >
+        모임 정보
+        <ArrowIcon size={20} className={`rotate-90 text-gray-800 transition-transform ${isOpen ? 'rotate-270' : ''}`} />
+      </button>
+
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-200 ease-in-out',
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        )}
+      >
+        <div className='overflow-hidden'>
+          <ul className='border-gray-150 flex flex-col gap-3 border-t px-5 py-4'>
+            <InfoRow icon={<CategoryIcon size={24} className='text-gray-800' />}>{data.category}</InfoRow>
+            <InfoRow icon={<FlagIcon size={24} className='text-gray-800' />}>{data.goal}</InfoRow>
+            <InfoRow icon={<CalendarIcon size={24} className='text-gray-800' />}>
+              {formatDate(data.startDate)} ~ {formatDate(data.endDate)} · {weeksLabel}
+            </InfoRow>
+            <InfoRow icon={<CalendarIcon size={24} className='text-gray-800' />}>
+              <span className='flex gap-1 text-gray-700'>
+                마감까지 <DeadlineLabel recruitDeadline={data.recruitDeadline} />
+              </span>
+            </InfoRow>
+            <InfoRow icon={<PersonIcon size={24} className='text-gray-800' />}>
+              <span className='text-gray-700'>{data.currentMembers}</span>
+              <span className='text-gray-600'>/{data.maxMembers}명</span>
+            </InfoRow>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 
 import { cn } from '@/lib/cn';
 
+import type { GatheringDetail } from '@/api/gatherings/types';
 import { ArrowIcon, CategoryIcon, FlagIcon, CalendarIcon, PersonIcon } from '@/components/ui/Icon';
 import { InfoRow } from './InfoRow';
 import { DeadlineLabel } from '../DeadlineLabel';
-import type { GatheringDetail } from '@/api/gatherings/types';
 
 export const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
@@ -30,7 +30,6 @@ interface InfoAccordionProps {
 export function InfoAccordion({ data, defaultOpen = true, className }: InfoAccordionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const weeksLabel = toWeeksLabel(data.startDate, data.endDate);
-  console.log(data);
 
   return (
     <div className={cn('border-gray-150 overflow-hidden rounded-xl border', className)}>

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
@@ -8,10 +8,7 @@ import type { GatheringDetail } from '@/api/gatherings/types';
 import { ArrowIcon, CategoryIcon, FlagIcon, CalendarIcon, PersonIcon } from '@/components/ui/Icon';
 import { InfoRow } from './InfoRow';
 import { DeadlineLabel } from '../DeadlineLabel';
-
-export const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
-
-export const formatDate = (isoDate: string) => isoDate.slice(0, 10);
+import { formatDate, MILLISECONDS_IN_A_DAY } from '../utils/dateUtils';
 
 const toWeeksLabel = (startDate: string, endDate: string) => {
   const start = new Date(startDate);

--- a/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/InfoAccordion/index.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { cn } from '@/lib/cn';
 
 import type { GatheringDetail } from '@/api/gatherings/types';
-import { ArrowIcon, CategoryIcon, FlagIcon, CalendarIcon, PersonIcon } from '@/components/ui/Icon';
+import { ArrowIcon, CategoryIcon, FlagIcon, CalendarIcon, PersonIcon, AlarmIcon } from '@/components/ui/Icon';
 import { InfoRow } from './InfoRow';
 import { DeadlineLabel } from '../DeadlineLabel';
 import { formatDate, MILLISECONDS_IN_A_DAY } from '../utils/dateUtils';
@@ -53,7 +53,7 @@ export function InfoAccordion({ data, defaultOpen = true, className }: InfoAccor
             <InfoRow icon={<CalendarIcon size={24} className='text-gray-800' />}>
               {formatDate(data.startDate)} ~ {formatDate(data.endDate)} · {weeksLabel}
             </InfoRow>
-            <InfoRow icon={<CalendarIcon size={24} className='text-gray-800' />}>
+            <InfoRow icon={<AlarmIcon size={24} className='text-gray-800' />}>
               <span className='flex items-center gap-1 text-gray-700'>
                 마감까지 <DeadlineLabel recruitDeadline={data.recruitDeadline} />
               </span>

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/cn';
+import type { MemberInfo } from '@/api/gatherings/types';
+
+import { AvatarGroup } from '@/components/ui/AvatarGroup';
+
+interface ParticipantsListProps {
+  members: MemberInfo[];
+  maxMembers: number;
+  className?: string;
+}
+
+export function ParticipantsList({ members, maxMembers, className }: ParticipantsListProps) {
+  const [selectedMember, setSelectedMember] = useState<MemberInfo | null>(null);
+  console.log(members);
+  return (
+    <div className={cn('flex items-center justify-end gap-2', className)}>
+      <AvatarGroup
+        avatars={members.map((member) => ({ id: member.userId, imageUrl: member.profileImage }))}
+        max={maxMembers}
+        size='md'
+      />
+
+      {maxMembers - members.length > 0 && (
+        <span className='text-small-01-sb text-blue-300'>
+          <span className='mr-2'>·</span> {maxMembers - members.length}명 남음
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useState } from 'react';
-
 import { cn } from '@/lib/cn';
-import type { MemberInfo } from '@/api/gatherings/types';
 
+import type { MemberInfo } from '@/api/gatherings/types';
 import { AvatarGroup } from '@/components/ui/AvatarGroup';
 
 interface ParticipantsListProps {
@@ -14,8 +12,6 @@ interface ParticipantsListProps {
 }
 
 export function ParticipantsList({ members, maxMembers, className }: ParticipantsListProps) {
-  const [selectedMember, setSelectedMember] = useState<MemberInfo | null>(null);
-  console.log(members);
   return (
     <div className={cn('flex items-center justify-end gap-2', className)}>
       <AvatarGroup

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cn } from '@/lib/cn';
 
 import type { MemberInfo } from '@/api/gatherings/types';

--- a/src/app/gatherings/[id]/_components/ApplySection/utils/dateUtils.ts
+++ b/src/app/gatherings/[id]/_components/ApplySection/utils/dateUtils.ts
@@ -1,0 +1,2 @@
+export const formatDate = (isoDate: string) => isoDate.slice(0, 10);
+export const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -6,7 +6,10 @@ import { gatheringQueries } from '@/api/gatherings/queries';
 
 import { AnchorTabNav } from './_components/AnchorTabNav';
 import { GatheringDetailContent } from './_components/GatheringDetailContent';
+import { FloatingActionBar } from './_components/ApplySection/FloatingActionBar';
 import { GatheringHero } from './_components/GatheringHero';
+import { GatheringInfoAside } from './_components/ApplySection/GatheringInfoAside';
+import { GatheringInfoCard } from './_components/ApplySection/GatheringInfoCard';
 
 interface GatheringDetailPageProps {
   params: Promise<{ id: string }>;
@@ -21,13 +24,20 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <main className='min-h-screen'>
+      <main className='min-h-screen pb-20 xl:pb-0'>
         <ErrorBoundary
           fallback={<p className='py-20 text-center text-gray-500'>모임 정보를 불러오는데 실패했습니다.</p>}
         >
           <GatheringHero gatheringId={gatheringId} />
 
           {/* TODO: [이슈 2] Mobile/Tablet 사이드바 정보 카드 (xl:hidden) */}
+
+          {/* Mobile/Tablet: 모임 정보 카드 (탭 위에 배치) */}
+          <div className='px-4 pt-6 md:px-8 xl:hidden'>
+            <GatheringInfoCard gatheringId={gatheringId} />
+          </div>
+
+          {/* TODO: [이슈 3] 앵커 탭 네비게이션 */}
 
           <AnchorTabNav />
 
@@ -37,10 +47,13 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
               {/* TODO: [이슈 4] 주차별 계획 아코디언, 모집 인원 현황 */}
             </section>
 
-            <aside className='xl:block xl:w-[560px] xl:shrink-0'>
-              {/* TODO: [이슈 2] Desktop 사이드바 (sticky) */}
+            {/* Desktop: 사이드바 (sticky) */}
+            <aside className='hidden xl:block xl:w-[560px] xl:shrink-0'>
+              <GatheringInfoAside gatheringId={gatheringId} />
             </aside>
           </div>
+          {/* Mobile/Tablet: 하단 고정 액션 바 */}
+          <FloatingActionBar />
         </ErrorBoundary>
       </main>
     </HydrationBoundary>

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
             </aside>
           </div>
           {/* Mobile/Tablet: 하단 고정 액션 바 */}
-          <FloatingActionBar />
+          <FloatingActionBar gatheringId={gatheringId} />
         </ErrorBoundary>
       </main>
     </HydrationBoundary>


### PR DESCRIPTION
## ❓ 이슈

- close #136 

## ✍️ Description

모임 상세 페이지 우측 사이드바의 모임 정보 카드를 반응형으로 구현합니다. 모집 상태, 모임 메타 정보, 참여자 아바타, 액션 버튼을 포함합니다.
반응형은 아래 기존pc용 사이드바에서 신청하기 부분만 하단에 붙은 구조입니다.

## 📸 스크린샷 (UI 변경 시)

<img width="652" height="804" alt="스크린샷 2026-04-01 오전 11 18 34" src="https://github.com/user-attachments/assets/85c95225-4004-457a-980e-0c3367a4a5dc" />

<img width="609" height="683" alt="스크린샷 2026-04-01 오전 11 19 08" src="https://github.com/user-attachments/assets/a7a9edba-3a69-4504-8a92-f51b16781a09" />

<img width="612" height="749" alt="스크린샷 2026-04-01 오전 11 19 49" src="https://github.com/user-attachments/assets/dda323fd-b748-4aa8-8603-7f4023f67c06" />

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)
