### PR TITLE
[SM-99] feat: 모임 상세 페이지 주차별 계획 아코디언 + 모집 인원 현황 구성

### DIFF
--- a/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
@@ -8,6 +8,8 @@ import { formatDateDot, formatDday } from '@/lib/formatGatheringDate';
 import { GatheringDescription } from '../GatheringDescription';
 import { ImageCarousel } from '../ImageCarousel';
 import { InfoCard } from '../InfoCard';
+import { MembersStatus } from '../MembersStatus';
+import { WeeklyPlanAccordion } from '../WeeklyPlanAccordion';
 
 interface GatheringDetailContentProps {
   gatheringId: number;
@@ -52,7 +54,21 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
         </InfoCard>
       </section>
 
-      {/* TODO: [이슈 4] id="weekly-plans", id="members" 섹션 */}
+      {data.weeklyPlans.length > 0 && (
+        <section id='weekly-plans' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+          <div className='flex flex-col gap-4 xl:gap-6'>
+            <h2 className='text-body-01-sb xl:text-h5-sb text-gray-900'>주차별 계획 ✅</h2>
+            <WeeklyPlanAccordion weeklyPlans={data.weeklyPlans} />
+          </div>
+        </section>
+      )}
+
+      <section id='members' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+        <div className='flex flex-col gap-6'>
+          <h2 className='text-body-01-sb xl:text-h5-sb text-gray-900'>모집 인원 현황 👀</h2>
+          <MembersStatus currentMembers={data.currentMembers} maxMembers={data.maxMembers} />
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/gatherings/[id]/_components/MembersStatus/index.tsx
+++ b/src/app/gatherings/[id]/_components/MembersStatus/index.tsx
@@ -1,0 +1,29 @@
+import { ProgressBar } from '@/components/ui/Progress';
+
+interface MembersStatusProps {
+  currentMembers: number;
+  maxMembers: number;
+}
+
+const PERCENTAGE_MULTIPLIER = 100;
+
+export function MembersStatus({ currentMembers, maxMembers }: MembersStatusProps) {
+  const progressValue = maxMembers > 0 ? Math.round((currentMembers / maxMembers) * PERCENTAGE_MULTIPLIER) : 0;
+
+  return (
+    <div className='rounded-lg bg-blue-50 px-4 pt-6 pb-4 xl:px-6 xl:pt-10 xl:pb-8'>
+      <ProgressBar value={progressValue} barClassName='h-3 xl:h-4'>
+        <div className='flex items-center justify-between'>
+          <span className='text-small-01-r xl:text-body-01-m text-gray-800'>인원</span>
+          <p className='flex items-center gap-1'>
+            <span>
+              <span className='text-body-02-b xl:text-body-01-b text-blue-500'>{currentMembers}</span>
+              <span className='text-body-02-r xl:text-body-01-r text-gray-600'>/{maxMembers}</span>
+            </span>
+            <span className='text-body-02-m xl:text-body-01-m text-gray-800'>명</span>
+          </p>
+        </div>
+      </ProgressBar>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/WeeklyPlanAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/WeeklyPlanAccordion/index.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { WeeklyPlan } from '@/api/gatherings/types';
+import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
+import { cn } from '@/lib/cn';
+import { formatDateShort } from '@/lib/formatGatheringDate';
+
+interface WeeklyPlanAccordionProps {
+  weeklyPlans: WeeklyPlan[];
+}
+
+export function WeeklyPlanAccordion({ weeklyPlans }: WeeklyPlanAccordionProps) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const handleToggle = (index: number) => {
+    setExpandedIndex((prev) => (prev === index ? null : index));
+  };
+
+  return (
+    <div className='flex flex-col gap-3 xl:gap-6'>
+      {weeklyPlans.map((plan, index) => {
+        const isExpanded = expandedIndex === index;
+
+        return (
+          <div key={plan.week} className='overflow-hidden rounded-lg'>
+            <button
+              type='button'
+              aria-expanded={isExpanded}
+              onClick={() => handleToggle(index)}
+              className='flex w-full cursor-pointer items-center justify-between rounded-lg bg-blue-50 px-4 py-3 xl:px-6 xl:py-5'
+            >
+              <div className='flex items-center gap-3 xl:gap-4'>
+                <span className='text-body-02-sb text-gray-0 xl:text-body-01-sb flex h-7 w-7 items-center justify-center rounded-md bg-blue-400 xl:h-8 xl:w-8'>
+                  {plan.week}
+                </span>
+                <div className='flex items-center gap-2 xl:gap-3'>
+                  <span className='text-small-01-sb xl:text-body-01-sb text-blue-500'>{plan.title}</span>
+                  <span className='text-small-02-r xl:text-small-01-r text-gray-500'>
+                    {formatDateShort(plan.startDate)} ~ {formatDateShort(plan.endDate)}
+                  </span>
+                </div>
+              </div>
+              <ArrowIcon
+                size={28}
+                className={cn(
+                  'text-gray-800 transition-transform duration-200 xl:h-8! xl:w-8!',
+                  isExpanded ? 'rotate-90' : '-rotate-90',
+                )}
+                viewBox='0 0 16 16'
+              />
+            </button>
+
+            <div
+              className={cn(
+                'grid transition-[grid-template-rows] duration-300 ease-in-out',
+                isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+              )}
+            >
+              <div className='overflow-hidden'>
+                <div role='region' className='flex flex-col items-start px-6 xl:px-8'>
+                  <div className='bg-blue-150 mx-[5px] h-[30px] w-px' />
+                  <div className='flex items-center gap-4'>
+                    <div className='bg-blue-150 h-3 w-3 shrink-0 rounded-full' />
+                    <p className='text-body-02-r xl:text-body-01-r text-gray-800'>01. {plan.title}</p>
+                  </div>
+                  <div className='bg-blue-150 mx-[5px] h-[36px] w-px' />
+                  <div className='flex items-center gap-4'>
+                    <div className='bg-blue-150 h-3 w-3 shrink-0 rounded-full' />
+                    <p className='text-body-02-r xl:text-body-01-r text-gray-800'>02. {plan.title}</p>
+                  </div>
+                  <div className='bg-blue-150 mx-[5px] h-[30px] w-px' />
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -21,7 +21,7 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <main className='min-h-screen'>
+      <main className='mb-20 min-h-screen'>
         <ErrorBoundary
           fallback={<p className='py-20 text-center text-gray-500'>모임 정보를 불러오는데 실패했습니다.</p>}
         >
@@ -34,7 +34,6 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
           <div className='px-4 pt-10 md:px-7 xl:flex xl:gap-20 xl:px-30'>
             <section className='min-w-0 flex-1'>
               <GatheringDetailContent gatheringId={gatheringId} />
-              {/* TODO: [이슈 4] 주차별 계획 아코디언, 모집 인원 현황 */}
             </section>
 
             <aside className='xl:block xl:w-[560px] xl:shrink-0'>

--- a/src/lib/formatGatheringDate.ts
+++ b/src/lib/formatGatheringDate.ts
@@ -5,6 +5,11 @@ export const formatDateDot = (dateString: string): string => {
   return format(new Date(dateString), 'yyyy.MM.dd');
 };
 
+/** ISO 날짜 문자열을 "M/d" 형식으로 변환 (예: "3/15") */
+export const formatDateShort = (dateString: string): string => {
+  return format(new Date(dateString), 'M/d');
+};
+
 /** 대상 날짜까지의 D-day 텍스트 반환 ("D-3" | "D-Day" | "D+1") */
 export const formatDday = (targetDateString: string): string => {
   const today = startOfDay(new Date());


### PR DESCRIPTION
## ❓ 이슈

- close #138

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
모임 상세 페이지에 주차별 계획 아코디언 섹션과 모집 인원 현황 프로그레스 바 섹션을 구현

주차별 계획 아코디언

  - 주차 번호 뱃지(1,2,3...), 제목, 날짜 범위(M/DD ~ M/DD) 표시
  - 클릭 시 확장/축소 동작 (grid-rows 기반 슬라이드 애니메이션)
  - 화살표 아이콘 위↔아래 회전 트랜지션
  - 확장 시 세로선 + 파란 점 인디케이터와 함께 항목 표시

  ⚠️ 하위 항목(tasks)은 임시 구현입니다.
  현재 WeeklyPlan API 타입에 하위 항목 필드가 없어서, 확장 시 plan.title을 임시로 표시합니다.
백엔드 or 디자인 변경에 따라 재구현

 모집 인원 현황

  - "인원" 라벨 + 현재/최대 인원 텍스트 + 프로그레스 바
  - 기존 ProgressBar 컴포넌트를 children + barClassName으로
  커스텀하여 재사용

  기타

  - formatDateShort 유틸 추가 (ISO 날짜 → "M/d" 포맷)
  - AnchorTabNav의 weekly-plans, members 섹션 ID와 연동 완료
  - page.tsx 완료된 TODO 주석 제거

## 📸 스크린샷 (UI 변경 시)
<img width="3840" height="5446" alt="screencapture-localhost-3000-gatherings-8-2026-04-01-14_02_35" src="https://github.com/user-attachments/assets/3ea49cef-2224-4e62-842c-7a2f4b873614" />

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
