### PR TITLE
[SM-122]fix:랜딩 시작하기 버튼 및 탐색 페이지 카드 참여하기 버튼 라우팅 수정

### DIFF
--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -2,6 +2,8 @@
 
 import { startTransition } from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { MainGatheringCard } from '@/components/MainGatheringCard';
@@ -13,6 +15,7 @@ import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
 const PAGE_LIMIT = 12;
 
 export function GatheringList() {
+  const router = useRouter();
   const { query, type, category, sort, status, page, setParams } = useGatheringSearchParams();
 
   const { data } = useSuspenseQuery(
@@ -33,6 +36,10 @@ export function GatheringList() {
     });
   };
 
+  const handleJoin = (id: number) => {
+    router.push(`/gatherings/${id}`);
+  };
+
   if (data.gatherings.length === 0) {
     return (
       <>
@@ -47,7 +54,12 @@ export function GatheringList() {
       <GatheringFilterBar totalCount={data.totalCount} />
       <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
         {data.gatherings.map((gathering) => (
-          <MainGatheringCard key={gathering.id} gathering={gathering} initialFavorite={gathering.isLiked} />
+          <MainGatheringCard
+            key={gathering.id}
+            gathering={gathering}
+            initialFavorite={gathering.isLiked}
+            onJoin={() => handleJoin(gathering.id)}
+          />
         ))}
       </div>
       {data.totalPages > 1 && (

--- a/src/components/landing/landingConstants.ts
+++ b/src/components/landing/landingConstants.ts
@@ -1,6 +1,6 @@
 /** 랜딩 CTA·미리보기 이미지 경로 (한곳에서 관리) */
 export const LANDING_LINKS = {
-  start: '/register',
+  start: '/main',
   browse: '/gatherings',
 } as const;
 


### PR DESCRIPTION
## ❓ 이슈

- close #185 

## ✍️ Description

랜딩 "시작하기" 버튼: /main으로 이동
탐색 "참여하기" 버튼: 해당 모임 상세 페이지(/gatherings/[id])로 이동

## 📸 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/de1cf6e7-c187-4e7b-914f-001faf7c78ff


https://github.com/user-attachments/assets/1b83ca25-134e-48bc-9098-c7cab0a04cfc


## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes


