### PR TITLE
[SM-110] feat: 활동 요약 탭의 이번주 요약 카드와 내/팀 달성률 게이지 차트 구현

### DIFF
--- a/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
@@ -1,6 +1,7 @@
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 
 import { MotivationSection } from '../MotivationSection';
+import { WeeklySummarySection } from '../WeeklySummarySection';
 
 import type { DashboardTab } from '../../_constants';
 
@@ -9,17 +10,41 @@ interface DashboardContentProps {
   gatheringId: number;
 }
 
+function WeeklySummarySkeleton() {
+  return (
+    <div className='border-gray-150 h-[677px] animate-pulse rounded-2xl border bg-white p-4 shadow-(--shadow-02) md:h-[1044px] md:p-6 lg:h-[723px]'>
+      <div className='bg-gray-150 mb-4 h-6 w-32 rounded' />
+      <div className='flex flex-col gap-4'>
+        <div className='h-20 rounded-2xl bg-gray-100' />
+        <div className='flex flex-col gap-4 lg:flex-row'>
+          <div className='h-60 flex-1 rounded-2xl bg-gray-100' />
+          <div className='h-60 flex-1 rounded-2xl bg-gray-100' />
+        </div>
+        <div className='h-20 rounded-2xl bg-gray-100' />
+      </div>
+    </div>
+  );
+}
+
 export function DashboardContent({ activeTab, gatheringId }: DashboardContentProps) {
   return (
     <section className='px-4 py-10 md:px-8 xl:px-30'>
       <div>
         {activeTab === 'summary' && (
-          <SuspenseBoundary
-            pendingFallback={<div className='h-96 animate-pulse rounded-2xl bg-gray-100' />}
-            errorFallback={<p className='text-body-02-r text-gray-400'>동기부여 섹션을 불러오는데 실패했습니다.</p>}
-          >
-            <MotivationSection gatheringId={gatheringId} />
-          </SuspenseBoundary>
+          <>
+            <SuspenseBoundary
+              pendingFallback={<div className='h-96 animate-pulse rounded-2xl bg-gray-100' />}
+              errorFallback={<p className='text-body-02-r text-gray-400'>동기부여 섹션을 불러오는데 실패했습니다.</p>}
+            >
+              <MotivationSection gatheringId={gatheringId} />
+            </SuspenseBoundary>
+            <SuspenseBoundary
+              pendingFallback={<WeeklySummarySkeleton />}
+              errorFallback={<p className='py-20 text-center text-gray-500'>활동 요약을 불러오는데 실패했습니다.</p>}
+            >
+              <WeeklySummarySection gatheringId={gatheringId} />
+            </SuspenseBoundary>
+          </>
         )}
       </div>
     </section>

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
@@ -31,7 +31,7 @@ export function DashboardContent({ activeTab, gatheringId }: DashboardContentPro
     <section className='px-4 py-10 md:px-8 xl:px-30'>
       <div>
         {activeTab === 'summary' && (
-          <>
+          <div className='flex flex-col gap-6'>
             <SuspenseBoundary
               pendingFallback={<div className='h-96 animate-pulse rounded-2xl bg-gray-100' />}
               errorFallback={<p className='text-body-02-r text-gray-400'>동기부여 섹션을 불러오는데 실패했습니다.</p>}
@@ -40,11 +40,11 @@ export function DashboardContent({ activeTab, gatheringId }: DashboardContentPro
             </SuspenseBoundary>
             <SuspenseBoundary
               pendingFallback={<WeeklySummarySkeleton />}
-              errorFallback={<p className='py-20 text-center text-gray-500'>활동 요약을 불러오는데 실패했습니다.</p>}
+              errorFallback={<p className='text-body-02-r text-gray-400'>활동 요약을 불러오는데 실패했습니다.</p>}
             >
               <WeeklySummarySection gatheringId={gatheringId} />
             </SuspenseBoundary>
-          </>
+          </div>
         )}
       </div>
     </section>

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardHeader/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardHeader/index.tsx
@@ -1,13 +1,11 @@
 'use client';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { differenceInDays, differenceInWeeks } from 'date-fns';
-
 import { AvatarGroup } from '@/components/ui/AvatarGroup';
 import { StudyIcon, ProjectIcon, ArrowIcon, PeriodIcon, TimeIcon, PeopleIcon, RisingIcon } from '@/components/ui/Icon';
 import { cn } from '@/lib/cn';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
-import { formatDateDot } from '@/lib/formatGatheringDate';
+import { formatDateDot, getCurrentWeek, getRemainingDays } from '@/lib/formatGatheringDate';
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { achievementQueries } from '@/api/achievements/queries';
 
@@ -40,11 +38,8 @@ export function DashboardHeader({ gatheringId }: DashboardHeaderProps) {
 
   const TypeIcon = TYPE_ICON[gathering.type];
 
-  const now = new Date();
-  const startDate = new Date(gathering.startDate);
-  const endDate = new Date(gathering.endDate);
-  const currentWeek = Math.max(1, differenceInWeeks(now, startDate) + 1);
-  const daysRemaining = Math.max(0, differenceInDays(endDate, now));
+  const currentWeek = getCurrentWeek(gathering.startDate);
+  const daysRemaining = getRemainingDays(gathering.endDate);
 
   const avatars = gathering.members.map((member) => ({
     id: member.userId,

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
@@ -1,0 +1,97 @@
+interface AchievementGaugeProps {
+  label: string;
+  rate: number;
+  arcColor: string;
+}
+
+const CX = 200;
+const CY = 180;
+const RADIUS = 150;
+const STROKE_WIDTH = 20;
+
+export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProps) {
+  // 0~99.99 클램프 (rate=100일 때 start/end 동일점 문제 방지)
+  const clampedRate = Math.min(Math.max(rate, 0), 99.99);
+  const endAngleRad = Math.PI - (clampedRate / 100) * Math.PI;
+  const endX = CX + RADIUS * Math.cos(endAngleRad);
+  const endY = CY - RADIUS * Math.sin(endAngleRad);
+
+  const startX = CX - RADIUS;
+  const startY = CY;
+  const endTrackX = CX + RADIUS;
+
+  const gradientId = `gauge-gradient-${label.replace(/\s/g, '-')}`;
+  const bgGradientId = `gauge-bg-${label.replace(/\s/g, '-')}`;
+  const markerGradientId = `marker-gradient-${label.replace(/\s/g, '-')}`;
+
+  return (
+    <div className='flex flex-1 flex-col rounded-2xl bg-gray-100 p-4 md:p-6'>
+      <svg viewBox='0 0 400 220' className='w-full' aria-label={`${label} ${rate}%`}>
+        <defs>
+          {/* 반원 안쪽 배경 그라데이션 */}
+          <linearGradient id={bgGradientId} x1='0%' y1='0%' x2='100%' y2='0%'>
+            <stop offset='0%' stopColor='#e8f4ff' />
+            <stop offset='100%' stopColor='#ffffff' stopOpacity='0' />
+          </linearGradient>
+          {/* 끝점 마커 그라데이션 */}
+          <linearGradient id={markerGradientId} x1='0%' y1='0%' x2='100%' y2='0%'>
+            <stop offset='0%' stopColor='#1e58f8' />
+            <stop offset='100%' stopColor='#00ccff' />
+          </linearGradient>
+        </defs>
+
+        {/* 반원 안쪽 배경 채우기 */}
+        <path
+          d={`M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 0 1 ${endTrackX} ${startY} Z`}
+          fill={`url(#${bgGradientId})`}
+        />
+
+        {/* 배경 arc (회색) */}
+        <path
+          d={`M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 0 1 ${endTrackX} ${startY}`}
+          fill='none'
+          stroke='#dddddd'
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap='round'
+        />
+
+        {/* 진행 arc */}
+        <path
+          d={`M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 0 1 ${endX} ${endY}`}
+          fill='none'
+          stroke={arcColor}
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap='round'
+        />
+
+        {/* 끝점 마커 원 (테두리만, 가운데 비어있음) */}
+        <circle cx={endX} cy={endY} r={10} fill='white' stroke={`url(#${markerGradientId})`} strokeWidth={3} />
+
+        {/* 라벨 텍스트 (왼쪽 위) */}
+        <text
+          x={startX + 4}
+          y={50}
+          fontSize={16}
+          fontWeight={600}
+          fill='#737373'
+          className='text-small-01-sb md:text-h5-sb'
+        >
+          {label}
+        </text>
+
+        {/* 달성률 숫자 (반원 중앙) */}
+        <text x={CX} y={CY - 10} textAnchor='middle' fontSize={48} fontWeight={700} fill='#010937'>
+          {rate}%
+        </text>
+
+        {/* 0 / 100 라벨 */}
+        <text x={startX} y={CY + 28} textAnchor='middle' fontSize={12} fill='#bbbbbb'>
+          0
+        </text>
+        <text x={endTrackX} y={CY + 28} textAnchor='middle' fontSize={12} fill='#bbbbbb'>
+          100
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
@@ -4,10 +4,10 @@ interface AchievementGaugeProps {
   arcColor: string;
 }
 
-const CX = 200;
+const CX = 250;
 const CY = 180;
-const RADIUS = 150;
-const STROKE_WIDTH = 20;
+const RADIUS = 120;
+const STROKE_WIDTH = 15;
 
 export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProps) {
   // 0~99.99 클램프 (rate=100일 때 start/end 동일점 문제 방지)
@@ -20,7 +20,6 @@ export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProp
   const startY = CY;
   const endTrackX = CX + RADIUS;
 
-  const gradientId = `gauge-gradient-${label.replace(/\s/g, '-')}`;
   const bgGradientId = `gauge-bg-${label.replace(/\s/g, '-')}`;
   const markerGradientId = `marker-gradient-${label.replace(/\s/g, '-')}`;
 
@@ -28,10 +27,10 @@ export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProp
     <div className='flex flex-1 flex-col rounded-2xl bg-gray-100 p-4 md:p-6'>
       <svg viewBox='0 0 400 220' className='w-full' aria-label={`${label} ${rate}%`}>
         <defs>
-          {/* 반원 안쪽 배경 그라데이션 */}
-          <linearGradient id={bgGradientId} x1='0%' y1='0%' x2='100%' y2='0%'>
+          {/* 반원 안쪽 배경 그라데이션 (위→아래) */}
+          <linearGradient id={bgGradientId} x1='0%' y1='0%' x2='0%' y2='100%'>
             <stop offset='0%' stopColor='#e8f4ff' />
-            <stop offset='100%' stopColor='#ffffff' stopOpacity='0' />
+            <stop offset='100%' stopColor='#e8f4ff' stopOpacity='0' />
           </linearGradient>
           {/* 끝점 마커 그라데이션 */}
           <linearGradient id={markerGradientId} x1='0%' y1='0%' x2='100%' y2='0%'>
@@ -46,11 +45,11 @@ export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProp
           fill={`url(#${bgGradientId})`}
         />
 
-        {/* 배경 arc (회색) */}
+        {/* 배경 arc */}
         <path
           d={`M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 0 1 ${endTrackX} ${startY}`}
           fill='none'
-          stroke='#dddddd'
+          stroke='#dbf0ff'
           strokeWidth={STROKE_WIDTH}
           strokeLinecap='round'
         />
@@ -69,13 +68,18 @@ export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProp
 
         {/* 라벨 텍스트 (왼쪽 위) */}
         <text
-          x={startX + 4}
-          y={50}
+          x={startX - 120}
+          y={30}
           fontSize={16}
           fontWeight={600}
-          fill='#737373'
-          className='text-small-01-sb md:text-h5-sb'
+          fill='#a4a4a4'
+          className='text-small-02-sb md:text-body-01-sb'
         >
+          {label}
+        </text>
+
+        {/* 라벨 텍스트 (반원 내부 중앙) */}
+        <text x={CX} y={115} textAnchor='middle' fill='#a4a4a4' className='text-small-02-sb md:text-body-01-sb'>
           {label}
         </text>
 

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
@@ -25,7 +25,7 @@ export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProp
 
   return (
     <div className='flex flex-1 flex-col rounded-2xl bg-gray-100 p-4 md:p-6'>
-      <svg viewBox='0 0 400 220' className='w-full' aria-label={`${label} ${rate}%`}>
+      <svg viewBox='0 0 400 220' className='max-h-80 w-full' aria-label={`${label} ${rate}%`}>
         <defs>
           {/* 반원 안쪽 배경 그라데이션 (위→아래) */}
           <linearGradient id={bgGradientId} x1='0%' y1='0%' x2='0%' y2='100%'>

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/StreakBadge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/StreakBadge/index.tsx
@@ -1,0 +1,17 @@
+import { FlagIcon } from '@/components/ui/Icon/FlagIcon';
+
+interface StreakBadgeProps {
+  streakDays: number;
+}
+
+export function StreakBadge({ streakDays }: StreakBadgeProps) {
+  return (
+    <div className='flex h-20 items-center justify-center gap-3 rounded-2xl bg-blue-50'>
+      <FlagIcon size={16} className='shrink-0 text-blue-300 md:hidden' />
+      <FlagIcon size={28} className='hidden shrink-0 text-blue-300 md:block' />
+      <span className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-blue-300'>
+        {streakDays}일 연속 달성 중
+      </span>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/SummaryInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/SummaryInfoCard/index.tsx
@@ -1,0 +1,31 @@
+interface SummaryInfoCardProps {
+  currentWeek: number;
+  remainingDays: number;
+  incompleteTodoCount: number;
+}
+
+interface SummaryItemProps {
+  label: string;
+  value: string;
+}
+
+function SummaryItem({ label, value }: SummaryItemProps) {
+  return (
+    <div className='flex flex-col items-center gap-1 py-1'>
+      <span className='text-small-02-m md:text-small-01-m lg:text-body-01-m text-gray-600'>{label}</span>
+      <span className='text-body-02-b md:text-h5-b lg:text-h3-b text-gray-900'>{value}</span>
+    </div>
+  );
+}
+
+export function SummaryInfoCard({ currentWeek, remainingDays, incompleteTodoCount }: SummaryInfoCardProps) {
+  return (
+    <div className='rounded-2xl bg-gray-100'>
+      <div className='grid grid-cols-3 divide-x divide-gray-200 px-2 py-3'>
+        <SummaryItem label='현재 주차' value={`${currentWeek}주차`} />
+        <SummaryItem label='목표까지' value={`${remainingDays}일`} />
+        <SummaryItem label='남은 Todo' value={`${incompleteTodoCount}개`} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
 
 import { achievementQueries } from '@/api/achievements/queries';
 import { gatheringQueries } from '@/api/gatherings/queries';
@@ -20,13 +20,14 @@ interface WeeklySummarySectionProps {
 }
 
 export function WeeklySummarySection({ gatheringId }: WeeklySummarySectionProps) {
-  const { data: gatheringData } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+  const [{ data: gatheringData }, { data: achievementData }] = useSuspenseQueries({
+    queries: [gatheringQueries.detail(gatheringId), achievementQueries.detail(gatheringId)],
+  });
 
   const currentWeek = getCurrentWeek(gatheringData.startDate);
   const remainingDays = getRemainingDays(gatheringData.endDate);
 
   const { data: myTodoData } = useSuspenseQuery(todoQueries.myList(gatheringId, { week: currentWeek }));
-  const { data: achievementData } = useSuspenseQuery(achievementQueries.detail(gatheringId));
 
   const currentWeekTodos = myTodoData.todos.filter((t) => t.week === currentWeek);
   const incompleteTodoCount = currentWeekTodos.filter((t) => !t.isCompleted).length;

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/index.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { achievementQueries } from '@/api/achievements/queries';
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { todoQueries } from '@/api/todos/queries';
+import { getCurrentWeek, getRemainingDays } from '@/lib/formatGatheringDate';
+import { calculateStreakDays } from '@/lib/streakUtils';
+
+import { AchievementGauge } from './AchievementGauge';
+import { StreakBadge } from './StreakBadge';
+import { SummaryInfoCard } from './SummaryInfoCard';
+
+const MY_ARC_COLOR = '#1e58f8'; // blue-400
+const TEAM_ARC_COLOR = '#00ccff'; // blue-200
+
+interface WeeklySummarySectionProps {
+  gatheringId: number;
+}
+
+export function WeeklySummarySection({ gatheringId }: WeeklySummarySectionProps) {
+  const { data: gatheringData } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+
+  const currentWeek = getCurrentWeek(gatheringData.startDate);
+  const remainingDays = getRemainingDays(gatheringData.endDate);
+
+  const { data: myTodoData } = useSuspenseQuery(todoQueries.myList(gatheringId, { week: currentWeek }));
+  const { data: achievementData } = useSuspenseQuery(achievementQueries.detail(gatheringId));
+
+  const currentWeekTodos = myTodoData.todos.filter((t) => t.week === currentWeek);
+  const incompleteTodoCount = currentWeekTodos.filter((t) => !t.isCompleted).length;
+  const myRate = myTodoData.weeklyAchievementRate;
+  const teamRate = achievementData.teamWeeklyRates.find((r) => r.week === currentWeek)?.rate ?? 0;
+  const streakDays = calculateStreakDays(myTodoData.todos, currentWeek);
+
+  return (
+    <div className='border-gray-150 h-[677px] rounded-2xl border bg-white p-4 shadow-(--shadow-02) md:h-[1044px] md:p-6 lg:h-[723px]'>
+      <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb mb-4 text-gray-900'>이번주 요약 ✅</p>
+
+      <div className='flex flex-col gap-4'>
+        <SummaryInfoCard
+          currentWeek={currentWeek}
+          remainingDays={remainingDays}
+          incompleteTodoCount={incompleteTodoCount}
+        />
+
+        <div className='flex flex-col gap-4 lg:flex-row'>
+          <AchievementGauge label='내 달성률' rate={myRate} arcColor={MY_ARC_COLOR} />
+          <AchievementGauge label='팀 달성률' rate={teamRate} arcColor={TEAM_ARC_COLOR} />
+        </div>
+
+        {streakDays > 0 && <StreakBadge streakDays={streakDays} />}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/formatGatheringDate.ts
+++ b/src/lib/formatGatheringDate.ts
@@ -1,4 +1,4 @@
-import { differenceInDays, format, startOfDay } from 'date-fns';
+import { differenceInDays, differenceInWeeks, format, startOfDay } from 'date-fns';
 
 /** ISO 날짜 문자열을 "yyyy.MM.dd" 형식으로 변환 */
 export const formatDateDot = (dateString: string): string => {
@@ -9,6 +9,14 @@ export const formatDateDot = (dateString: string): string => {
 export const formatDateShort = (dateString: string): string => {
   return format(new Date(dateString), 'M/d');
 };
+
+/** startDate 기준 현재 주차 반환 (1-based) */
+export const getCurrentWeek = (startDate: string): number =>
+  Math.max(1, differenceInWeeks(startOfDay(new Date()), startOfDay(new Date(startDate))) + 1);
+
+/** endDate까지 남은 일수 반환 */
+export const getRemainingDays = (endDate: string): number =>
+  Math.max(0, differenceInDays(startOfDay(new Date(endDate)), startOfDay(new Date())));
 
 /** 대상 날짜까지의 D-day 텍스트 반환 ("D-3" | "D-Day" | "D+1") */
 export const formatDday = (targetDateString: string): string => {

--- a/src/lib/streakUtils.ts
+++ b/src/lib/streakUtils.ts
@@ -1,0 +1,17 @@
+import type { Todo } from '@/api/todos/types';
+
+/**
+ * 현재 주차부터 역순으로 완료된 todo가 하나라도 있는 연속 주차 수 × 7을 반환
+ *
+ * TODO: 정확한 일별 연속 달성 일수를 계산하려면 일별 완료 데이터(completedAt 등)가 필요함.
+ * 현재 API는 주차별 달성률만 제공하므로 주 단위로 근사 계산.
+ */
+export const calculateStreakDays = (todos: Todo[], currentWeek: number): number => {
+  let streak = 0;
+  for (let w = currentWeek; w >= 1; w--) {
+    const hasCompleted = todos.some((t) => t.week === w && t.isCompleted);
+    if (!hasCompleted) break;
+    streak++;
+  }
+  return streak * 7;
+};

--- a/src/mocks/handlers/achievements.ts
+++ b/src/mocks/handlers/achievements.ts
@@ -31,7 +31,7 @@ const mockSunny: GatheringAchievements = {
     },
     {
       userId: 3,
-      nickname: '박디자인',
+      nickname: '박프로',
       weeklyRates: [
         { week: 1, rate: 60.0 },
         { week: 2, rate: 100.0 },
@@ -150,7 +150,7 @@ const mockRanking: AchievementRanking = {
     {
       rank: 2,
       userId: 3,
-      nickname: '박디자인',
+      nickname: '박프로',
       profileImage: 'https://picsum.photos/seed/user3/200',
       overallRate: 80.0,
     },

--- a/src/mocks/handlers/todos.ts
+++ b/src/mocks/handlers/todos.ts
@@ -11,7 +11,7 @@ import type {
 } from '@/api/todos/types';
 
 let mockTodos: Todo[] = [
-  // userId 1 (김코딩) — week 1: 5/5 = 100%
+  // userId 1 (김코딩) — week 1 (2026-04-15 ~ 2026-04-21): 5/5 = 100%
   {
     id: 1,
     userId: 1,
@@ -19,7 +19,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'React 19 공식 문서 읽기',
     isCompleted: true,
-    createdAt: '2025-03-22T09:00:00Z',
+    createdAt: '2026-04-15T09:00:00Z',
   },
   {
     id: 2,
@@ -28,7 +28,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'TanStack Query v5 마이그레이션 정리',
     isCompleted: true,
-    createdAt: '2025-03-22T10:00:00Z',
+    createdAt: '2026-04-15T10:00:00Z',
   },
   {
     id: 3,
@@ -37,7 +37,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'Zustand 상태 관리 패턴 학습',
     isCompleted: true,
-    createdAt: '2025-03-22T11:00:00Z',
+    createdAt: '2026-04-16T09:00:00Z',
   },
   {
     id: 4,
@@ -46,7 +46,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'Next.js App Router 구조 파악',
     isCompleted: true,
-    createdAt: '2025-03-22T13:00:00Z',
+    createdAt: '2026-04-17T09:00:00Z',
   },
   {
     id: 5,
@@ -55,10 +55,10 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'TypeScript strict 모드 설정 복습',
     isCompleted: true,
-    createdAt: '2025-03-22T14:00:00Z',
+    createdAt: '2026-04-18T09:00:00Z',
   },
 
-  // userId 1 (김코딩) — week 2: 4/5 = 80%
+  // userId 1 (김코딩) — week 2 (2026-04-22 ~ 2026-04-28): 4/5 = 80%
   {
     id: 6,
     userId: 1,
@@ -66,7 +66,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'MSW로 API 모킹 구현',
     isCompleted: true,
-    createdAt: '2025-03-29T09:00:00Z',
+    createdAt: '2026-04-22T09:00:00Z',
   },
   {
     id: 7,
@@ -75,7 +75,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'react-hook-form + Zod 연동',
     isCompleted: true,
-    createdAt: '2025-03-29T10:00:00Z',
+    createdAt: '2026-04-22T10:00:00Z',
   },
   {
     id: 8,
@@ -84,7 +84,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'TailwindCSS v4 변경사항 정리',
     isCompleted: true,
-    createdAt: '2025-03-29T11:00:00Z',
+    createdAt: '2026-04-23T09:00:00Z',
   },
   {
     id: 9,
@@ -93,7 +93,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'Storybook 컴포넌트 문서화',
     isCompleted: true,
-    createdAt: '2025-03-29T13:00:00Z',
+    createdAt: '2026-04-24T09:00:00Z',
   },
   {
     id: 10,
@@ -102,10 +102,10 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'ErrorBoundary 패턴 정리',
     isCompleted: false,
-    createdAt: '2025-03-29T14:00:00Z',
+    createdAt: '2026-04-25T09:00:00Z',
   },
 
-  // userId 2 (이개발) — week 1: 4/5 = 80%
+  // userId 2 (이개발) — week 1 (2026-04-15 ~ 2026-04-21): 4/5 = 80%
   {
     id: 11,
     userId: 2,
@@ -113,7 +113,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'Axios 인터셉터 구현',
     isCompleted: true,
-    createdAt: '2025-03-23T09:00:00Z',
+    createdAt: '2026-04-15T09:00:00Z',
   },
   {
     id: 12,
@@ -122,7 +122,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'fetch vs axios 차이 정리',
     isCompleted: true,
-    createdAt: '2025-03-23T10:00:00Z',
+    createdAt: '2026-04-16T09:00:00Z',
   },
   {
     id: 13,
@@ -131,7 +131,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'Server Action 실습',
     isCompleted: true,
-    createdAt: '2025-03-23T11:00:00Z',
+    createdAt: '2026-04-17T09:00:00Z',
   },
   {
     id: 14,
@@ -140,7 +140,7 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'Next.js 캐싱 전략 학습',
     isCompleted: true,
-    createdAt: '2025-03-23T13:00:00Z',
+    createdAt: '2026-04-18T09:00:00Z',
   },
   {
     id: 15,
@@ -149,10 +149,10 @@ let mockTodos: Todo[] = [
     week: 1,
     content: 'HydrationBoundary 사용법 익히기',
     isCompleted: false,
-    createdAt: '2025-03-23T14:00:00Z',
+    createdAt: '2026-04-19T09:00:00Z',
   },
 
-  // userId 2 (이개발) — week 2: 3/5 = 60%
+  // userId 2 (이개발) — week 2 (2026-04-22 ~ 2026-04-28): 3/5 = 60%
   {
     id: 16,
     userId: 2,
@@ -160,7 +160,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'CVA로 버튼 컴포넌트 리팩터링',
     isCompleted: true,
-    createdAt: '2025-03-30T09:00:00Z',
+    createdAt: '2026-04-22T09:00:00Z',
   },
   {
     id: 17,
@@ -169,7 +169,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'Suspense Boundary 적용',
     isCompleted: true,
-    createdAt: '2025-03-30T10:00:00Z',
+    createdAt: '2026-04-23T09:00:00Z',
   },
   {
     id: 18,
@@ -178,7 +178,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'queryKey 팩토리 패턴 정리',
     isCompleted: true,
-    createdAt: '2025-03-30T11:00:00Z',
+    createdAt: '2026-04-24T09:00:00Z',
   },
   {
     id: 19,
@@ -187,7 +187,7 @@ let mockTodos: Todo[] = [
     week: 2,
     content: 'prefetchQuery 실습',
     isCompleted: false,
-    createdAt: '2025-03-30T13:00:00Z',
+    createdAt: '2026-04-25T09:00:00Z',
   },
   {
     id: 20,
@@ -196,101 +196,101 @@ let mockTodos: Todo[] = [
     week: 2,
     content: '낙관적 업데이트 구현',
     isCompleted: false,
-    createdAt: '2025-03-30T14:00:00Z',
+    createdAt: '2026-04-26T09:00:00Z',
   },
 
-  // userId 3 (박디자인) — week 1: 3/5 = 60%
+  // userId 3 (박프로) — week 1 (2026-04-15 ~ 2026-04-21): 3/5 = 60%
   {
     id: 21,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 1,
     content: 'Figma 컴포넌트 라이브러리 구성',
     isCompleted: true,
-    createdAt: '2025-03-24T09:00:00Z',
+    createdAt: '2026-04-15T09:00:00Z',
   },
   {
     id: 22,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 1,
     content: 'TailwindCSS 디자인 토큰 설정',
     isCompleted: true,
-    createdAt: '2025-03-24T10:00:00Z',
+    createdAt: '2026-04-16T09:00:00Z',
   },
   {
     id: 23,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 1,
     content: 'Storybook 디자인 시스템 문서화',
     isCompleted: true,
-    createdAt: '2025-03-24T11:00:00Z',
+    createdAt: '2026-04-17T09:00:00Z',
   },
   {
     id: 24,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 1,
     content: 'clsx + tailwind-merge 활용법 정리',
     isCompleted: false,
-    createdAt: '2025-03-24T13:00:00Z',
+    createdAt: '2026-04-18T09:00:00Z',
   },
   {
     id: 25,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 1,
     content: '반응형 레이아웃 패턴 학습',
     isCompleted: false,
-    createdAt: '2025-03-24T14:00:00Z',
+    createdAt: '2026-04-19T09:00:00Z',
   },
 
-  // userId 3 (박디자인) — week 2: 5/5 = 100%
+  // userId 3 (박프로) — week 2 (2026-04-22 ~ 2026-04-28): 5/5 = 100%
   {
     id: 26,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 2,
     content: 'SVG 아이콘 컴포넌트화',
     isCompleted: true,
-    createdAt: '2025-03-31T09:00:00Z',
+    createdAt: '2026-04-22T09:00:00Z',
   },
   {
     id: 27,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 2,
     content: '다크모드 CSS 변수 설계',
     isCompleted: true,
-    createdAt: '2025-03-31T10:00:00Z',
+    createdAt: '2026-04-23T09:00:00Z',
   },
   {
     id: 28,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 2,
     content: '접근성(a11y) 체크리스트 작성',
     isCompleted: true,
-    createdAt: '2025-03-31T11:00:00Z',
+    createdAt: '2026-04-24T09:00:00Z',
   },
   {
     id: 29,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 2,
     content: '애니메이션 트랜지션 구현',
     isCompleted: true,
-    createdAt: '2025-03-31T13:00:00Z',
+    createdAt: '2026-04-25T09:00:00Z',
   },
   {
     id: 30,
     userId: 3,
-    nickname: '박디자인',
+    nickname: '박프로',
     week: 2,
     content: 'framer-motion 기초 학습',
     isCompleted: true,
-    createdAt: '2025-03-31T14:00:00Z',
+    createdAt: '2026-04-26T09:00:00Z',
   },
 ];
 

--- a/src/mocks/handlers/todos.ts
+++ b/src/mocks/handlers/todos.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/api/todos/types';
 
 let mockTodos: Todo[] = [
+  // userId 1 (김코딩) — week 1: 5/5 = 100%
   {
     id: 1,
     userId: 1,
@@ -25,27 +26,271 @@ let mockTodos: Todo[] = [
     userId: 1,
     nickname: '김코딩',
     week: 1,
-    content: 'TanStack Query v5 마이그레이션 가이드 정리',
-    isCompleted: false,
+    content: 'TanStack Query v5 마이그레이션 정리',
+    isCompleted: true,
     createdAt: '2025-03-22T10:00:00Z',
   },
   {
     id: 3,
-    userId: 2,
-    nickname: '이개발',
+    userId: 1,
+    nickname: '김코딩',
     week: 1,
     content: 'Zustand 상태 관리 패턴 학습',
-    isCompleted: false,
-    createdAt: '2025-03-23T09:00:00Z',
+    isCompleted: true,
+    createdAt: '2025-03-22T11:00:00Z',
   },
   {
     id: 4,
     userId: 1,
     nickname: '김코딩',
+    week: 1,
+    content: 'Next.js App Router 구조 파악',
+    isCompleted: true,
+    createdAt: '2025-03-22T13:00:00Z',
+  },
+  {
+    id: 5,
+    userId: 1,
+    nickname: '김코딩',
+    week: 1,
+    content: 'TypeScript strict 모드 설정 복습',
+    isCompleted: true,
+    createdAt: '2025-03-22T14:00:00Z',
+  },
+
+  // userId 1 (김코딩) — week 2: 4/5 = 80%
+  {
+    id: 6,
+    userId: 1,
+    nickname: '김코딩',
     week: 2,
     content: 'MSW로 API 모킹 구현',
-    isCompleted: false,
+    isCompleted: true,
     createdAt: '2025-03-29T09:00:00Z',
+  },
+  {
+    id: 7,
+    userId: 1,
+    nickname: '김코딩',
+    week: 2,
+    content: 'react-hook-form + Zod 연동',
+    isCompleted: true,
+    createdAt: '2025-03-29T10:00:00Z',
+  },
+  {
+    id: 8,
+    userId: 1,
+    nickname: '김코딩',
+    week: 2,
+    content: 'TailwindCSS v4 변경사항 정리',
+    isCompleted: true,
+    createdAt: '2025-03-29T11:00:00Z',
+  },
+  {
+    id: 9,
+    userId: 1,
+    nickname: '김코딩',
+    week: 2,
+    content: 'Storybook 컴포넌트 문서화',
+    isCompleted: true,
+    createdAt: '2025-03-29T13:00:00Z',
+  },
+  {
+    id: 10,
+    userId: 1,
+    nickname: '김코딩',
+    week: 2,
+    content: 'ErrorBoundary 패턴 정리',
+    isCompleted: false,
+    createdAt: '2025-03-29T14:00:00Z',
+  },
+
+  // userId 2 (이개발) — week 1: 4/5 = 80%
+  {
+    id: 11,
+    userId: 2,
+    nickname: '이개발',
+    week: 1,
+    content: 'Axios 인터셉터 구현',
+    isCompleted: true,
+    createdAt: '2025-03-23T09:00:00Z',
+  },
+  {
+    id: 12,
+    userId: 2,
+    nickname: '이개발',
+    week: 1,
+    content: 'fetch vs axios 차이 정리',
+    isCompleted: true,
+    createdAt: '2025-03-23T10:00:00Z',
+  },
+  {
+    id: 13,
+    userId: 2,
+    nickname: '이개발',
+    week: 1,
+    content: 'Server Action 실습',
+    isCompleted: true,
+    createdAt: '2025-03-23T11:00:00Z',
+  },
+  {
+    id: 14,
+    userId: 2,
+    nickname: '이개발',
+    week: 1,
+    content: 'Next.js 캐싱 전략 학습',
+    isCompleted: true,
+    createdAt: '2025-03-23T13:00:00Z',
+  },
+  {
+    id: 15,
+    userId: 2,
+    nickname: '이개발',
+    week: 1,
+    content: 'HydrationBoundary 사용법 익히기',
+    isCompleted: false,
+    createdAt: '2025-03-23T14:00:00Z',
+  },
+
+  // userId 2 (이개발) — week 2: 3/5 = 60%
+  {
+    id: 16,
+    userId: 2,
+    nickname: '이개발',
+    week: 2,
+    content: 'CVA로 버튼 컴포넌트 리팩터링',
+    isCompleted: true,
+    createdAt: '2025-03-30T09:00:00Z',
+  },
+  {
+    id: 17,
+    userId: 2,
+    nickname: '이개발',
+    week: 2,
+    content: 'Suspense Boundary 적용',
+    isCompleted: true,
+    createdAt: '2025-03-30T10:00:00Z',
+  },
+  {
+    id: 18,
+    userId: 2,
+    nickname: '이개발',
+    week: 2,
+    content: 'queryKey 팩토리 패턴 정리',
+    isCompleted: true,
+    createdAt: '2025-03-30T11:00:00Z',
+  },
+  {
+    id: 19,
+    userId: 2,
+    nickname: '이개발',
+    week: 2,
+    content: 'prefetchQuery 실습',
+    isCompleted: false,
+    createdAt: '2025-03-30T13:00:00Z',
+  },
+  {
+    id: 20,
+    userId: 2,
+    nickname: '이개발',
+    week: 2,
+    content: '낙관적 업데이트 구현',
+    isCompleted: false,
+    createdAt: '2025-03-30T14:00:00Z',
+  },
+
+  // userId 3 (박디자인) — week 1: 3/5 = 60%
+  {
+    id: 21,
+    userId: 3,
+    nickname: '박디자인',
+    week: 1,
+    content: 'Figma 컴포넌트 라이브러리 구성',
+    isCompleted: true,
+    createdAt: '2025-03-24T09:00:00Z',
+  },
+  {
+    id: 22,
+    userId: 3,
+    nickname: '박디자인',
+    week: 1,
+    content: 'TailwindCSS 디자인 토큰 설정',
+    isCompleted: true,
+    createdAt: '2025-03-24T10:00:00Z',
+  },
+  {
+    id: 23,
+    userId: 3,
+    nickname: '박디자인',
+    week: 1,
+    content: 'Storybook 디자인 시스템 문서화',
+    isCompleted: true,
+    createdAt: '2025-03-24T11:00:00Z',
+  },
+  {
+    id: 24,
+    userId: 3,
+    nickname: '박디자인',
+    week: 1,
+    content: 'clsx + tailwind-merge 활용법 정리',
+    isCompleted: false,
+    createdAt: '2025-03-24T13:00:00Z',
+  },
+  {
+    id: 25,
+    userId: 3,
+    nickname: '박디자인',
+    week: 1,
+    content: '반응형 레이아웃 패턴 학습',
+    isCompleted: false,
+    createdAt: '2025-03-24T14:00:00Z',
+  },
+
+  // userId 3 (박디자인) — week 2: 5/5 = 100%
+  {
+    id: 26,
+    userId: 3,
+    nickname: '박디자인',
+    week: 2,
+    content: 'SVG 아이콘 컴포넌트화',
+    isCompleted: true,
+    createdAt: '2025-03-31T09:00:00Z',
+  },
+  {
+    id: 27,
+    userId: 3,
+    nickname: '박디자인',
+    week: 2,
+    content: '다크모드 CSS 변수 설계',
+    isCompleted: true,
+    createdAt: '2025-03-31T10:00:00Z',
+  },
+  {
+    id: 28,
+    userId: 3,
+    nickname: '박디자인',
+    week: 2,
+    content: '접근성(a11y) 체크리스트 작성',
+    isCompleted: true,
+    createdAt: '2025-03-31T11:00:00Z',
+  },
+  {
+    id: 29,
+    userId: 3,
+    nickname: '박디자인',
+    week: 2,
+    content: '애니메이션 트랜지션 구현',
+    isCompleted: true,
+    createdAt: '2025-03-31T13:00:00Z',
+  },
+  {
+    id: 30,
+    userId: 3,
+    nickname: '박디자인',
+    week: 2,
+    content: 'framer-motion 기초 학습',
+    isCompleted: true,
+    createdAt: '2025-03-31T14:00:00Z',
   },
 ];
 
@@ -53,17 +298,28 @@ const BASE = '/api/v1/gatherings/:gatheringId/todos';
 
 export const todosHandlers = [
   /** GET /api/v1/gatherings/:gatheringId/todos/me — 내 Todo + 달성률 */
-  http.get(`${BASE}/me`, async () => {
+  http.get(`${BASE}/me`, async ({ request }) => {
     await delay(300);
 
+    const url = new URL(request.url);
+    const week = url.searchParams.get('week');
+
     const myTodos = mockTodos.filter((todo) => todo.userId === 1);
-    const completed = myTodos.filter((todo) => todo.isCompleted).length;
+    const filteredTodos = week ? myTodos.filter((todo) => todo.week === Number(week)) : myTodos;
+
+    const overallCompleted = myTodos.filter((todo) => todo.isCompleted).length;
+    const weeklyCompleted = filteredTodos.filter((todo) => todo.isCompleted).length;
+
+    const overallAchievementRate =
+      myTodos.length > 0 ? Math.round((overallCompleted / myTodos.length) * 100 * 10) / 10 : 0;
+    const weeklyAchievementRate =
+      filteredTodos.length > 0 ? Math.round((weeklyCompleted / filteredTodos.length) * 100 * 10) / 10 : 0;
 
     return HttpResponse.json(
       createApiResponse<MyTodoListResponse>({
-        todos: myTodos,
-        weeklyAchievementRate: Math.round((completed / myTodos.length) * 100 * 10) / 10,
-        overallAchievementRate: Math.round((completed / myTodos.length) * 100 * 10) / 10,
+        todos: filteredTodos,
+        weeklyAchievementRate,
+        overallAchievementRate,
       }),
     );
   }),


### PR DESCRIPTION
## ❓ 이슈

- close #157 

## ✍️ Description


활동 요약 탭에 이번주 요약 카드와 내/팀 달성률 게이지 차트를 구현했습니다.

**WeeklySummarySection 신규 구현**
- `SummaryInfoCard` — 현재 주차 / 목표까지 남은 일수 / 미완료 Todo 개수 3열 그리드 카드
- `AchievementGauge` — 반원형 SVG 게이지 차트 (내 달성률 / 팀 달성률)
  - 0~100 스케일, 끝점 원형 마커, 중앙 달성률 숫자 표시
- `StreakBadge` — 연속 달성 일수 배지 (달성 시에만 노출)

**유틸 추가**
- `formatGatheringDate` — `getCurrentWeek`, `getRemainingDays` 유틸 함수 추가
- `streakUtils` — 연속 달성 일수 계산 유틸 추가

**반응형**
- 모바일/태블릿: 게이지 세로 배치
- PC: 내/팀 달성률 게이지 가로 배치

**렌더링 전략**
- `useSuspenseQuery` 기반 클라이언트 컴포넌트
- WeeklySummarySection 내 쿼리 병렬 실행으로 성능 개선
- `DashboardContent`의 summary 탭에서 `SuspenseBoundary`로 로딩/에러 처리

**기타**
- GET /gatherings/:gatheringId/todos/me API에 week 쿼리 파라미터 추가 (API 명세 반영)
- DashboardHeader의 currentWeek, daysRemaining 계산을 formatGatheringDate.ts 유틸 함수로 교체
- todos mock 데이터 week 파라미터 지원 + 3명 기준 데이터 정합성 수정

## 📸 스크린샷 (UI 변경 시)
<img width="956" height="576" alt="화면 캡처 2026-04-02 134140" src="https://github.com/user-attachments/assets/3f00e077-a2d7-4a85-be60-e649d16f20f0" />

<img width="152" height="199" alt="image" src="https://github.com/user-attachments/assets/48907fd2-4507-4557-9f25-d0fa1e9c5406" />



## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes
- [x] `WeeklySummarySection` 폴더 위치 괜찮나요?
