### PR TITLE
[SM-113] feat: MemberTodoSection 구현

### DIFF
--- a/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardContent/index.tsx
@@ -3,6 +3,7 @@ import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { MotivationSection } from '../MotivationSection';
 import { WeeklySummarySection } from '../WeeklySummarySection';
 import { WeeklyTrendChart } from '../WeeklyTrendChart';
+import { MemberTodoSection } from '../MemberTodoSection';
 
 import type { DashboardTab } from '../../_constants';
 
@@ -52,6 +53,17 @@ export function DashboardContent({ activeTab, gatheringId }: DashboardContentPro
               }
             >
               <WeeklyTrendChart gatheringId={gatheringId} />
+            </SuspenseBoundary>
+          </div>
+        )}
+
+        {activeTab === 'weekly' && (
+          <div className='flex flex-col gap-6'>
+            <SuspenseBoundary
+              pendingFallback={<div className='h-96 animate-pulse rounded-2xl bg-gray-100' />}
+              errorFallback={<p className='text-body-02-r text-gray-400'>멤버 할 일을 불러오는데 실패했습니다.</p>}
+            >
+              <MemberTodoSection gatheringId={gatheringId} />
             </SuspenseBoundary>
           </div>
         )}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from 'react';
 
-import type { Member } from '@/api/memberships/types';
-import type { Todo } from '@/api/todos/types';
 import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
 import { Profile } from '@/components/ui/Profile';
 import { cn } from '@/lib/cn';
@@ -11,6 +9,9 @@ import { StateIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 
 import { MemberTodoGrid } from '../MemberTodoGrid';
+
+import type { Member } from '@/api/memberships/types';
+import type { Todo } from '@/api/todos/types';
 
 interface MemberTodoAccordionProps {
   member: Member;

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -56,7 +56,7 @@ export function MemberTodoAccordion({ member, todos }: MemberTodoAccordionProps)
             <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] bg-blue-50 px-2 py-0.5 text-blue-400'>
               <Tag variant='info' state='good'>
                 <StateIcon variant='active' size={14} />
-                14일
+                {dDay}일
               </Tag>
             </span>
           )}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { Member } from '@/api/memberships/types';
+import type { Todo } from '@/api/todos/types';
+import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
+import { Profile } from '@/components/ui/Profile';
+import { cn } from '@/lib/cn';
+import { StateIcon } from '@/components/ui/Icon';
+import { Tag } from '@/components/ui/Tag';
+
+import { MemberTodoGrid } from '../MemberTodoGrid';
+
+interface MemberTodoAccordionProps {
+  member: Member;
+  todos: Todo[];
+}
+
+export function MemberTodoAccordion({ member, todos }: MemberTodoAccordionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // 디자인 시안에 따른 임시 배지 로직 (D-day 및 주의)
+  const isWarning = member.userId % 3 === 0; // 임시 조건
+  const dDay = 14; // 임시 값
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-2xl border transition-all duration-300',
+        isOpen ? 'bg-blue-25/10 border-blue-100 shadow-lg' : 'border-gray-50 bg-white hover:border-gray-200',
+      )}
+    >
+      <button
+        type='button'
+        onClick={() => setIsOpen(!isOpen)}
+        className='flex w-full cursor-pointer items-center justify-between p-4 md:px-6 md:py-5'
+        aria-expanded={isOpen}
+      >
+        <div className='flex items-center gap-3 md:gap-5'>
+          <Profile imageUrl={member.profileImage} className='size-8 rounded-lg shadow-sm md:size-12' />
+
+          <div className='flex items-center gap-1 md:flex-row md:items-center md:gap-4'>
+            <span className='text-small-01-m md:text-body-01-m text-gray-900'>{member.nickname}</span>
+          </div>
+        </div>
+        <div className='flex items-center gap-2 md:gap-4'>
+          {isWarning ? (
+            <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] bg-orange-50 px-2 py-0.5 text-orange-400'>
+              <Tag variant='info' state='bad'>
+                <StateIcon variant='warning' size={14} />
+                주의
+              </Tag>
+            </span>
+          ) : (
+            <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] bg-blue-50 px-2 py-0.5 text-blue-400'>
+              <Tag variant='info' state='good'>
+                <StateIcon variant='active' size={14} />
+                14일
+              </Tag>
+            </span>
+          )}
+          <p className='text-small-01-r md:text-body-01-r mr-3 flex gap-1 whitespace-nowrap text-gray-900'>
+            달성률
+            <span className='text-small-01-sb md:text-body-01-sb flex items-center font-semibold text-blue-300'>
+              {member.overallAchievementRate}%
+            </span>
+          </p>
+
+          <ArrowIcon
+            size={24}
+            className={cn(
+              'h-6 w-6 text-gray-400 transition-transform duration-300 md:size-7 md:h-8 md:w-8',
+              isOpen ? 'rotate-90 text-blue-500' : '-rotate-90',
+            )}
+          />
+        </div>
+      </button>
+
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-300 ease-in-out',
+          isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        )}
+      >
+        <div className='overflow-hidden'>
+          <div className='bg-gray-25/50 border-t border-gray-50 p-4 md:p-6'>
+            <MemberTodoGrid todos={todos} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoGrid/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoGrid/index.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { MemberTodoItem } from '../MemberTodoItem';
+
+import type { Todo } from '@/api/todos/types';
+
+interface MemberTodoGridProps {
+  todos: Todo[];
+}
+
+export function MemberTodoGrid({ todos }: MemberTodoGridProps) {
+  if (todos.length === 0) {
+    return (
+      <div className='bg-gray-25/50 text-body-02-r flex h-24 items-center justify-center rounded-xl border border-dashed border-gray-200 text-gray-400'>
+        이번 주 할 일이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className='grid grid-cols-1 gap-3 lg:grid-cols-2 xl:gap-4'>
+      {todos.map((todo) => (
+        <MemberTodoItem key={todo.id} content={todo.content} isCompleted={todo.isCompleted} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoItem/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { cn } from '@/lib/cn';
+import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
+
+interface MemberTodoItemProps {
+  content: string;
+  isCompleted: boolean;
+}
+
+export function MemberTodoItem({ content, isCompleted }: MemberTodoItemProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between rounded-xl border border-gray-50 bg-white p-4 transition-all hover:bg-gray-50/50',
+        isCompleted && 'bg-gray-25/50 border-gray-100',
+      )}
+    >
+      <div className='flex items-center gap-5'>
+        <div
+          className={cn(
+            'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-blue-300 transition-colors md:h-12 md:w-12',
+            isCompleted ? 'border-blue-300 bg-blue-300 text-white' : 'border-gray-200 bg-white',
+          )}
+        >
+          {isCompleted && <CheckIcon className='h-8 w-8 md:h-12 md:w-12' />}
+        </div>
+        <span
+          className={cn(
+            'text-small-01-r md:text-body-01-r text-gray-900 transition-all',
+            isCompleted && 'text-gray-400 line-through',
+          )}
+        >
+          {content}
+        </span>
+      </div>
+      <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-xl shadow-inner'>
+        🔥
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useSuspenseQueries } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { membershipQueries } from '@/api/memberships/queries';
+import { todoQueries } from '@/api/todos/queries';
+import { Pagination } from '@/components/ui/Pagination';
+import { getCurrentWeek } from '@/lib/formatGatheringDate';
+
+import { MemberTodoAccordion } from './MemberTodoAccordion';
+
+interface MemberTodoSectionProps {
+  gatheringId: number;
+}
+
+const ITEMS_PER_PAGE = 5;
+
+export function MemberTodoSection({ gatheringId }: MemberTodoSectionProps) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const [{ data: gatheringData }, { data: membersData }] = useSuspenseQueries({
+    queries: [gatheringQueries.detail(gatheringId), membershipQueries.members(gatheringId)],
+  });
+
+  const currentWeek = getCurrentWeek(gatheringData.startDate);
+
+  const { data: todoData } = useSuspenseQueries({
+    queries: [todoQueries.list(gatheringId, { week: currentWeek })],
+    combine: (results) => ({
+      data: results[0].data,
+    }),
+  });
+
+  const totalMembers = membersData.members.length;
+  const totalPages = Math.ceil(totalMembers / ITEMS_PER_PAGE);
+
+  const paginatedMembers = membersData.members.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+
+  return (
+    <section className='flex flex-col gap-2 md:gap-4'>
+      <div className='flex items-center justify-between'>
+        <h2 className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-900'>멤버 할 일 👀</h2>
+      </div>
+
+      <div className='flex flex-col gap-4'>
+        {paginatedMembers.map((member) => (
+          <MemberTodoAccordion
+            key={member.userId}
+            member={member}
+            todos={todoData.todos.filter((t) => t.userId === member.userId)}
+          />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div className='mt-6 flex justify-center border-t border-gray-50 pt-8'>
+          <Pagination
+            variant='numbered'
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useSuspenseQueries } from '@tanstack/react-query';
 import { useState } from 'react';
+
+import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { membershipQueries } from '@/api/memberships/queries';
@@ -26,11 +27,8 @@ export function MemberTodoSection({ gatheringId }: MemberTodoSectionProps) {
 
   const currentWeek = getCurrentWeek(gatheringData.startDate);
 
-  const { data: todoData } = useSuspenseQueries({
-    queries: [todoQueries.list(gatheringId, { week: currentWeek })],
-    combine: (results) => ({
-      data: results[0].data,
-    }),
+  const { data: todoData } = useSuspenseQuery({
+    ...todoQueries.list(gatheringId, { week: currentWeek }),
   });
 
   const totalMembers = membersData.members.length;


### PR DESCRIPTION
## ❓ 이슈

- close #161 

## ✍️ Description

맴버별 투두를 볼 수 있는 섹션을 구현합니다.

## 📸 스크린샷 (UI 변경 시)

<img width="661" height="807" alt="스크린샷 2026-04-03 오전 5 25 42" src="https://github.com/user-attachments/assets/80a317bb-3a40-4d86-8428-ff34580c96cb" />

<img width="691" height="806" alt="스크린샷 2026-04-03 오전 5 26 00" src="https://github.com/user-attachments/assets/a0ee9f5e-2876-447a-835f-a824a16638ce" />

<img width="954" height="810" alt="스크린샷 2026-04-03 오전 5 26 24" src="https://github.com/user-attachments/assets/f470b8cd-68ed-417d-9ef3-d70233e244bc" />

## ✅ Checklist

- [x] 페이지 별 5명 투두 리스트 보여주게 구현
- [x] 디자인 시안에 맞게 아코디언UI 구현
- [x] pc 투두 2개, 태블릿 모바일 투두 1개 보이게 구현
- [x] memberTodoSection 렌더 (activeTab이 weekly일 때)

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)
