### PR TITLE
[SM-104] feat: 모임 만들기 페이지 이미지 업로드 섹션 구현

### DIFF
--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -44,4 +44,8 @@ export const gatheringFormPartialSchema = z.object({
   description: z.string().min(1, '상세 소개를 입력해 주세요.').max(1000, '상세 설명은 최대 1000자까지 가능합니다.'),
   tags: z.array(z.string()).min(1, '최소 1개의 태그를 입력해 주세요.').max(5, '태그는 최대 5개까지 가능합니다.'),
   goal: z.string().min(1, '모임 목표를 입력해 주세요.').max(200, '모임 목표는 최대 200자까지 가능합니다.'),
+  images: z
+    .array(z.instanceof(File, { message: '유효한 파일이 아닙니다.' }))
+    .max(6, '이미지는 최대 6장까지 업로드 가능합니다.')
+    .optional(),
 });

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { BackupIcon, CloseIcon } from '@/components/ui/Icon';
+import { cn } from '@/lib/cn';
+
+const MAX_IMAGES = 6;
+const ACCEPTED_MIME_TYPES = ['image/jpeg', 'image/png', 'application/pdf'];
+
+interface ImageUploadProps {
+  value: File[];
+  onChange: (files: File[]) => void;
+  error?: string;
+}
+
+export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // render에서 img src로 사용 → state로 관리 (render 중 ref 접근 금지)
+  const [previewUrls, setPreviewUrls] = useState<Map<File, string>>(new Map());
+
+  // cleanup 전용: 생성된 모든 URL을 누적 보관
+  // state는 cleanup 시점에 stale해질 수 있어서 ref로 별도 관리
+  const allCreatedUrls = useRef<string[]>([]);
+
+  // 언마운트 시 생성했던 URL 전부 메모리 해제
+  useEffect(() => {
+    const urls = allCreatedUrls.current; // effect 안에서 복사 (cleanup warning 방지)
+    return () => {
+      urls.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, []);
+
+  const addFiles = (newFiles: File[]) => {
+    const valid = newFiles.filter((f) => ACCEPTED_MIME_TYPES.includes(f.type));
+    const merged = [...value, ...valid].slice(0, MAX_IMAGES);
+
+    // 새 파일의 URL 생성 후 state와 cleanup ref 모두에 저장
+    const newUrls = new Map(previewUrls);
+    valid.forEach((file) => {
+      if (!newUrls.has(file)) {
+        const url = URL.createObjectURL(file);
+        newUrls.set(file, url);
+        allCreatedUrls.current.push(url); // 언마운트 시 해제할 목록에 추가
+      }
+    });
+    setPreviewUrls(newUrls);
+    onChange(merged);
+  };
+
+  const handleRemove = (index: number) => {
+    const file = value[index];
+    // state에서 해당 파일 URL 제거 (즉시 해제는 하지 않음, 언마운트 시 일괄 해제)
+    const newUrls = new Map(previewUrls);
+    newUrls.delete(file);
+    setPreviewUrls(newUrls);
+    onChange(value.filter((_, i) => i !== index));
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    addFiles(Array.from(e.target.files));
+    e.target.value = '';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    addFiles(Array.from(e.dataTransfer.files));
+  };
+
+  const openFilePicker = () => fileInputRef.current?.click();
+
+  const hasImages = value.length > 0;
+  const emptySlotCount = MAX_IMAGES - value.length;
+
+  return (
+    <div className='flex flex-col gap-1.5'>
+      <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>이미지</p>
+
+      {!hasImages ? (
+        /* ── 0장: 큰 드롭존 ── */
+        <div
+          className={cn(
+            'flex w-full cursor-pointer flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-gray-300 bg-gray-100',
+            'h-[408px]',
+            isDragging && 'border-gradient-primary',
+          )}
+          onClick={openFilePicker}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <BackupIcon size={80} className='text-gray-300' />
+          <div className='flex flex-col items-center gap-1'>
+            <p className='text-body-01-m text-gray-600'>이곳을 클릭해 이미지를 업로드해주세요</p>
+            <p className='text-body-02-r text-gray-300'>JPEG, PNG, PDF</p>
+          </div>
+          <Button
+            type='button'
+            variant='file-upload'
+            size='file-upload'
+            onClick={(e) => {
+              e.stopPropagation();
+              openFilePicker();
+            }}
+          >
+            파일 찾기
+          </Button>
+        </div>
+      ) : (
+        /* ── 1장 이상: 썸네일 + 빈 슬롯 ── */
+        <div className='flex flex-row gap-2 overflow-x-auto md:flex-wrap md:overflow-x-visible'>
+          {value.map((file, index) => {
+            const isPdf = file.type === 'application/pdf';
+            const previewUrl = isPdf ? undefined : previewUrls.get(file);
+
+            return (
+              <div
+                key={index}
+                className='relative aspect-3/4 w-[200px] shrink-0 overflow-hidden rounded-lg md:w-[calc((100%-1rem)/3)] lg:w-[264px]'
+              >
+                {isPdf ? (
+                  <div className='flex h-full w-full flex-col items-center justify-center gap-2 bg-gray-100'>
+                    <span className='text-body-02-sb rounded bg-gray-300 px-2 py-0.5 text-gray-600'>PDF</span>
+                    <p className='text-body-02-r w-full truncate px-3 text-center text-gray-600'>{file.name}</p>
+                  </div>
+                ) : (
+                  // blob URL(브라우저 메모리의 임시 주소)은 next/image가 서버에서 접근할 수 없어
+                  // <img> 태그를 직접 사용. ESLint 규칙을 이 줄만 예외 처리
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={previewUrl} alt={file.name} className='h-full w-full object-cover' />
+                )}
+
+                {/* 삭제 버튼 */}
+                <button
+                  type='button'
+                  onClick={() => handleRemove(index)}
+                  className='absolute top-1.5 right-1.5 flex h-7 w-7 items-center justify-center rounded-full bg-white/[0.28] transition-colors hover:bg-white/50'
+                >
+                  <CloseIcon size={20} className='text-white' />
+                </button>
+              </div>
+            );
+          })}
+
+          {/* 빈 슬롯 */}
+          {Array.from({ length: emptySlotCount }).map((_, i) => (
+            <button
+              key={`empty-${i}`}
+              type='button'
+              onClick={openFilePicker}
+              className='bg-gray-150 flex aspect-[3/4] w-[200px] shrink-0 items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] lg:w-[264px]'
+            >
+              <span className='text-body-01-m text-gray-600'>+</span>
+              <span className='text-body-01-m text-gray-600'>이미지 추가</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type='file'
+        accept='image/jpeg,image/png,application/pdf'
+        multiple
+        className='hidden'
+        onChange={handleFileChange}
+      />
+
+      {error && (
+        <p className='text-xs text-red-200' role='alert'>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -73,7 +73,9 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    setIsDragging(false);
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragging(false);
+    }
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -123,7 +125,15 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         </div>
       ) : (
         /* ── 1장 이상: 썸네일 + 빈 슬롯 ── */
-        <div className='flex flex-row gap-2 overflow-x-auto md:flex-wrap md:overflow-x-visible'>
+        <div
+          className={cn(
+            'flex flex-row gap-2 overflow-x-auto rounded-lg md:flex-wrap md:overflow-x-visible',
+            isDragging && 'outline-2 outline-blue-300 outline-dashed',
+          )}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
           {value.map((file, index) => {
             const isPdf = file.type === 'application/pdf';
             const previewUrl = isPdf ? undefined : previewUrls.get(file);
@@ -139,9 +149,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
                     <p className='text-body-02-r w-full truncate px-3 text-center text-gray-600'>{file.name}</p>
                   </div>
                 ) : (
-                  // blob URL(브라우저 메모리의 임시 주소)은 next/image가 서버에서 접근할 수 없어
-                  // <img> 태그를 직접 사용. ESLint 규칙을 이 줄만 예외 처리
-                  // eslint-disable-next-line @next/next/no-img-element
+                  // blob URL(브라우저 메모리의 임시 주소)은 next/image가 서버에서 접근할 수 없어 <img> 태그를 직접 사용
                   <img src={previewUrl} alt={file.name} className='h-full w-full object-cover' />
                 )}
 
@@ -163,7 +171,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
               key={`empty-${i}`}
               type='button'
               onClick={openFilePicker}
-              className='bg-gray-150 flex aspect-[3/4] w-[200px] shrink-0 items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] lg:w-[264px]'
+              className='bg-gray-150 flex aspect-3/4 w-[200px] shrink-0 cursor-pointer items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] lg:w-[264px]'
             >
               <span className='text-body-01-m text-gray-600'>+</span>
               <span className='text-body-01-m text-gray-600'>이미지 추가</span>

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -91,14 +91,12 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
 
   return (
     <div className='flex flex-col gap-1.5'>
-      <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>이미지</p>
-
       {!hasImages ? (
         /* ── 0장: 큰 드롭존 ── */
         <div
           className={cn(
             'flex w-full cursor-pointer flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-gray-300 bg-gray-100',
-            'h-[408px]',
+            'h-[343px] md:h-[688px] lg:h-[448px]',
             isDragging && 'border-gradient-primary',
           )}
           onClick={openFilePicker}
@@ -106,15 +104,18 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          <BackupIcon size={80} className='text-gray-300' />
+          {/* size prop이 숫자라 반응형 클래스 불가 → 두 개 렌더 후 breakpoint별 show/hide */}
+          <BackupIcon size={44} className='text-gray-300 md:hidden' />
+          <BackupIcon size={80} className='hidden text-gray-300 md:block' />
           <div className='flex flex-col items-center gap-1'>
-            <p className='text-body-01-m text-gray-600'>이곳을 클릭해 이미지를 업로드해주세요</p>
-            <p className='text-body-02-r text-gray-300'>JPEG, PNG, PDF</p>
+            <p className='text-small-02-m md:text-body-01-m text-gray-600'>이곳을 클릭해 이미지를 업로드해주세요</p>
+            <p className='text-small-01-r md:text-body-02-r text-gray-300'>JPEG, PNG, PDF</p>
           </div>
           <Button
             type='button'
             variant='file-upload'
             size='file-upload'
+            className='text-small-02-sb md:text-body-01-sb h-[35px] w-[101px] md:h-12 md:w-[122px]'
             onClick={(e) => {
               e.stopPropagation();
               openFilePicker();
@@ -171,10 +172,10 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
               key={`empty-${i}`}
               type='button'
               onClick={openFilePicker}
-              className='bg-gray-150 flex aspect-3/4 w-[200px] shrink-0 cursor-pointer items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] lg:w-[264px]'
+              className='bg-gray-150 aspect-3/4 w-[200px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] md:flex-row lg:w-[264px]'
             >
-              <span className='text-body-01-m text-gray-600'>+</span>
-              <span className='text-body-01-m text-gray-600'>이미지 추가</span>
+              <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>+</span>
+              <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>이미지 추가</span>
             </button>
           ))}
         </div>

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -172,7 +172,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
               key={`empty-${i}`}
               type='button'
               onClick={openFilePicker}
-              className='bg-gray-150 aspect-3/4 w-[200px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] md:flex-row lg:w-[264px]'
+              className='bg-gray-150 flex aspect-3/4 w-[200px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] md:flex-row lg:w-[264px]'
             >
               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>+</span>
               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>이미지 추가</span>

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -18,6 +18,7 @@ import { gatheringFormPartialSchema } from '@/api/gatherings/schemas';
 import { GATHERING_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 
+import { ImageUpload } from './ImageUpload';
 import { TagInput } from './TagInput';
 
 import type { GatheringForm, GatheringFormPartial } from '@/api/gatherings/types';
@@ -282,6 +283,15 @@ export function CreateGatheringForm() {
         />
       </div>
 
+      {/* 이미지 */}
+      <Controller
+        name='images'
+        control={control}
+        render={({ field }) => (
+          <ImageUpload value={field.value ?? []} onChange={field.onChange} error={errors.images?.message} />
+        )}
+      />
+
       {/* 모임 최종 목표 */}
       <div className='flex flex-col gap-1'>
         <Input
@@ -298,9 +308,6 @@ export function CreateGatheringForm() {
         />
         <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
       </div>
-
-      {/* 이미지 */}
-      <div />
 
       {/* 날짜/일정 */}
       <div />

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -284,13 +284,16 @@ export function CreateGatheringForm() {
       </div>
 
       {/* 이미지 */}
-      <Controller
-        name='images'
-        control={control}
-        render={({ field }) => (
-          <ImageUpload value={field.value ?? []} onChange={field.onChange} error={errors.images?.message} />
-        )}
-      />
+      <div className='flex flex-col gap-1'>
+        <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>이미지</p>
+        <Controller
+          name='images'
+          control={control}
+          render={({ field }) => (
+            <ImageUpload value={field.value ?? []} onChange={field.onChange} error={errors.images?.message} />
+          )}
+        />
+      </div>
 
       {/* 모임 최종 목표 */}
       <div className='flex flex-col gap-1'>


### PR DESCRIPTION
## ❓ 이슈

- close #146 

## ✍️ Description

모임 만들기 페이지의 이미지 업로드 섹션을 구현했습니다.

- 클릭 및 드래그 앤 드롭으로 이미지 업로드 가능
- 허용 포맷: JPEG, PNG, PDF / 최대 6장 제한
- 업로드된 이미지 썸네일 미리보기 및 개별 삭제 기능
- 이미지가 1장 이상일 때 드래그 앤 드롭 지원 및 드롭존 flickering 수정
- 반응형 스타일 적용
- react-hook-form `images` 필드 연동 (optional)

## 📸 스크린샷 (UI 변경 시)
<img width="1300" height="400" alt="image" src="https://github.com/user-attachments/assets/00e3171b-3802-4b29-97fc-2732e434e772" />

<img width="838" height="884" alt="화면 캡처 2026-04-01 164859" src="https://github.com/user-attachments/assets/464cc5df-25b7-4ab2-abb4-f4977ff851f6" />
<img width="918" height="894" alt="화면 캡처 2026-04-01 164808" src="https://github.com/user-attachments/assets/4922408e-ca48-4d0a-8ebf-974ff5fd3577" />
<img width="832" height="896" alt="화면 캡처 2026-04-01 164701" src="https://github.com/user-attachments/assets/4388fb05-bb5a-45f2-a163-326910a2d8cb" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


