### PR TITLE
[SM-125] fix: 모임 상세페이지 앵커탭, 신청폼크기, 비로그인 유저 신청 시 플로우 개선(BottomSheet overlay로 전환), ParticipantsList 드롭다운 위치 너비 개선(모바일 대응)

### DIFF
--- a/src/api/auth/queries.ts
+++ b/src/api/auth/queries.ts
@@ -49,10 +49,16 @@ export const useCheckNickname = (options?: UseMutationOptions<CheckAvailabilityR
 
 /** POST /auth/register — 이메일 회원가입 */
 export const useRegister = (options?: UseMutationOptions<RegisterResponse, Error, SignupForm, unknown>) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: register,
-    // NOTE: 신규 가입이므로 무효화할 기존 캐시 없음
     ...options,
+    onSuccess: (...args) => {
+      // NOTE: 상세페이지 같은 곳에서 유저 정보가 필요한 경우(상세페이지에서 회원가입 시 헤더 업데이트)를 대비해 유저 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: userKeys.me() });
+      options?.onSuccess?.(...args);
+    },
   });
 };
 

--- a/src/app/gatherings/[id]/_components/AnchorTabNav/index.tsx
+++ b/src/app/gatherings/[id]/_components/AnchorTabNav/index.tsx
@@ -60,7 +60,7 @@ export function AnchorTabNav() {
   };
 
   return (
-    <nav className='border-gray-150 bg-gray-0 border-b px-4 md:px-7 xl:px-30'>
+    <nav className='bg-gray-0 border-gray-150 sticky top-0 z-20 border-b px-4 md:px-7 xl:px-30'>
       <div className='mx-auto max-w-[1680px]'>
         <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
           {TAB_ITEMS.map(({ id, label }) => {

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCreateApplication } from '@/api/applications/queries';
 import { BottomSheet } from '@/components/ui/BottomSheet';
 import { useFunnel } from '@/hooks/useFunnel';

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
@@ -1,0 +1,40 @@
+import { useCreateApplication } from '@/api/applications/queries';
+import { BottomSheet } from '@/components/ui/BottomSheet';
+import { useFunnel } from '@/hooks/useFunnel';
+import { GatheringApplyForm } from '../../GatheringApplyForm';
+import { GatheringApplySuccess } from '../../GatheringApplySuccess';
+
+interface GatheringApplyBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  gatheringId: number;
+  gatheringTitle: string;
+}
+
+export function GatheringApplyBottomSheet({
+  isOpen,
+  onClose,
+  gatheringId,
+  gatheringTitle,
+}: GatheringApplyBottomSheetProps) {
+  const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
+
+  const { mutate, isPending } = useCreateApplication(gatheringId, {
+    onSuccess: () => setStep('SUCCESS'),
+  });
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose}>
+      <BottomSheet.Header showCloseButton={currentStep === 'APPLY'}>{null}</BottomSheet.Header>
+      <BottomSheet.Body>
+        <Funnel>
+          <Step name='APPLY'>
+            <GatheringApplyForm gatheringTitle={gatheringTitle} onSubmit={mutate} isLoading={isPending} />
+          </Step>
+          <Step name='SUCCESS'>
+            <GatheringApplySuccess onClose={onClose} />
+          </Step>
+        </Funnel>
+      </BottomSheet.Body>
+    </BottomSheet>
+  );
+}

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from 'react';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
-import { useCreateApplication } from '@/api/applications/queries';
+import { applicationQueries, useCreateApplication } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 import { BottomSheet } from '@/components/ui/BottomSheet';
@@ -20,6 +20,10 @@ interface FloatingActionBarProps {
 
 export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+  const { data: myApplications } = useQuery(applicationQueries.myList());
+
+  const hasPendingApplication =
+    myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const [isFavorite, setIsFavorite] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
@@ -52,11 +56,11 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
           </Button>
           <Button
             variant='action'
-            className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-            disabled={data.myApplicationStatus === 'PENDING'}
+            className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${hasPendingApplication ? 'bg-gray-300' : ''}`}
+            disabled={hasPendingApplication}
             onClick={() => setIsOpen(true)}
           >
-            {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
+            {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
           </Button>
         </div>
       </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -5,17 +5,14 @@ import { useState } from 'react';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
-import { applicationQueries, useCreateApplication } from '@/api/applications/queries';
+import { applicationQueries } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
-import { BottomSheet } from '@/components/ui/BottomSheet';
 import { AuthModal } from '@/components/AuthModal';
 import { useAuth } from '@/hooks/useAuth';
-import { useFunnel } from '@/hooks/useFunnel';
-
-import { GatheringApplyForm } from '../GatheringApplyForm';
-import { GatheringApplySuccess } from '../GatheringApplySuccess';
 import { useOverlay } from '@/hooks/useOverlay';
+
+import { GatheringApplyBottomSheet } from './GatheringApplyBottomSheet';
 
 interface FloatingActionBarProps {
   gatheringId: number;
@@ -32,20 +29,7 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const hasPendingApplication =
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const [isFavorite, setIsFavorite] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
   const overlay = useOverlay();
-  const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
-
-  const { mutate, isPending } = useCreateApplication(gatheringId, {
-    onSuccess: () => {
-      setStep('SUCCESS');
-    },
-  });
-
-  const handleClose = () => {
-    setIsOpen(false);
-    setStep('APPLY');
-  };
 
   return (
     <>
@@ -81,27 +65,20 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
                 });
                 if (!isLoginSuccessful) return;
               }
-              setIsOpen(true);
+              overlay.open(({ isOpen, close }) => (
+                <GatheringApplyBottomSheet
+                  gatheringId={gatheringId}
+                  gatheringTitle={data.title}
+                  isOpen={isOpen}
+                  onClose={() => close(false)}
+                />
+              ));
             }}
           >
             {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
           </Button>
         </div>
       </div>
-
-      <BottomSheet isOpen={isOpen} onClose={handleClose}>
-        <BottomSheet.Header showCloseButton={currentStep === 'APPLY'}>{null}</BottomSheet.Header>
-        <BottomSheet.Body className='scrollbar-none pb-10'>
-          <Funnel>
-            <Step name='APPLY'>
-              <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
-            </Step>
-            <Step name='SUCCESS'>
-              <GatheringApplySuccess onClose={handleClose} />
-            </Step>
-          </Funnel>
-        </BottomSheet.Body>
-      </BottomSheet>
     </>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -9,23 +9,31 @@ import { applicationQueries, useCreateApplication } from '@/api/applications/que
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 import { BottomSheet } from '@/components/ui/BottomSheet';
+import { AuthModal } from '@/components/AuthModal';
+import { useAuth } from '@/hooks/useAuth';
 import { useFunnel } from '@/hooks/useFunnel';
 
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
+import { useOverlay } from '@/hooks/useOverlay';
 
 interface FloatingActionBarProps {
   gatheringId: number;
 }
 
 export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
+  const { isLoggedIn } = useAuth();
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
-  const { data: myApplications } = useQuery(applicationQueries.myList());
+  const { data: myApplications } = useQuery({
+    ...applicationQueries.myList(),
+    enabled: isLoggedIn,
+  });
 
   const hasPendingApplication =
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const [isFavorite, setIsFavorite] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const overlay = useOverlay();
   const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
@@ -49,7 +57,15 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
             data-selected={isFavorite}
             aria-label='찜하기'
             aria-pressed={isFavorite}
-            onClick={() => setIsFavorite((prev) => !prev)}
+            onClick={async () => {
+              if (!isLoggedIn) {
+                const isLoginSuccessful = await overlay.open(({ isOpen, close }) => {
+                  return <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />;
+                });
+                if (!isLoginSuccessful) return;
+              }
+              setIsFavorite((prev) => !prev);
+            }}
             className='h-13.5 md:h-18'
           >
             <HeartIcon size={24} variant={isFavorite ? 'filled' : 'outline'} />
@@ -58,7 +74,15 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
             variant='action'
             className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${hasPendingApplication ? 'bg-gray-300' : ''}`}
             disabled={hasPendingApplication}
-            onClick={() => setIsOpen(true)}
+            onClick={async () => {
+              if (!isLoggedIn) {
+                const isLoginSuccessful = await overlay.open(({ isOpen, close }) => {
+                  return <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />;
+                });
+                if (!isLoginSuccessful) return;
+              }
+              setIsOpen(true);
+            }}
           >
             {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
           </Button>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
@@ -50,7 +50,7 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
   };
 
   return (
-    <form onSubmit={handleSubmit(handleFormSubmit)} className='flex flex-col gap-8'>
+    <form onSubmit={handleSubmit(handleFormSubmit)} className='flex flex-col gap-6'>
       <div className='flex flex-col gap-2'>
         <h2 className='text-h3-b text-gray-900'>모임 신청</h2>
         <p className='text-body-02-m text-gray-600'>
@@ -59,7 +59,7 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
         </p>
       </div>
 
-      <div className='flex flex-col gap-6'>
+      <div className='flex flex-col gap-4'>
         <div className='relative flex flex-col gap-2'>
           <div className='flex justify-between'>
             <label className='text-body-02-b text-gray-900'>
@@ -72,7 +72,7 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
             className='min-h-[160px]'
             error={errors.personalGoal?.message}
           />
-          <span className='text-small-01-r absolute right-4 bottom-10 text-gray-400'>{personalGoal.length}/200</span>
+          <span className='text-small-01-r absolute right-4 bottom-1 text-gray-400'>{personalGoal.length}/200</span>
         </div>
 
         <div className='relative flex flex-col gap-2'>
@@ -83,18 +83,18 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
             className='min-h-[120px]'
             error={errors.selfIntroduction?.message}
           />
-          <span className='text-small-01-r absolute right-4 bottom-10 text-gray-400'>
+          <span className='text-small-01-r absolute right-4 bottom-1 text-gray-400'>
             {selfIntroduction?.length}/100
           </span>
         </div>
       </div>
 
-      <div className='flex flex-col gap-4'>
+      <div className='flex flex-col gap-2'>
         <p className='text-body-02-b text-gray-900'>팀 구성을 위해 닉네임과 평판 점수가 모임장에게 전달됩니다.</p>
         <label className='flex cursor-pointer items-center gap-2'>
           <div className='relative flex h-5 w-5 items-center justify-center'>
             <input type='checkbox' {...register('agreement')} className='peer sr-only' />
-            <div className='flex h-6 w-6 items-center justify-center rounded-md border border-gray-200 bg-white transition-colors peer-checked:border-blue-300 peer-checked:bg-blue-300'>
+            <div className='flex h-4 w-4 items-center justify-center rounded-md border border-gray-200 bg-white transition-colors peer-checked:border-blue-300 peer-checked:bg-blue-300'>
               <CheckIcon size={16} className='text-white' />
             </div>
           </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from 'react';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
-import { useCreateApplication } from '@/api/applications/queries';
+import { applicationQueries, useCreateApplication } from '@/api/applications/queries';
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
@@ -32,6 +32,10 @@ interface GatheringInfoAsideProps {
 
 export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+  const { data: myApplications } = useQuery(applicationQueries.myList());
+
+  const hasPendingApplication =
+    myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const [isFavorite, setIsFavorite] = useState(false);
   const { Funnel, Step, setStep } = useFunnel<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
 
@@ -47,9 +51,9 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
     GATHERING_CATEGORY_LABEL[data.category as keyof typeof GATHERING_CATEGORY_LABEL] || data.category;
 
   return (
-    <div className='sticky top-[0.1px]'>
+    <div className='sticky top-[-20px]'>
       {/* 모집 상태 바 - 항상 노출 */}
-      <div className='border-focus-100 mt-15 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+      <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
         <div className='text-body-02-sb flex items-center text-blue-400'>모집중</div>
         <div className='flex items-center gap-2'>
           <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
@@ -112,11 +116,11 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
             <Button
               variant='action'
-              className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${data.myApplicationStatus === 'PENDING' ? 'bg-gray-300' : ''}`}
-              disabled={data.myApplicationStatus === 'PENDING'}
+              className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${hasPendingApplication ? 'bg-gray-300' : ''}`}
+              disabled={hasPendingApplication}
               onClick={() => setStep('APPLY')}
             >
-              {data.myApplicationStatus === 'PENDING' ? '참여 대기중' : '참여 신청하기'}
+              {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
             </Button>
           </GatheringCard>
         </Step>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -10,8 +10,11 @@ import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
+import { AuthModal } from '@/components/AuthModal';
 import { GATHERING_CATEGORY_LABEL, GATHERING_TYPE_LABEL } from '@/constants/gathering';
+import { useAuth } from '@/hooks/useAuth';
 import { useFunnel } from '@/hooks/useFunnel';
+import { useOverlay } from '@/hooks/useOverlay';
 
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
@@ -31,12 +34,17 @@ interface GatheringInfoAsideProps {
 }
 
 export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
+  const { isLoggedIn } = useAuth();
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
-  const { data: myApplications } = useQuery(applicationQueries.myList());
+  const { data: myApplications } = useQuery({
+    ...applicationQueries.myList(),
+    enabled: isLoggedIn,
+  });
 
   const hasPendingApplication =
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const [isFavorite, setIsFavorite] = useState(false);
+  const overlay = useOverlay();
   const { Funnel, Step, setStep } = useFunnel<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
@@ -91,7 +99,15 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                 data-selected={isFavorite}
                 aria-label='찜하기'
                 aria-pressed={isFavorite}
-                onClick={() => setIsFavorite((prev) => !prev)}
+                onClick={async () => {
+                  if (!isLoggedIn) {
+                    const isLoginSuccessful = await overlay.open(({ isOpen, close }) => (
+                      <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />
+                    ));
+                    if (!isLoginSuccessful) return;
+                  }
+                  setIsFavorite((prev) => !prev);
+                }}
               >
                 <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
               </Button>
@@ -118,7 +134,15 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
               variant='action'
               className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${hasPendingApplication ? 'bg-gray-300' : ''}`}
               disabled={hasPendingApplication}
-              onClick={() => setStep('APPLY')}
+              onClick={async () => {
+                if (!isLoggedIn) {
+                  const isLoginSuccessful = await overlay.open(({ isOpen, close }) => (
+                    <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />
+                  ));
+                  if (!isLoginSuccessful) return;
+                }
+                setStep('APPLY');
+              }}
             >
               {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
             </Button>

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -31,7 +31,7 @@ export function ParticipantsList({ members, maxMembers, className }: Participant
             />
           </div>
         </Dropdown.Trigger>
-        <Dropdown.Menu className='scrollbar-hide custom-scrollbar absolute top-[-20px] z-50 mt-2 max-h-60 w-48 overflow-y-auto rounded-xl bg-white p-2 shadow-lg'>
+        <Dropdown.Menu className='scrollbar-hide custom-scrollbar absolute top-[-20px] right-[-110px] z-50 mt-2 max-h-60 w-42 overflow-y-auto rounded-xl bg-white p-2 shadow-lg md:right-[-130px] md:w-48'>
           {members.map((member) => (
             <Dropdown.Item
               key={member.userId}

--- a/src/components/AuthModal/index.tsx
+++ b/src/components/AuthModal/index.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import { Modal } from '@/components/ui/Modal';
+
 import { AuthFunnel } from './AuthFunnel';
 
 interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onSuccess?: () => void;
 }
 
-export function AuthModal({ isOpen, onClose }: AuthModalProps) {
+export function AuthModal({ isOpen, onClose, onSuccess }: AuthModalProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <Modal.Body className='px-6 py-8'>
-        <AuthFunnel onSuccess={onClose} />
+        <AuthFunnel onSuccess={onSuccess ? onSuccess : onClose} />
       </Modal.Body>
     </Modal>
   );


### PR DESCRIPTION
## ❓ 이슈

- close #187 

## ✍️ Description

앵커탭 sticky 안되는 이슈와, 신청 폼 크기가(높이) 너무 커서 일부 화면에서 짤려보이는 이슈, 비 로그인 유저 신청/찜 시 플로우 개선을 하였습니다.

- [x] 앵커탭, 신청폼, 신청하기 버튼 상태 수정
  - [x] 앵커탭이 sticky되게
  - [x] pc버전 신청폼 gap을 줄이기
  - [x] 신청하기 버튼 상태가 신청 대기중, 신청하기로 applications 도메인의 status에 맞게 수정

- [x] AuthModal overlay 및 로그인 후 자동 액션 로직 구현
  - [x] useOverlay를 사용하여 AuthModal을 명령형으로 띄우도록 구성
  - [x] AuthModal에 onSuccess prop을 추가하여 성공/닫기 액션을 구분할 수 있도록 개선
  - [x] FloatingActionBar 및 GatheringInfoAside에서 로그인 성공 시 후속 액션이 바로 실행되도록 await 로직 적용
  - [x] 회원가입, 로그인, 로그아웃 성공 시 유저 정보 캐시 무효화 로직 추가

- [x] 태블릿 이하 참여 신청 로직을 GatheringApplyBottomSheet로 분리 및 useOverlay 적용
  - [x] FloatingActionBar의 참여 신청 로직(useFunnel, useCreateApplication)을 별도 컴포넌트로 캡슐화
  - [x] BottomSheet 열림 상태 관리를 useState에서 useOverlay(명령형) 방식으로 전환
  - [x] FloatingActionBar의 코드 복잡도 감소 및 관심사 분리
  - [x] ParticipantsList 드롭다운 위치 너비 개선(모바일 대응)

## 📸 스크린샷 (UI 변경 시)

비 로그인 유저 참여 신청 플로우 (로그인 후 버튼 클릭 흐름이 이어집니다. 태블릿 이하도 적용)

https://github.com/user-attachments/assets/b186e972-cd75-4d85-a329-3b36694989ca

비회원 유저 찜 플로우 (회원가입 후 버튼 클릭 흐름이 이어집니다)

https://github.com/user-attachments/assets/f9e06e07-24b2-4c2d-a88f-d47971a48670



## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- 찜의 경우 localStorage에 뒀다가 로그인/회원가입 시 동기화가 가장 best일 것 같지만 우선 전에 이야기한대로 회원만 찜 기능 이용할 수 있게 하기 위해 위와 같이 구현했습니다. (추후 로컬스토리지 동기화 로직 추가되면 찜은 제거)