### PR TITLE
[SM-133] feat: AuthModal, AuthFunnel  컴포넌트 구현

### DIFF
--- a/src/components/AuthModal/AuthFunnel/EmailStep.tsx
+++ b/src/components/AuthModal/AuthFunnel/EmailStep.tsx
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { useCheckEmail } from '@/api/auth/queries';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { SocialLoginButtons } from '@/app/(auth)/components/SocialLoginButtons';
+import { AuthDivider } from '@/app/(auth)/components/AuthDivider';
+
+const emailSchema = z.object({
+  email: z.string().min(1, '이메일은 필수 입력입니다.').pipe(z.email('이메일 형식으로 작성해 주세요.')),
+});
+type EmailForm = z.infer<typeof emailSchema>;
+
+export function EmailStep({ onResolved }: { onResolved: (email: string, isAvailable: boolean) => void }) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<EmailForm>({
+    resolver: zodResolver(emailSchema),
+    mode: 'onChange',
+  });
+
+  const checkEmailMutation = useCheckEmail();
+
+  const onSubmit = (data: EmailForm) => {
+    checkEmailMutation.mutate(data.email, {
+      onSuccess: (res) => {
+        onResolved(data.email, res.available);
+      },
+    });
+  };
+
+  return (
+    <div className='flex flex-col gap-8'>
+      <div className='flex flex-col gap-2'>
+        <h2 className='text-h4-b text-center text-gray-900'>로그인 / 회원가입</h2>
+        <p className='text-body-02-r text-center text-gray-600'>
+          이메일을 입력하시면 가입 여부에 따라 로그인 또는 회원가입을 진행합니다.
+        </p>
+      </div>
+
+      <SocialLoginButtons kakaoLabel='카카오로 시작하기' googleLabel='구글로 시작하기' />
+      <AuthDivider text='또는 이메일로 시작' />
+
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-6'>
+        <Input
+          label={
+            <>
+              이메일 <span className='ml-1 text-blue-400'>*</span>
+            </>
+          }
+          placeholder='이메일을 입력해주세요'
+          type='email'
+          error={errors.email?.message}
+          {...register('email')}
+          className='h-11'
+        />
+        <Button
+          variant='primary'
+          size='join-login'
+          type='submit'
+          disabled={!isValid || checkEmailMutation.isPending}
+          className='w-full'
+        >
+          {checkEmailMutation.isPending ? '확인 중...' : '다음'}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/AuthModal/AuthFunnel/LoginStep.tsx
+++ b/src/components/AuthModal/AuthFunnel/LoginStep.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { VisibilityIcon } from '@/components/ui/Icon';
+import { useLogin } from '@/api/auth/queries';
+import { loginFormSchema } from '@/api/auth/schemas';
+
+import type { LoginForm } from '@/api/auth/types';
+
+export function LoginStep({ email, onSuccess, onBack }: { email: string; onSuccess: () => void; onBack: () => void }) {
+  const [showPassword, setShowPassword] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isValid },
+  } = useForm<LoginForm>({
+    resolver: zodResolver(loginFormSchema),
+    mode: 'onChange',
+    defaultValues: { email },
+  });
+
+  const { mutate: loginMutate, isPending } = useLogin({
+    onSuccess,
+    onError: () => setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' }),
+  });
+
+  const onSubmit = (data: LoginForm) => loginMutate(data);
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='flex flex-col gap-2'>
+        <h2 className='text-h4-b text-center text-gray-900'>비밀번호 입력</h2>
+        <p className='text-body-02-r text-center text-gray-600'>{email} 계정으로 로그인합니다.</p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
+        <div className='relative'>
+          <Input
+            label={
+              <>
+                비밀번호 <span className='ml-1 text-blue-400'>*</span>
+              </>
+            }
+            placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요'
+            type={showPassword ? 'text' : 'password'}
+            error={errors.password?.message}
+            {...register('password')}
+            className='h-11'
+          />
+          <button
+            type='button'
+            className='absolute top-9 right-3 cursor-pointer text-gray-400'
+            onClick={() => setShowPassword((prev) => !prev)}
+            aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+          >
+            <VisibilityIcon variant={showPassword ? 'on' : 'off'} size={20} />
+          </button>
+        </div>
+
+        {errors.root && <p className='text-small-02-r text-center text-red-200'>{errors.root.message}</p>}
+
+        <div className='flex flex-col gap-3'>
+          <Button variant='primary' size='join-login' type='submit' disabled={!isValid || isPending} className='w-full'>
+            로그인
+          </Button>
+          <Button type='button' variant='login-outline' onClick={onBack} className='h-14 w-full'>
+            뒤로가기
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/AuthModal/AuthFunnel/RegisterStep.tsx
+++ b/src/components/AuthModal/AuthFunnel/RegisterStep.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { VisibilityIcon } from '@/components/ui/Icon';
+import { useCheckNickname, useRegister } from '@/api/auth/queries';
+import { signupFormSchema } from '@/api/auth/schemas';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
+
+import type { SignupForm } from '@/api/auth/types';
+
+export function RegisterStep({
+  email,
+  onSuccess,
+  onBack,
+}: {
+  email: string;
+  onSuccess: () => void;
+  onBack: () => void;
+}) {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+  const showToast = useToastStore((state) => state.showToast);
+
+  const {
+    register: formRegister,
+    handleSubmit,
+    watch,
+    trigger,
+    setError,
+    formState: { errors, isValid },
+  } = useForm<SignupForm>({
+    resolver: zodResolver(signupFormSchema),
+    mode: 'onBlur',
+    defaultValues: { email },
+  });
+
+  const nicknameValue = watch('nickname');
+  const checkNicknameMutation = useCheckNickname();
+  const isNicknameChecked =
+    !!checkNicknameMutation.data?.available && checkNicknameMutation.variables === nicknameValue;
+
+  const { mutate: registerMutate, isPending: isRegistering } = useRegister();
+
+  const handleCheckNickname = async () => {
+    if (checkNicknameMutation.isPending || !nicknameValue) return;
+    const result = await trigger('nickname');
+    if (!result) return;
+
+    checkNicknameMutation.mutate(nicknameValue, {
+      onSuccess: (data) => {
+        if (!data.available) {
+          setError('nickname', { type: 'manual', message: '이미 사용 중인 닉네임입니다.' });
+        }
+      },
+    });
+  };
+
+  const onSubmit = (data: SignupForm) => {
+    if (!isNicknameChecked) {
+      showToast({ title: '닉네임 중복 확인을 완료해주세요.', variant: 'warning' });
+      return;
+    }
+    registerMutate(data, {
+      onSuccess: () => {
+        showToast({ title: '회원가입이 완료되었습니다.', variant: 'success' });
+        onSuccess();
+      },
+      onError: () => {
+        showToast({ title: '회원가입 중 오류가 발생했습니다.', variant: 'error' });
+      },
+    });
+  };
+
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='flex flex-col gap-2'>
+        <h2 className='text-h4-b text-center text-gray-900'>회원가입</h2>
+        <p className='text-body-02-r text-center text-gray-600'>완성도 서비스 가입을 위해 정보를 입력해주세요.</p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
+        <Input label='이메일' type='email' value={email} disabled className='h-11 bg-gray-50' />
+
+        <div className='flex flex-col gap-2'>
+          <div className={`flex gap-2 ${errors.nickname ? 'items-center' : 'items-end'}`}>
+            <div className='flex-1'>
+              <Input
+                label={
+                  <>
+                    닉네임 <span className='ml-1 text-blue-400'>*</span>
+                  </>
+                }
+                placeholder='닉네임을 입력해주세요.'
+                error={errors.nickname?.message}
+                {...formRegister('nickname')}
+                className='h-11'
+              />
+            </div>
+            <Button
+              variant='check'
+              size='check'
+              type='button'
+              onClick={handleCheckNickname}
+              disabled={checkNicknameMutation.isPending || !nicknameValue}
+            >
+              {checkNicknameMutation.isPending ? '확인 중...' : '확인'}
+            </Button>
+          </div>
+          {isNicknameChecked && !errors.nickname && (
+            <p className='text-small-02-r ml-1 text-blue-400'>사용 가능한 닉네임입니다.</p>
+          )}
+        </div>
+
+        <div className='relative'>
+          <Input
+            label={
+              <>
+                비밀번호 <span className='ml-1 text-blue-400'>*</span>
+              </>
+            }
+            placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요'
+            type={showPassword ? 'text' : 'password'}
+            error={errors.password?.message}
+            {...formRegister('password', { onBlur: () => trigger('passwordConfirmation') })}
+            className='h-11'
+          />
+          <button
+            type='button'
+            className='absolute top-9 right-3 cursor-pointer text-gray-400'
+            onClick={() => setShowPassword((prev) => !prev)}
+            aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+          >
+            <VisibilityIcon variant={showPassword ? 'on' : 'off'} size={20} />
+          </button>
+        </div>
+
+        <div className='relative'>
+          <Input
+            label={
+              <>
+                비밀번호 확인 <span className='ml-1 text-blue-400'>*</span>
+              </>
+            }
+            placeholder='비밀번호를 한번 더 입력해주세요.'
+            type={showPasswordConfirm ? 'text' : 'password'}
+            error={errors.passwordConfirmation?.message}
+            {...formRegister('passwordConfirmation')}
+            className='h-11'
+          />
+          <button
+            type='button'
+            className='absolute top-9 right-3 cursor-pointer text-gray-400'
+            onClick={() => setShowPasswordConfirm((prev) => !prev)}
+            aria-label={showPasswordConfirm ? '비밀번호 숨기기' : '비밀번호 보기'}
+          >
+            <VisibilityIcon variant={showPasswordConfirm ? 'on' : 'off'} size={20} />
+          </button>
+        </div>
+
+        <div className='flex flex-col gap-3'>
+          <Button
+            variant='primary'
+            size='join-login'
+            type='submit'
+            disabled={!isValid || !isNicknameChecked || isRegistering}
+            className='w-full'
+          >
+            {isRegistering ? '가입 중...' : '회원가입 완료'}
+          </Button>
+          <Button type='button' variant='login-outline' onClick={onBack} className='h-14 w-full'>
+            뒤로가기
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/AuthModal/AuthFunnel/index.tsx
+++ b/src/components/AuthModal/AuthFunnel/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useFunnel } from '@/hooks/useFunnel';
+
+import { EmailStep } from './EmailStep';
+import { LoginStep } from './LoginStep';
+import { RegisterStep } from './RegisterStep';
+
+interface AuthFunnelProps {
+  onSuccess: () => void;
+}
+
+export function AuthFunnel({ onSuccess }: AuthFunnelProps) {
+  const { Funnel, Step, setStep } = useFunnel<'EMAIL' | 'LOGIN' | 'REGISTER'>('EMAIL');
+  const [certifiedEmail, setCertifiedEmail] = useState('');
+
+  return (
+    <Funnel>
+      <Step name='EMAIL'>
+        <EmailStep
+          onResolved={(email, isAvailable) => {
+            setCertifiedEmail(email);
+            if (isAvailable) {
+              setStep('REGISTER');
+            } else {
+              setStep('LOGIN');
+            }
+          }}
+        />
+      </Step>
+      <Step name='LOGIN'>
+        <LoginStep email={certifiedEmail} onSuccess={onSuccess} onBack={() => setStep('EMAIL')} />
+      </Step>
+      <Step name='REGISTER'>
+        <RegisterStep email={certifiedEmail} onSuccess={onSuccess} onBack={() => setStep('EMAIL')} />
+      </Step>
+    </Funnel>
+  );
+}

--- a/src/components/AuthModal/index.tsx
+++ b/src/components/AuthModal/index.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Modal } from '@/components/ui/Modal';
+import { AuthFunnel } from './AuthFunnel';
+
+interface AuthModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function AuthModal({ isOpen, onClose }: AuthModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal.Body className='px-6 py-8'>
+        <AuthFunnel onSuccess={onClose} />
+      </Modal.Body>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## ❓ 이슈

- close #195 

## ✍️ Description

AuthModal, AuthFunnel 구현
- 가입 여부에 따라 로그인/회원가입으로 분기되는 인증 모달 추가
- Email, Login, Register 단계별 컴포넌트 구조와
- 모달 내 성공 시 콜백 및 에러 핸들링 로직 구현

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- 스크린샷(영상)은 SM-125에서 제공예정입니다.
- 추가적으로 기존의 로그인/회원가입 페이지와 중복아니야? 라고 생각이 드실 수 있을 것 같아 간단하게 내용 정리해봤습니다.
  
1. 목적과 사용자 맥락(Context)이 완전히 다릅니다 
    - AuthModal (맥락 유지용) 사용자가 '모임 신청'이나 '찜하기' 같은 특정 행동을 하려다 인증이 필요해진 상황입니다. 이때 페이지를 다른 곳으로 리다이렉트 시켜버리면, 사용자는 원래 하려던 행동을 잊거나 돌아오는 과정이 귀찮아져서 최종 전환율(이탈)이 크게 떨어집니다. 모달은 사용자의 흐름(Flow)을 끊지 않고 자연스럽게 다음 행동으로 이어지게 하는 장치입니다.
    - app/(auth) (직접 진입용) 로그아웃 상태에서 공유된 특정 딥링크를 타고 오거나, 헤더의 로그인 버튼을 직접 눌러 처음부터 로그인이 목적일 때 진입하는 곳입니다. 브라우저의 뒤로가기, 즐겨찾기, 외부(카카오톡 등)에서 들어오는 진입점 등을 고려하면 고유한 URL(/login)을 가진 독립적인 페이지가 필요합니다.

2. 퍼널(Funnel) 구조 등 동작 방식 자체가 다릅니다 
    - 현재 코드를 살펴보면 두 곳의 플로우가 차이가 납니다.

    - 모달은 AuthFunnel 구조를 띄고 있어서, 사용자가 자신이 가입했는지 여부를 몰라도 **'이메일 입력 -> API가 알아서 가입 여부 판단 -> 로그인/회원가입 분기'**라는 스마트한 플로우를 띄고 있습니다.
반면 **페이지(/login, /signup)**는 사용자가 본인의 상태를 알고 명시적으로 로그인이나 회원가입 화면을 골라 진입하는 고전적인(그리고 익숙한) 플로우입니다. 이처럼 **역할(Role)과 플로우(Flow)**가 다르기 때문에 코드가 분리되어 있는 것이 아키텍처상 맞다고 판단했습니다.