### PR TITLE
[SM-108] feat: 대시보드 페이지 라우팅 및 공통 레이아웃

### DIFF
--- a/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
@@ -1,0 +1,22 @@
+import { DASHBOARD_TAB_ITEMS, DEFAULT_TAB } from '../../_constants';
+
+import type { DashboardTab } from '../../_constants';
+
+interface DashboardContentProps {
+  activeTab: DashboardTab;
+  gatheringId: number;
+}
+
+export function DashboardContent({ activeTab }: DashboardContentProps) {
+  const label =
+    DASHBOARD_TAB_ITEMS.find((item) => item.key === activeTab)?.label ??
+    DASHBOARD_TAB_ITEMS.find((item) => item.key === DEFAULT_TAB)!.label;
+
+  return (
+    <section className='px-4 py-10 md:px-8 lg:px-30'>
+      <div className='mx-auto max-w-[1200px]'>
+        <p className='text-body-02-r text-gray-400'>{label} 콘텐츠가 여기에 표시됩니다.</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardHeader/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardHeader/index.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { differenceInDays, differenceInWeeks } from 'date-fns';
+
+import { AvatarGroup } from '@/components/ui/AvatarGroup';
+import { StudyIcon, ProjectIcon, ArrowIcon, PeriodIcon, TimeIcon, PeopleIcon, RisingIcon } from '@/components/ui/Icon';
+import { cn } from '@/lib/cn';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { formatDateDot } from '@/lib/formatGatheringDate';
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { achievementQueries } from '@/api/achievements/queries';
+
+import { StatCard } from '../StatCard';
+import { useSnapCarousel } from './useSnapCarousel';
+
+import type { StatCardProps } from '../StatCard';
+import type { GatheringType } from '@/api/gatherings/types';
+
+const TYPE_ICON: Record<GatheringType, typeof StudyIcon> = {
+  스터디: StudyIcon,
+  프로젝트: ProjectIcon,
+};
+
+interface DashboardHeaderProps {
+  gatheringId: number;
+}
+
+/** 모바일: 1개씩 → 페이지 4개 / 태블릿: 2개씩 → 페이지 2개 */
+const MOBILE_PAGES = 4;
+const TABLET_PAGES = 2;
+
+export function DashboardHeader({ gatheringId }: DashboardHeaderProps) {
+  const { data: gathering } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+  const { data: achievements } = useSuspenseQuery(achievementQueries.detail(gatheringId));
+
+  const isMd = useMediaQuery('(min-width: 768px)');
+  const pageCount = isMd ? TABLET_PAGES : MOBILE_PAGES;
+  const { scrollRef, activeIndex, scrollToPage } = useSnapCarousel({ pageCount });
+
+  const TypeIcon = TYPE_ICON[gathering.type];
+
+  const now = new Date();
+  const startDate = new Date(gathering.startDate);
+  const endDate = new Date(gathering.endDate);
+  const currentWeek = Math.max(1, differenceInWeeks(now, startDate) + 1);
+  const daysRemaining = Math.max(0, differenceInDays(endDate, now));
+
+  const avatars = gathering.members.map((member) => ({
+    id: member.userId,
+    imageUrl: member.profileImage,
+  }));
+
+  const cards: StatCardProps[] = [
+    {
+      icon: <PeriodIcon size={24} className='lg:h-8 lg:w-8' />,
+      label: '활동기간',
+      value: `${gathering.totalWeeks}주`,
+      subInfo: `${formatDateDot(gathering.startDate)} ~ ${formatDateDot(gathering.endDate)}`,
+    },
+    {
+      icon: <TimeIcon size={24} className='lg:h-8 lg:w-8' />,
+      label: '진행차수',
+      value: `${currentWeek}주차`,
+      subInfo: `${daysRemaining}일 남음`,
+    },
+    {
+      icon: <PeopleIcon size={24} className='lg:h-8 lg:w-8' />,
+      label: '모임 구성원',
+      value: `${gathering.members.length}명`,
+      subInfo: <AvatarGroup avatars={avatars} max={5} size='sm' />,
+    },
+    {
+      icon: <RisingIcon size={24} className='lg:h-8 lg:w-8' />,
+      label: '전체 달성률',
+      value: `${achievements.teamOverallRate}%`,
+      subInfo: `${gathering.totalWeeks}주간 팀 달성률`,
+    },
+  ];
+
+  return (
+    <section className='bg-gradient-sub-200 px-4 pt-20 md:px-7 lg:pb-8 xl:px-30'>
+      <div className='mx-auto max-w-[1680px]'>
+        {/* 타이틀 영역 */}
+        <div className='flex flex-col gap-1'>
+          <p className='flex items-center gap-0.5 text-blue-500'>
+            <TypeIcon size={14} className='text-blue-500' />
+            <span className='text-small-01-sb'>{gathering.type}</span>
+            <ArrowIcon size={14} />
+            <span className='text-small-01-r'>{gathering.category}</span>
+          </p>
+          <h1 className='text-h5-b md:text-h3-b xl:text-h2-b text-blue-500'>{gathering.title}</h1>
+          <p className='text-small-02-r md:text-body-02-r text-gray-800'>{gathering.shortDescription}</p>
+        </div>
+
+        {/* 통계 카드 — PC: 4열 그리드 (스와이프 없음) */}
+        <div className='mt-8 hidden lg:grid lg:grid-cols-4 lg:gap-4'>
+          {cards.map((card) => (
+            <StatCard key={card.label} {...card} />
+          ))}
+        </div>
+
+        {/* 통계 카드 — 모바일(1개씩) / 태블릿(2개씩) 스와이퍼 */}
+        <div className='mt-6 lg:hidden'>
+          <div ref={scrollRef} className='scrollbar-none flex snap-x snap-mandatory gap-4 overflow-x-auto'>
+            {cards.map((card) => (
+              <div key={card.label} className='min-w-[calc(100%-16px)] snap-start md:min-w-[calc(50%-8px)]'>
+                <StatCard {...card} />
+              </div>
+            ))}
+          </div>
+
+          {/* Dot Indicator */}
+          <div className='flex justify-center gap-1.5 py-4'>
+            {Array.from({ length: pageCount }).map((_, index) => (
+              <button
+                key={index}
+                type='button'
+                aria-label={`${index + 1}페이지로 이동`}
+                onClick={() => scrollToPage(index)}
+                className={cn(
+                  'h-2 w-2 rounded-full transition-colors',
+                  activeIndex === index ? 'bg-blue-300' : 'bg-gray-200',
+                )}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardHeader/useSnapCarousel.ts
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardHeader/useSnapCarousel.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseSnapCarouselOptions {
+  pageCount: number;
+}
+
+export const useSnapCarousel = ({ pageCount }: UseSnapCarouselOptions) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleScroll = useCallback(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    const pageWidth = container.scrollWidth / pageCount;
+    const newIndex = Math.round(container.scrollLeft / pageWidth);
+    setActiveIndex(Math.min(newIndex, pageCount - 1));
+  }, [pageCount]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  const scrollToPage = useCallback(
+    (index: number) => {
+      const container = scrollRef.current;
+      if (!container) return;
+
+      const pageWidth = container.scrollWidth / pageCount;
+      container.scrollTo({ left: pageWidth * index, behavior: 'smooth' });
+    },
+    [pageCount],
+  );
+
+  return { scrollRef, activeIndex, scrollToPage } as const;
+};

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardSkeleton/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardSkeleton/index.tsx
@@ -1,0 +1,65 @@
+function StatCardSkeleton() {
+  return (
+    <div className='border-focus-100 bg-gray-0 shadow-01 flex items-end justify-between rounded-2xl border p-6'>
+      <div className='flex flex-col gap-4'>
+        <span className='text-small-02-m lg:text-body-02-m w-14 rounded bg-gray-200 text-transparent select-none'>
+          &nbsp;
+        </span>
+        <div className='flex flex-col gap-1'>
+          <span className='text-h5-b md:text-h4-b lg:text-h3-b w-16 rounded bg-gray-200 text-transparent select-none'>
+            &nbsp;
+          </span>
+          <div className='text-small-02-r lg:text-small-01-r w-28 rounded bg-gray-200 text-transparent select-none'>
+            &nbsp;
+          </div>
+        </div>
+      </div>
+      <div className='h-18 w-18 shrink-0 rounded-full bg-blue-50' />
+    </div>
+  );
+}
+
+export function DashboardSkeleton() {
+  return (
+    <section className='bg-gradient-sub-200 px-4 pt-20 md:px-7 lg:pb-8 xl:px-30'>
+      <div className='mx-auto max-w-[1680px] animate-pulse'>
+        {/* 타이틀 영역 */}
+        <div className='flex flex-col gap-1'>
+          <div className='text-small-01-sb w-28 rounded bg-blue-100 text-transparent select-none'>&nbsp;</div>
+          <div className='text-h5-b md:text-h3-b xl:text-h2-b w-48 rounded bg-blue-100 text-transparent select-none'>
+            &nbsp;
+          </div>
+          <div className='text-small-02-r md:text-body-02-r w-64 rounded bg-blue-100 text-transparent select-none'>
+            &nbsp;
+          </div>
+        </div>
+
+        {/* 통계 카드 — PC: 4열 그리드 */}
+        <div className='mt-8 hidden lg:grid lg:grid-cols-4 lg:gap-4'>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <StatCardSkeleton key={i} />
+          ))}
+        </div>
+
+        {/* 통계 카드 — 모바일(1개) / 태블릿(2개) */}
+        <div className='mt-6 lg:hidden'>
+          <div className='flex gap-4 overflow-hidden'>
+            <div className='min-w-[calc(100%-16px)] md:min-w-[calc(50%-8px)]'>
+              <StatCardSkeleton />
+            </div>
+            <div className='hidden min-w-[calc(50%-8px)] md:block'>
+              <StatCardSkeleton />
+            </div>
+          </div>
+
+          {/* Dot Indicator */}
+          <div className='flex justify-center gap-1.5 py-4'>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className='h-2 w-2 rounded-full bg-gray-200 first:bg-blue-300 md:nth-[n+3]:hidden' />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardTabNav/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardTabNav/index.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+import { cn } from '@/lib/cn';
+
+import { DASHBOARD_TAB_ITEMS } from '../../_constants';
+
+import type { DashboardTab } from '../../_constants';
+
+interface DashboardTabNavProps {
+  activeTab: DashboardTab;
+  gatheringId: number;
+}
+
+export function DashboardTabNav({ activeTab, gatheringId }: DashboardTabNavProps) {
+  return (
+    <nav className='border-gray-150 bg-gray-0 border-b px-4 md:px-7 xl:px-30'>
+      <div className='mx-auto max-w-[1680px]'>
+        <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
+          {DASHBOARD_TAB_ITEMS.map(({ key, label }) => {
+            const isActive = activeTab === key;
+
+            return (
+              <li key={key} className='shrink-0'>
+                <Link
+                  href={`/gatherings/${gatheringId}/dashboard?tab=${key}`}
+                  replace
+                  scroll={false}
+                  className={cn(
+                    'text-small-02-m md:text-body-02-m flex h-[39px] shrink-0 items-center px-2.5 transition-colors md:h-12',
+                    isActive ? 'border-b-2 border-gray-800 text-gray-800' : 'text-gray-300',
+                  )}
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/StatCard/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/StatCard/index.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+export interface StatCardProps {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  subInfo: ReactNode;
+}
+
+export function StatCard({ icon, label, value, subInfo }: StatCardProps) {
+  return (
+    <div className='border-focus-100 bg-gray-0 shadow-01 flex items-end justify-between rounded-2xl border p-6'>
+      <div className='flex flex-col gap-4'>
+        <span className='text-small-02-m lg:text-body-02-m text-blue-300'>{label}</span>
+        <div className='flex flex-col gap-1'>
+          <span className='text-h5-b md:text-h4-b lg:text-h3-b text-gray-900'>{value}</span>
+          <div className='text-small-02-r lg:text-small-01-r text-gray-600'>{subInfo}</div>
+        </div>
+      </div>
+      <div className='flex h-18 w-18 shrink-0 items-center justify-center rounded-full bg-blue-50'>{icon}</div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_constants.ts
+++ b/src/app/gatherings/[id]/dashboard/_constants.ts
@@ -1,0 +1,9 @@
+export const DASHBOARD_TAB_ITEMS = [
+  { key: 'summary', label: '활동 요약' },
+  { key: 'weekly', label: '주차별 현황' },
+  { key: 'members', label: '멤버' },
+] as const;
+
+export type DashboardTab = (typeof DASHBOARD_TAB_ITEMS)[number]['key'];
+
+export const DEFAULT_TAB: DashboardTab = 'summary';

--- a/src/app/gatherings/[id]/dashboard/page.tsx
+++ b/src/app/gatherings/[id]/dashboard/page.tsx
@@ -1,0 +1,35 @@
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+
+import { DashboardContent } from './_components/DashboardContent';
+import { DashboardHeader } from './_components/DashboardHeader';
+import { DashboardSkeleton } from './_components/DashboardSkeleton';
+import { DashboardTabNav } from './_components/DashboardTabNav';
+import { DEFAULT_TAB } from './_constants';
+
+import type { DashboardTab } from './_constants';
+
+interface DashboardPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ tab?: DashboardTab }>;
+}
+
+export default async function DashboardPage({ params, searchParams }: DashboardPageProps) {
+  const { id } = await params;
+  const { tab } = await searchParams;
+  const gatheringId = Number(id);
+  const activeTab = tab ?? DEFAULT_TAB;
+
+  return (
+    <main className='min-h-screen bg-gray-50'>
+      <SuspenseBoundary
+        pendingFallback={<DashboardSkeleton />}
+        errorFallback={<p className='py-20 text-center text-gray-500'>대시보드 정보를 불러오는데 실패했습니다.</p>}
+      >
+        <DashboardHeader gatheringId={gatheringId} />
+      </SuspenseBoundary>
+
+      <DashboardTabNav activeTab={activeTab} gatheringId={gatheringId} />
+      <DashboardContent activeTab={activeTab} gatheringId={gatheringId} />
+    </main>
+  );
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,18 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+export const useMediaQuery = (query: string) => {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const mq = window.matchMedia(query);
+      mq.addEventListener('change', callback);
+      return () => mq.removeEventListener('change', callback);
+    },
+    [query],
+  );
+
+  const getSnapshot = () => window.matchMedia(query).matches;
+
+  const getServerSnapshot = () => false;
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};


### PR DESCRIPTION
## ❓ 이슈

- close #155 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
모임 대시보드 페이지(`/gatherings/[id]/dashboard`) 헤더 영역 및 탭 네비게이션 구조 구현

 **대시보드 헤더**

  - 브레드크럼(타입 아이콘 + 카테고리), 제목, 설명 표시
  - 통계 카드 4종: 활동기간, 진행차수, 모임 구성원, 전체 달성률
  - PC: 4열 그리드 / 태블릿: 2개씩 스와이프(dot 2개) / 모바일: 1개씩 스와이프(dot 4개)
  - CSS scroll-snap 기반 캐러셀 (외부 라이브러리 없음)
  - SuspenseBoundary + useSuspenseQuery로 로딩/에러 처리

  **탭 네비게이션**

  - 활동 요약 / 주차별 현황 / 멤버 3개 탭
  - URL searchParams(`?tab=`)로 상태 관리, `<Link replace scroll={false} />`
  - AnchorTabNav와 동일한 스타일 적용

  **신규 훅**

  - `useMediaQuery`: useSyncExternalStore 기반 SSR-safe 미디어쿼리 훅


## 📸 스크린샷 (UI 변경 시)
<img width="1000" height="2282" alt="screencapture-localhost-3000-gatherings-1-dashboard-2026-04-01-17_17_08" src="https://github.com/user-attachments/assets/95e0acdb-e359-402b-834c-9c193566f5ae" />
<img width="1920" height="2282" alt="screencapture-localhost-3000-gatherings-1-dashboard-2026-04-01-17_16_52" src="https://github.com/user-attachments/assets/aa4746c0-f36e-4deb-84b3-f4a4d365dc45" />
<img width="3840" height="2244" alt="screencapture-localhost-3000-gatherings-1-dashboard-2026-04-01-17_16_37" src="https://github.com/user-attachments/assets/b1c9ab1a-0e6a-43bb-9509-87937237d077" />

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
