### PR TITLE
[SM-101] feat: 모임 참여 신청 플로우 구현

### DIFF
--- a/src/api/applications/index.ts
+++ b/src/api/applications/index.ts
@@ -18,7 +18,7 @@ export const createApplication = async (
   body: ApplyGatheringForm,
 ): Promise<CreateApplicationResponse> => {
   const { data } = await axiosClient.post<ApiResponse<CreateApplicationResponse>>(
-    `/gatherings/${gatheringId}/applications`,
+    `/v1/gatherings/${gatheringId}/applications`,
     body,
   );
   return unwrapResponse(data);
@@ -27,7 +27,7 @@ export const createApplication = async (
 /** GET v1/gatherings/:gatheringId/applications — 신청 목록 조회(모임장) */
 export const getApplicationList = async (gatheringId: number): Promise<ApplicationListResponse> => {
   const { data } = await axiosClient.get<ApiResponse<ApplicationListResponse>>(
-    `/gatherings/${gatheringId}/applications`,
+    `/v1/gatherings/${gatheringId}/applications`,
   );
   return unwrapResponse(data);
 };
@@ -39,7 +39,7 @@ export const updateApplicationStatus = async (
   body: UpdateApplicationStatusRequest,
 ): Promise<UpdateApplicationStatusResponse> => {
   const { data } = await axiosClient.patch<ApiResponse<UpdateApplicationStatusResponse>>(
-    `/gatherings/${gatheringId}/applications/${applicationId}`,
+    `/v1/gatherings/${gatheringId}/applications/${applicationId}`,
     body,
   );
   return unwrapResponse(data);
@@ -47,11 +47,11 @@ export const updateApplicationStatus = async (
 
 /** DELETE v1/gatherings/:gatheringId/applications/:applicationId — 신청 취소(신청자 본인) */
 export const deleteApplication = async (gatheringId: number, applicationId: number): Promise<void> => {
-  await axiosClient.delete(`/gatherings/${gatheringId}/applications/${applicationId}`);
+  await axiosClient.delete(`/v1/gatherings/${gatheringId}/applications/${applicationId}`);
 };
 
 /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
 export const getMyApplicationList = async (): Promise<MyApplicationListResponse> => {
-  const { data } = await axiosClient.get<ApiResponse<MyApplicationListResponse>>(`/users/me/applications`);
+  const { data } = await axiosClient.get<ApiResponse<MyApplicationListResponse>>(`/v1/users/me/applications`);
   return unwrapResponse(data);
 };

--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -1,4 +1,5 @@
 import { queryOptions, useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+
 import {
   createApplication,
   deleteApplication,
@@ -6,13 +7,17 @@ import {
   getMyApplicationList,
   updateApplicationStatus,
 } from '.';
+
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
+
+import { GATHERING_TAGS } from '../gatherings';
+
 import {
   ApplyGatheringForm,
   CreateApplicationResponse,
   UpdateApplicationStatusRequest,
   UpdateApplicationStatusResponse,
 } from './types';
-import { invalidateServerCache } from '@/lib/invalidateServerCache';
 
 export const applicationKeys = {
   all: ['applications'] as const,
@@ -49,8 +54,8 @@ export const useCreateApplication = (
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all });
 
-      invalidateServerCache('gatherings');
-      invalidateServerCache(`gatherings-detail-${gatheringId}`);
+      invalidateServerCache(GATHERING_TAGS.all);
+      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -12,6 +12,7 @@ import {
   UpdateApplicationStatusRequest,
   UpdateApplicationStatusResponse,
 } from './types';
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
 
 export const applicationKeys = {
   all: ['applications'] as const,
@@ -47,6 +48,9 @@ export const useCreateApplication = (
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all });
+
+      invalidateServerCache('gatherings');
+      invalidateServerCache(`gatherings-detail-${gatheringId}`);
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
@@ -8,6 +9,7 @@ import { useCreateApplication } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 import { BottomSheet } from '@/components/ui/BottomSheet';
+
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
 

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -9,6 +9,7 @@ import { useCreateApplication } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 import { BottomSheet } from '@/components/ui/BottomSheet';
+import { useFunnel } from '@/hooks/useFunnel';
 
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
@@ -21,7 +22,7 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
   const [isFavorite, setIsFavorite] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const [step, setStep] = useState<'APPLY' | 'SUCCESS'>('APPLY');
+  const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
@@ -61,13 +62,16 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
       </div>
 
       <BottomSheet isOpen={isOpen} onClose={handleClose}>
-        <BottomSheet.Header showCloseButton={step === 'APPLY'}>{null}</BottomSheet.Header>
+        <BottomSheet.Header showCloseButton={currentStep === 'APPLY'}>{null}</BottomSheet.Header>
         <BottomSheet.Body className='scrollbar-none pb-10'>
-          {step === 'APPLY' ? (
-            <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
-          ) : (
-            <GatheringApplySuccess onClose={handleClose} />
-          )}
+          <Funnel>
+            <Step name='APPLY'>
+              <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
+            </Step>
+            <Step name='SUCCESS'>
+              <GatheringApplySuccess onClose={handleClose} />
+            </Step>
+          </Funnel>
         </BottomSheet.Body>
       </BottomSheet>
     </>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { useState } from 'react';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
 
-import { gatheringQueries } from '@/api/gatherings/queries';
+import { gatheringQueries, gatheringKeys } from '@/api/gatherings/queries';
+import { useCreateApplication } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
+import { BottomSheet } from '@/components/ui/BottomSheet';
+import { GatheringApplyForm } from '../GatheringApplyForm';
+import { GatheringApplySuccess } from '../GatheringApplySuccess';
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
+import { GATHERING_TAGS } from '@/api/gatherings';
 
 interface FloatingActionBarProps {
   gatheringId: number;
@@ -13,30 +19,60 @@ interface FloatingActionBarProps {
 
 export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+  const queryClient = useQueryClient();
   const [isFavorite, setIsFavorite] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [step, setStep] = useState<'APPLY' | 'SUCCESS'>('APPLY');
+
+  const { mutate, isPending } = useCreateApplication(gatheringId, {
+    onSuccess: () => {
+      setStep('SUCCESS');
+      invalidateServerCache(GATHERING_TAGS.all);
+      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
+    },
+  });
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setStep('APPLY');
+  };
 
   return (
-    <div className='border-gray-150 bg-gray-0 fixed right-0 bottom-0 left-0 z-50 border-t px-5 py-4 md:px-7 md:py-6 xl:hidden'>
-      <div className='mx-auto flex items-center gap-3'>
-        <Button
-          variant='bookmark'
-          size='bookmark-lg'
-          data-selected={isFavorite}
-          aria-label='찜하기'
-          aria-pressed={isFavorite}
-          onClick={() => setIsFavorite((prev) => !prev)}
-          className='h-13.5 md:h-18'
-        >
-          <HeartIcon size={24} variant={isFavorite ? 'filled' : 'outline'} />
-        </Button>
-        <Button
-          variant='action'
-          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-          disabled={data.myApplicationStatus === 'PENDING'}
-        >
-          {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
-        </Button>
+    <>
+      <div className='border-gray-150 bg-gray-0 fixed right-0 bottom-0 left-0 z-40 border-t px-5 py-4 md:px-7 md:py-6 xl:hidden'>
+        <div className='mx-auto flex items-center gap-3'>
+          <Button
+            variant='bookmark'
+            size='bookmark-lg'
+            data-selected={isFavorite}
+            aria-label='찜하기'
+            aria-pressed={isFavorite}
+            onClick={() => setIsFavorite((prev) => !prev)}
+            className='h-13.5 md:h-18'
+          >
+            <HeartIcon size={24} variant={isFavorite ? 'filled' : 'outline'} />
+          </Button>
+          <Button
+            variant='action'
+            className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+            disabled={data.myApplicationStatus === 'PENDING'}
+            onClick={() => setIsOpen(true)}
+          >
+            {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
+          </Button>
+        </div>
       </div>
-    </div>
+
+      <BottomSheet isOpen={isOpen} onClose={handleClose}>
+        <BottomSheet.Header showCloseButton={step === 'APPLY'}>{null}</BottomSheet.Header>
+        <BottomSheet.Body className='scrollbar-none pb-10'>
+          {step === 'APPLY' ? (
+            <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
+          ) : (
+            <GatheringApplySuccess onClose={handleClose} />
+          )}
+        </BottomSheet.Body>
+      </BottomSheet>
+    </>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -10,8 +10,6 @@ import { HeartIcon } from '@/components/ui/Icon';
 import { BottomSheet } from '@/components/ui/BottomSheet';
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
-import { invalidateServerCache } from '@/lib/invalidateServerCache';
-import { GATHERING_TAGS } from '@/api/gatherings';
 
 interface FloatingActionBarProps {
   gatheringId: number;
@@ -19,7 +17,6 @@ interface FloatingActionBarProps {
 
 export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
-  const queryClient = useQueryClient();
   const [isFavorite, setIsFavorite] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<'APPLY' | 'SUCCESS'>('APPLY');

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { gatheringQueries, gatheringKeys } from '@/api/gatherings/queries';
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { useCreateApplication } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -27,8 +27,6 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
       setStep('SUCCESS');
-      invalidateServerCache(GATHERING_TAGS.all);
-      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
     },
   });
 

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+import { applyGatheringFormSchema } from '@/api/applications/schemas';
+import { Button } from '@/components/ui/Button';
+import { Textarea } from '@/components/ui/Textarea';
+import { CheckIcon } from '@/components/ui/Icon';
+import { cn } from '@/lib/cn';
+
+const formSchema = applyGatheringFormSchema.extend({
+  agreement: z.boolean().refine((val) => val === true, {
+    message: '내용을 확인했으며 제공에 동의해야 합니다.',
+  }),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface GatheringApplyFormProps {
+  gatheringTitle: string;
+  onSubmit: (values: z.infer<typeof applyGatheringFormSchema>) => void;
+  isLoading?: boolean;
+}
+
+export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: GatheringApplyFormProps) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+    defaultValues: {
+      personalGoal: '',
+      selfIntroduction: '',
+      agreement: false,
+    },
+  });
+
+  const personalGoal = watch('personalGoal');
+  const selfIntroduction = watch('selfIntroduction');
+  const agreement = watch('agreement');
+
+  const handleFormSubmit = (data: FormValues) => {
+    const { agreement, ...submitData } = data;
+    onSubmit(submitData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleFormSubmit)} className='flex flex-col gap-8'>
+      <div className='flex flex-col gap-2'>
+        <h2 className='text-h3-b text-gray-900'>모임 신청</h2>
+        <p className='text-body-02-m text-gray-600'>
+          신청 모임 <span className='mx-2 text-gray-300'>|</span>{' '}
+          <span className='text-body-02-b text-gray-900'>{gatheringTitle}</span>
+        </p>
+      </div>
+
+      <div className='flex flex-col gap-6'>
+        <div className='relative flex flex-col gap-2'>
+          <div className='flex justify-between'>
+            <label className='text-body-02-b text-gray-900'>
+              나의 목표 <span className='text-blue-300'>*</span>
+            </label>
+          </div>
+          <Textarea
+            {...register('personalGoal')}
+            placeholder='이 모임에서 달성할 목표를 적어주세요. (최소 5자, 최대 200자)'
+            className='min-h-[160px]'
+            error={errors.personalGoal?.message}
+          />
+          <span className='text-small-01-r absolute right-4 bottom-10 text-gray-400'>{personalGoal.length}/200</span>
+        </div>
+
+        <div className='relative flex flex-col gap-2'>
+          <label className='text-body-02-b text-gray-900'>한 줄 소개</label>
+          <Textarea
+            {...register('selfIntroduction')}
+            placeholder='(선택) 모임장에게 한마디를 적어주세요.'
+            className='min-h-[120px]'
+            error={errors.selfIntroduction?.message}
+          />
+          <span className='text-small-01-r absolute right-4 bottom-10 text-gray-400'>
+            {selfIntroduction?.length}/100
+          </span>
+        </div>
+      </div>
+
+      <div className='flex flex-col gap-4'>
+        <p className='text-body-02-b text-gray-900'>팀 구성을 위해 닉네임과 평판 점수가 모임장에게 전달됩니다.</p>
+        <label className='flex cursor-pointer items-center gap-2'>
+          <div className='relative flex h-5 w-5 items-center justify-center'>
+            <input type='checkbox' {...register('agreement')} className='peer sr-only' />
+            <div className='flex h-6 w-6 items-center justify-center rounded-md border border-gray-200 bg-white transition-colors peer-checked:border-blue-300 peer-checked:bg-blue-300'>
+              <CheckIcon size={16} className='text-white' />
+            </div>
+          </div>
+          <span className={cn('text-body-02-m transition-colors', agreement ? 'text-gray-900' : 'text-gray-400')}>
+            내용을 확인했으며 제공에 동의합니다.
+          </span>
+        </label>
+      </div>
+
+      <Button type='submit' variant='action' className='w-full' disabled={!isValid || isLoading}>
+        {isLoading ? '신청 중...' : '작성 완료'}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringApplySuccess/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringApplySuccess/index.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { CheckIcon } from '@/components/ui/Icon';
+import { Button } from '@/components/ui/Button';
+
+interface GatheringApplySuccessProps {
+  onClose: () => void;
+}
+
+export function GatheringApplySuccess({ onClose }: GatheringApplySuccessProps) {
+  return (
+    <div className='flex flex-col items-center py-10 text-center'>
+      <div className='bg-gradient-primary mb-10 flex h-20 w-20 items-center justify-center rounded-full md:h-30 md:w-30'>
+        <CheckIcon className='size-20 text-white md:size-30' />
+      </div>
+
+      <div className='mb-20 flex flex-col gap-2'>
+        <h2 className='text-h5-b md:text-h3-b text-gray-900'>신청이 완료되었어요!</h2>
+        <p className='text-small-01-r md:text-body-01-r text-gray-600'>모임장의 승인을 기다려주세요.</p>
+      </div>
+
+      <Button variant='action' className='w-full' onClick={onClose}>
+        확인
+      </Button>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { gatheringQueries, gatheringKeys } from '@/api/gatherings/queries';
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { useCreateApplication } from '@/api/applications/queries';
 import type { GatheringType } from '@/api/gatherings/types';
 import { Button } from '@/components/ui/Button';

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -15,8 +15,6 @@ import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
-import { invalidateServerCache } from '@/lib/invalidateServerCache';
-import { GATHERING_TAGS } from '@/api/gatherings';
 
 const TYPE_ICON: Record<GatheringType, typeof StudyIcon> = {
   스터디: StudyIcon,

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
+import { useFunnel } from '@/hooks/useFunnel';
 
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
@@ -31,7 +32,7 @@ interface GatheringInfoAsideProps {
 export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
   const [isFavorite, setIsFavorite] = useState(false);
-  const [step, setStep] = useState<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
+  const { Funnel, Step, setStep } = useFunnel<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
@@ -54,66 +55,68 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
         </div>
       </div>
 
-      {step === 'APPLY' && (
-        <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
-          <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
-        </div>
-      )}
+      <Funnel>
+        <Step name='APPLY'>
+          <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+            <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
+          </div>
+        </Step>
 
-      {step === 'SUCCESS' && (
-        <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
-          <GatheringApplySuccess onClose={() => setStep('DEFAULT')} />
-        </div>
-      )}
+        <Step name='SUCCESS'>
+          <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+            <GatheringApplySuccess onClose={() => setStep('DEFAULT')} />
+          </div>
+        </Step>
 
-      {step === 'DEFAULT' && (
-        <GatheringCard className='border-focus-100 w-full border'>
-          <GatheringCard.Header className='items-center'>
-            <Tag
-              variant='category'
-              icon={<TypeIcon size={14} className='text-blue-200' />}
-              label={data.type}
-              sublabel={data.category}
-            />
+        <Step name='DEFAULT'>
+          <GatheringCard className='border-focus-100 w-full border'>
+            <GatheringCard.Header className='items-center'>
+              <Tag
+                variant='category'
+                icon={<TypeIcon size={14} className='text-blue-200' />}
+                label={data.type}
+                sublabel={data.category}
+              />
+              <Button
+                variant='bookmark'
+                size='bookmark-sm'
+                data-selected={isFavorite}
+                aria-label='찜하기'
+                aria-pressed={isFavorite}
+                onClick={() => setIsFavorite((prev) => !prev)}
+              >
+                <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+              </Button>
+            </GatheringCard.Header>
+
+            <GatheringCard.Body className='mb-10 gap-2'>
+              <div className='flex flex-wrap gap-1'>
+                {data.tags.map((tag) => (
+                  <span key={tag} className='text-body-02-r text-gray-700'>
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+              <p className='text-body-01-b text-gray-900'>{data.title}</p>
+              <p className='text-small-01-r text-gray-800'>{data.shortDescription}</p>
+            </GatheringCard.Body>
+
+            <GatheringCard.Footer className='flex-col'>
+              <InfoAccordion data={data} className='mb-7' />
+              <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
+            </GatheringCard.Footer>
+
             <Button
-              variant='bookmark'
-              size='bookmark-sm'
-              data-selected={isFavorite}
-              aria-label='찜하기'
-              aria-pressed={isFavorite}
-              onClick={() => setIsFavorite((prev) => !prev)}
+              variant='action'
+              className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+              disabled={data.myApplicationStatus === 'PENDING'}
+              onClick={() => setStep('APPLY')}
             >
-              <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+              {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
             </Button>
-          </GatheringCard.Header>
-
-          <GatheringCard.Body className='mb-10 gap-2'>
-            <div className='flex flex-wrap gap-1'>
-              {data.tags.map((tag) => (
-                <span key={tag} className='text-body-02-r text-gray-700'>
-                  #{tag}
-                </span>
-              ))}
-            </div>
-            <p className='text-body-01-b text-gray-900'>{data.title}</p>
-            <p className='text-small-01-r text-gray-800'>{data.shortDescription}</p>
-          </GatheringCard.Body>
-
-          <GatheringCard.Footer className='flex-col'>
-            <InfoAccordion data={data} className='mb-7' />
-            <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
-          </GatheringCard.Footer>
-
-          <Button
-            variant='action'
-            className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-            disabled={data.myApplicationStatus === 'PENDING'}
-            onClick={() => setStep('APPLY')}
-          >
-            {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
-          </Button>
-        </GatheringCard>
-      )}
+          </GatheringCard>
+        </Step>
+      </Funnel>
     </div>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -35,8 +35,6 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
       setStep('SUCCESS');
-      invalidateServerCache(GATHERING_TAGS.all);
-      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
     },
   });
 

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { gatheringQueries } from '@/api/gatherings/queries';
+import { gatheringQueries, gatheringKeys } from '@/api/gatherings/queries';
+import { useCreateApplication } from '@/api/applications/queries';
 import type { GatheringType } from '@/api/gatherings/types';
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
@@ -12,6 +13,10 @@ import { Tag } from '@/components/ui/Tag';
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
+import { GatheringApplyForm } from '../GatheringApplyForm';
+import { GatheringApplySuccess } from '../GatheringApplySuccess';
+import { invalidateServerCache } from '@/lib/invalidateServerCache';
+import { GATHERING_TAGS } from '@/api/gatherings';
 
 const TYPE_ICON: Record<GatheringType, typeof StudyIcon> = {
   스터디: StudyIcon,
@@ -25,11 +30,21 @@ interface GatheringInfoAsideProps {
 export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
   const [isFavorite, setIsFavorite] = useState(false);
+  const [step, setStep] = useState<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
+
+  const { mutate, isPending } = useCreateApplication(gatheringId, {
+    onSuccess: () => {
+      setStep('SUCCESS');
+      invalidateServerCache(GATHERING_TAGS.all);
+      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
+    },
+  });
 
   const TypeIcon = TYPE_ICON[data.type];
 
   return (
     <div className='sticky top-24'>
+      {/* 모집 상태 바 - 항상 노출 */}
       <div className='border-focus-100 mt-15 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
         <div className='text-body-02-sb flex items-center text-blue-400'>모집중</div>
         <div className='flex items-center gap-2'>
@@ -39,51 +54,67 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
           </Tag>
         </div>
       </div>
-      <GatheringCard className='border-focus-100 w-full border'>
-        <GatheringCard.Header className='items-center'>
-          <Tag
-            variant='category'
-            icon={<TypeIcon size={14} className='text-blue-200' />}
-            label={data.type}
-            sublabel={data.category}
-          />
+
+      {step === 'APPLY' && (
+        <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+          <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
+        </div>
+      )}
+
+      {step === 'SUCCESS' && (
+        <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+          <GatheringApplySuccess onClose={() => setStep('DEFAULT')} />
+        </div>
+      )}
+
+      {step === 'DEFAULT' && (
+        <GatheringCard className='border-focus-100 w-full border'>
+          <GatheringCard.Header className='items-center'>
+            <Tag
+              variant='category'
+              icon={<TypeIcon size={14} className='text-blue-200' />}
+              label={data.type}
+              sublabel={data.category}
+            />
+            <Button
+              variant='bookmark'
+              size='bookmark-sm'
+              data-selected={isFavorite}
+              aria-label='찜하기'
+              aria-pressed={isFavorite}
+              onClick={() => setIsFavorite((prev) => !prev)}
+            >
+              <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+            </Button>
+          </GatheringCard.Header>
+
+          <GatheringCard.Body className='mb-10 gap-2'>
+            <div className='flex flex-wrap gap-1'>
+              {data.tags.map((tag) => (
+                <span key={tag} className='text-body-02-r text-gray-700'>
+                  #{tag}
+                </span>
+              ))}
+            </div>
+            <p className='text-body-01-b text-gray-900'>{data.title}</p>
+            <p className='text-small-01-r text-gray-800'>{data.shortDescription}</p>
+          </GatheringCard.Body>
+
+          <GatheringCard.Footer className='flex-col'>
+            <InfoAccordion data={data} className='mb-7' />
+            <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
+          </GatheringCard.Footer>
+
           <Button
-            variant='bookmark'
-            size='bookmark-sm'
-            data-selected={isFavorite}
-            aria-label='찜하기'
-            aria-pressed={isFavorite}
-            onClick={() => setIsFavorite((prev) => !prev)}
+            variant='action'
+            className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
+            disabled={data.myApplicationStatus === 'PENDING'}
+            onClick={() => setStep('APPLY')}
           >
-            <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+            {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
           </Button>
-        </GatheringCard.Header>
-
-        <GatheringCard.Body className='mb-10 gap-2'>
-          <div className='flex flex-wrap gap-1'>
-            {data.tags.map((tag) => (
-              <span key={tag} className='text-body-02-r text-gray-700'>
-                #{tag}
-              </span>
-            ))}
-          </div>
-          <p className='text-body-01-b text-gray-900'>{data.title}</p>
-          <p className='text-small-01-r text-gray-800'>{data.shortDescription}</p>
-        </GatheringCard.Body>
-
-        <GatheringCard.Footer className='flex-col'>
-          <InfoAccordion data={data} className='mb-7' />
-          <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
-        </GatheringCard.Footer>
-
-        <Button
-          variant='action'
-          className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-          disabled={data.myApplicationStatus === 'PENDING'}
-        >
-          {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
-        </Button>
-      </GatheringCard>
+        </GatheringCard>
+      )}
     </div>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -1,20 +1,23 @@
 'use client';
 
 import { useState } from 'react';
+
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { useCreateApplication } from '@/api/applications/queries';
-import type { GatheringType } from '@/api/gatherings/types';
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
+
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
+
+import type { GatheringType } from '@/api/gatherings/types';
 
 const TYPE_ICON: Record<GatheringType, typeof StudyIcon> = {
   스터디: StudyIcon,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -256,6 +256,38 @@
   animation: slide-down-out 0.3s ease-in forwards;
 }
 
+@keyframes funnel-in {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes funnel-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+}
+
+.animate-funnel-in {
+  animation: funnel-in 0.3s ease-out forwards;
+}
+
+.animate-funnel-out {
+  animation: funnel-out 0.3s ease-in forwards;
+}
+
 @utility scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -35,7 +35,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
           {label}
         </label>
       )}
-      {hasError ? control : <div className={fieldGradientFocusWrapperClass}>{control}</div>}
+      <div className={cn(hasError ? 'w-full' : fieldGradientFocusWrapperClass)}>{control}</div>
       {error && (
         <p className='text-xs text-red-200' role='alert'>
           {error}

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -45,7 +45,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
           {label}
         </label>
       )}
-      {hasError ? control : <div className={fieldGradientFocusWrapperClass}>{control}</div>}
+      <div className={cn(hasError ? 'w-full' : fieldGradientFocusWrapperClass)}>{control}</div>
       {error && (
         <p className='text-xs text-red-200' role='alert'>
           {error}

--- a/src/hooks/useFunnel.test.tsx
+++ b/src/hooks/useFunnel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useFunnel } from './useFunnel';
 
@@ -37,10 +37,23 @@ describe('useFunnel (상태 기반 다단계 전환)', () => {
     expect(screen.queryByText('모임 신청 폼')).not.toBeInTheDocument();
 
     await user.click(screen.getByText('참여 신청하기'));
-    expect(screen.getByText('모임 신청 폼')).toBeInTheDocument();
-    expect(screen.queryByText('피그마 기초 스터디')).not.toBeInTheDocument();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('모임 신청 폼')).toBeInTheDocument();
+        expect(screen.queryByText('피그마 기초 스터디')).not.toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
 
     await user.click(screen.getByText('작성 완료'));
-    expect(screen.getByText('신청이 완료되었어요!')).toBeInTheDocument();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('신청이 완료되었어요!')).toBeInTheDocument();
+        expect(screen.queryByText('모임 신청 폼')).not.toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
   });
 });

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,6 +1,6 @@
 import React, { isValidElement, useMemo, type ReactElement, type ReactNode } from 'react';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 export interface StepProps<S extends string> {
   name: S;
@@ -16,7 +16,18 @@ function StepComponent<S extends string>({ children }: StepProps<S>): ReactEleme
 }
 
 export const useFunnel = <S extends string>(defaultStep: S) => {
-  const [step, setStep] = useState<S>(defaultStep);
+  const [step, setStepState] = useState<S>(defaultStep);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  // Transition handler that wraps the actual state update
+  const setStep = useCallback((nextStep: S) => {
+    setIsAnimating(true);
+    // 300ms match the duration in globals.css (.animate-funnel-out)
+    setTimeout(() => {
+      setStepState(nextStep);
+      setIsAnimating(false);
+    }, 300);
+  }, []);
 
   const Funnel = useMemo(() => {
     return function FunnelComponent({ children }: FunnelProps<S>) {
@@ -24,9 +35,15 @@ export const useFunnel = <S extends string>(defaultStep: S) => {
 
       const targetStep = childArray.find((childStep) => childStep.props.name === step);
 
-      return targetStep || null;
+      if (!targetStep) return null;
+
+      return (
+        <div key={step} className={isAnimating ? 'animate-funnel-out' : 'animate-funnel-in'}>
+          {targetStep}
+        </div>
+      );
     };
-  }, [step]);
+  }, [step, isAnimating]);
 
   return { Funnel, Step: StepComponent<S>, setStep, currentStep: step };
 };


### PR DESCRIPTION
## ❓ 이슈

- close #140 

## ✍️ Description

모임 참여 신청 기능을 구현합니다. PC에서는 사이드바 카드 내에서 폼으로 전환되고, 태블릿/모바일에서는 BottomSheet로 폼이 표시됩니다. 신청 완료 시 성공 상태를 보여주고 버튼이 "참여 대기중"으로 전환됩니다.

## 📸 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/f16f048f-f597-4306-ac37-00c4ac9f6143


https://github.com/user-attachments/assets/7599f427-97eb-4ce9-aa3e-90b4b7c64c35


https://github.com/user-attachments/assets/49007614-e453-491b-8e0f-ce97a441f3f0



## ✅ Checklist
- [x] 엔드포인트 수정
  - [x] fix: 엔드포인트 수정(v1 누락)
- [x] 모임 참여신청 플로우 구현
  - [x] 기존의 Aside(pc용 신청하기)나 ActionBar(모바일/태블릿용 신청하기)를 누르면 GatheringApplyForm이 등장하게 구현
  - [x] useCreateApplication훅을 통해 해당 모임에 신청 api연결, 이때 invalidateServerCache 주입을 통한 이중 캐시 무효화 구현
  - [x] GatheringApplyForm에서는 rhf zod를 통한 폼 유효성 검사, watch를 통한 리렌더링 유발 -> 실시간 텍스트 수 변경 구현
  - [x] GahteringApplySuccess에서 신청 완료 표시, 확인 버튼 누르면 해당 플로우 종료
  - [x] useFunnel 훅을 통해 스텝 구현, 애니메이션 적용
- [x] 공통 컴포넌트 Input, Textarea 수정
  - [x] 기존 코드는 해당 공통 컴포넌트 내부에서 에러 유무에 따라 감싸고 있던 부모 div 태그가 마운트/언마운트 되는 변화로 인한 포커스 잃는 현상 발생
  - [x] 컴포넌트 구조 개선(에러 상태와 관계 없이 항상 동일한 부모 div 유지하도록)을 통한 포커스 잃음 현상 개선

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)