### PR TITLE
[SM-126] feat: 마이페이지 라우트 셸 + 레이아웃 + 탭 네비게이션

### DIFF
--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { MyPageTab } from '../../_constants';
+
+interface MyPageContentProps {
+  activeTab: MyPageTab;
+}
+
+export function MyPageContent({ activeTab }: MyPageContentProps) {
+  if (activeTab === 'my-gatherings') return <p>나의 모임</p>;
+  if (activeTab === 'created-gatherings') return <p>만든 모임</p>;
+  if (activeTab === 'pending-gatherings') return <p>대기중인 모임</p>;
+  if (activeTab === 'received-reviews') return <p>받은 리뷰</p>;
+  if (activeTab === 'liked-gatherings') return <p>찜한 모임</p>;
+}

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { MyPageTab } from '../../_constants';
 
 interface MyPageContentProps {

--- a/src/app/my/_components/MyPageTabs/index.tsx
+++ b/src/app/my/_components/MyPageTabs/index.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+
+import { cn } from '@/lib/cn';
+
+import { MY_PAGE_TAB_ITEMS } from '../../_constants';
+
+import type { MyPageTab } from '../../_constants';
+
+interface MyPageTabsProps {
+  activeTab: MyPageTab;
+}
+
+export function MyPageTabs({ activeTab }: MyPageTabsProps) {
+  return (
+    <nav className='border-gray-150 bg-gray-0 border-b px-4 md:px-7 xl:px-30'>
+      <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
+        {MY_PAGE_TAB_ITEMS.map(({ key, label }) => {
+          const isActive = activeTab === key;
+
+          return (
+            <li key={key} className='shrink-0'>
+              <Link
+                href={`/my?tab=${key}`}
+                replace
+                scroll={false}
+                className={cn(
+                  'text-small-02-m md:text-body-02-m flex h-[39px] shrink-0 items-center px-2.5 transition-colors md:h-12',
+                  isActive ? 'border-b-2 border-gray-800 text-gray-800' : 'text-gray-300',
+                )}
+              >
+                {label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/app/my/_components/MyPageTabs/index.tsx
+++ b/src/app/my/_components/MyPageTabs/index.tsx
@@ -12,7 +12,7 @@ interface MyPageTabsProps {
 
 export function MyPageTabs({ activeTab }: MyPageTabsProps) {
   return (
-    <nav className='border-gray-150 bg-gray-0 border-b px-4 md:px-7 xl:px-30'>
+    <nav>
       <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
         {MY_PAGE_TAB_ITEMS.map(({ key, label }) => {
           const isActive = activeTab === key;
@@ -24,8 +24,10 @@ export function MyPageTabs({ activeTab }: MyPageTabsProps) {
                 replace
                 scroll={false}
                 className={cn(
-                  'text-small-02-m md:text-body-02-m flex h-[39px] shrink-0 items-center px-2.5 transition-colors md:h-12',
-                  isActive ? 'border-b-2 border-gray-800 text-gray-800' : 'text-gray-300',
+                  'text-small-01-m md:text-body-01-m h-[3 9px] flex shrink-0 items-center px-2.5 transition-colors md:h-12',
+                  isActive
+                    ? 'text-small-01-b md:text-body-01-b border-b-2 border-gray-800 text-gray-800'
+                    : 'text-gray-300',
                 )}
               >
                 {label}

--- a/src/app/my/_components/MyPageTabs/index.tsx
+++ b/src/app/my/_components/MyPageTabs/index.tsx
@@ -24,7 +24,7 @@ export function MyPageTabs({ activeTab }: MyPageTabsProps) {
                 replace
                 scroll={false}
                 className={cn(
-                  'text-small-01-m md:text-body-01-m h-[3 9px] flex shrink-0 items-center px-2.5 transition-colors md:h-12',
+                  'text-small-01-m md:text-body-01-m flex h-[39px] shrink-0 items-center px-2.5 transition-colors md:h-12',
                   isActive
                     ? 'text-small-01-b md:text-body-01-b border-b-2 border-gray-800 text-gray-800'
                     : 'text-gray-300',

--- a/src/app/my/_constants.ts
+++ b/src/app/my/_constants.ts
@@ -1,0 +1,10 @@
+export const MY_PAGE_TAB_ITEMS = [
+  { key: 'my-gatherings', label: '나의 모임' },
+  { key: 'created-gatherings', label: '만든 모임' },
+  { key: 'pending-gatherings', label: '대기중인 모임' },
+  { key: 'received-reviews', label: '받은 리뷰' },
+  { key: 'liked-gatherings', label: '찜한 모임' },
+] as const;
+
+export type MyPageTab = (typeof MY_PAGE_TAB_ITEMS)[number]['key'];
+export const DEFAULT_TAB: MyPageTab = 'my-gatherings';

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,0 +1,28 @@
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+
+import { MyPageContent } from './_components/MyPageContent';
+import { MyPageTabs } from './_components/MyPageTabs';
+import { DEFAULT_TAB } from './_constants';
+
+import type { MyPageTab } from './_constants';
+
+interface MyPageProps {
+  searchParams: Promise<{ tab?: MyPageTab }>;
+}
+
+export default async function MyPage({ searchParams }: MyPageProps) {
+  const { tab } = await searchParams;
+  const activeTab = tab ?? DEFAULT_TAB;
+
+  return (
+    <main className='min-h-screen bg-gray-50'>
+      <MyPageTabs activeTab={activeTab} />
+      <SuspenseBoundary
+        pendingFallback={<p className='py-20 text-center text-gray-500'>불러오는 중...</p>}
+        errorFallback={<p className='py-20 text-center text-gray-500'>데이터를 불러오는데 실패했습니다.</p>}
+      >
+        <MyPageContent activeTab={activeTab} />
+      </SuspenseBoundary>
+    </main>
+  );
+}

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,5 +1,3 @@
-import { SuspenseBoundary } from '@/components/SuspenseBoundary';
-
 import { MyPageContent } from './_components/MyPageContent';
 import { MyPageTabs } from './_components/MyPageTabs';
 import { DEFAULT_TAB } from './_constants';
@@ -16,13 +14,13 @@ export default async function MyPage({ searchParams }: MyPageProps) {
 
   return (
     <main className='min-h-screen bg-gray-50'>
-      <MyPageTabs activeTab={activeTab} />
-      <SuspenseBoundary
-        pendingFallback={<p className='py-20 text-center text-gray-500'>불러오는 중...</p>}
-        errorFallback={<p className='py-20 text-center text-gray-500'>데이터를 불러오는데 실패했습니다.</p>}
-      >
-        <MyPageContent activeTab={activeTab} />
-      </SuspenseBoundary>
+      <div className='px-4 py-6 md:px-7 lg:px-15'>
+        <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mt-12'>마이페이지</h1>
+        <div className='mt-11'>
+          <MyPageTabs activeTab={activeTab} />
+          <MyPageContent activeTab={activeTab} />
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## ❓ 이슈

- close #188 

## ✍️ Description

마이페이지(`/my`) 라우트가 없는 상태에서 페이지 뼈대를 구현합니다.

**생성 파일**
- `page.tsx`: `searchParams.tab`으로 활성 탭 결정, 마이페이지 타이틀 및 레이아웃 구조
- `_constants.ts`: `MY_PAGE_TAB_ITEMS`, `MyPageTab` 타입, `DEFAULT_TAB` 정의
- `MyPageTabs`: 5개 탭 Link 네비게이션 (DashboardTabNav 패턴, `replace` + `scroll={false}`)
- `MyPageContent`: `activeTab` 기반 if-분기 라우터 (각 탭은 별도 이슈로 구현 예정)

**탭 목록**
나의 모임 / 만든 모임 / 대기중인 모임 / 받은 리뷰 / 찜한 모임

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

