### PR TITLE
[SM-136] fix: GET /gatherings 타입 필터 500 에러 및 모임 관련 type 파라미터 영어화

### DIFF
--- a/src/api/gatherings/index.ts
+++ b/src/api/gatherings/index.ts
@@ -5,6 +5,7 @@ import type { ApiResponse } from '@/api/common/types';
 import type {
   GatheringListItem,
   GatheringDetail,
+  GatheringTypeParam,
   GetApplicationStatusResponse,
   GetCategoriesResponse,
   GetGatheringsParams,
@@ -18,7 +19,13 @@ import type {
   UpdateGatheringResponse,
 } from './types';
 
-// ── 백엔드 호환 레이어 (백엔드가 categories: string[] 로 전환하면 제거) ──────
+// ── 백엔드 호환 레이어 ──────
+
+/** 프론트 한글 타입 → 백엔드 영어 타입 매핑 */
+const GATHERING_TYPE_TO_PARAM: Record<string, GatheringTypeParam> = {
+  스터디: 'STUDY',
+  프로젝트: 'PROJECT',
+};
 
 /** 백엔드 category 키 → 한글 라벨 매핑 */
 const CATEGORY_KEY_TO_LABEL: Record<string, string> = {
@@ -128,7 +135,8 @@ export const getGatherings = async (params?: GetGatheringsParams): Promise<GetGa
 export const createGathering = async (body: CreateGatheringRequest): Promise<CreateGatheringResponse> => {
   const formData = new FormData();
 
-  const { images, ...requestData } = body;
+  const { images, type, ...rest } = body;
+  const requestData = { ...rest, type: GATHERING_TYPE_TO_PARAM[type] };
 
   const requestBlob = new Blob([JSON.stringify(requestData)], { type: 'application/json' });
   formData.append('request', requestBlob);
@@ -148,7 +156,12 @@ export const updateGathering = async (
   gatheringId: number,
   body: UpdateGatheringRequest,
 ): Promise<UpdateGatheringResponse> => {
-  const { data } = await axiosClient.put<ApiResponse<UpdateGatheringResponse>>(`/v1/gatherings/${gatheringId}`, body);
+  const { type, ...rest } = body;
+  const requestData = { ...rest, ...(type && { type: GATHERING_TYPE_TO_PARAM[type] }) };
+  const { data } = await axiosClient.put<ApiResponse<UpdateGatheringResponse>>(
+    `/v1/gatherings/${gatheringId}`,
+    requestData,
+  );
   return unwrapResponse(data);
 };
 

--- a/src/api/gatherings/index.ts
+++ b/src/api/gatherings/index.ts
@@ -5,7 +5,6 @@ import type { ApiResponse } from '@/api/common/types';
 import type {
   GatheringListItem,
   GatheringDetail,
-  GatheringTypeParam,
   GetApplicationStatusResponse,
   GetCategoriesResponse,
   GetGatheringsParams,
@@ -18,14 +17,9 @@ import type {
   UpdateGatheringRequest,
   UpdateGatheringResponse,
 } from './types';
+import { GATHERING_TYPE_TO_PARAM } from './types';
 
 // ── 백엔드 호환 레이어 ──────
-
-/** 프론트 한글 타입 → 백엔드 영어 타입 매핑 */
-const GATHERING_TYPE_TO_PARAM: Record<string, GatheringTypeParam> = {
-  스터디: 'STUDY',
-  프로젝트: 'PROJECT',
-};
 
 /** 백엔드 category 키 → 한글 라벨 매핑 */
 const CATEGORY_KEY_TO_LABEL: Record<string, string> = {

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -15,7 +15,10 @@ export const gatheringFormSchema = z.object({
   type: z.enum(['스터디', '프로젝트'], {
     message: '모임 유형을 지정해 주세요.',
   }),
-  categoryIds: z.array(z.number()).min(1, '카테고리를 최소 1개 선택해 주세요.'),
+  categoryIds: z
+    .array(z.number())
+    .min(1, '카테고리를 최소 1개 선택해 주세요.')
+    .max(3, '카테고리는 최대 3개까지 선택 가능합니다.'),
   title: z.string().min(2, '제목은 2자 이상이어야 합니다.').max(30, '제목은 최대 30자까지 가능합니다.'),
   shortDescription: z
     .string()

--- a/src/api/gatherings/types.ts
+++ b/src/api/gatherings/types.ts
@@ -2,8 +2,11 @@ import type { z } from 'zod';
 
 import type { gatheringFormSchema, gatheringUpdateFormSchema } from './schemas';
 
-/** 모임 유형 */
+/** 모임 유형 (응답/표시용) */
 export type GatheringType = '스터디' | '프로젝트';
+
+/** 모임 유형 (API 쿼리 파라미터용) */
+export type GatheringTypeParam = 'STUDY' | 'PROJECT';
 
 /** 카테고리 항목 (GET /gatherings/categories 응답) */
 export interface Category {
@@ -90,7 +93,7 @@ export type GatheringUpdateForm = z.infer<typeof gatheringUpdateFormSchema>;
 
 /** GET `/gatherings` — 쿼리 파라미터 */
 export interface GetGatheringsParams {
-  type?: GatheringType;
+  type?: GatheringTypeParam;
   categoryIds?: number[];
   sort?: 'latest' | 'popular' | 'deadline';
   status?: GatheringStatus | 'ALL';

--- a/src/api/gatherings/types.ts
+++ b/src/api/gatherings/types.ts
@@ -8,6 +8,12 @@ export type GatheringType = '스터디' | '프로젝트';
 /** 모임 유형 (API 쿼리 파라미터용) */
 export type GatheringTypeParam = 'STUDY' | 'PROJECT';
 
+/** 프론트 한글 타입 → 백엔드 영어 타입 매핑 */
+export const GATHERING_TYPE_TO_PARAM: Record<GatheringType, GatheringTypeParam> = {
+  스터디: 'STUDY',
+  프로젝트: 'PROJECT',
+};
+
 /** 카테고리 항목 (GET /gatherings/categories 응답) */
 export interface Category {
   id: number;

--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -12,17 +12,24 @@ import { Pagination } from '@/components/ui/Pagination';
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
 
+import type { GatheringTypeParam } from '@/api/gatherings/types';
+
+const GATHERING_TYPE_PARAM_MAP: Record<string, GatheringTypeParam> = {
+  스터디: 'STUDY',
+  프로젝트: 'PROJECT',
+};
+
 const PAGE_LIMIT = 12;
 
 export function GatheringList() {
   const router = useRouter();
-  const { query, type, categoryId, sort, status, page, setParams } = useGatheringSearchParams();
+  const { query, type, categoryIds, sort, status, page, setParams } = useGatheringSearchParams();
 
   const { data } = useSuspenseQuery(
     gatheringQueries.list({
       ...(query && { query }),
-      ...(type && { type }),
-      ...(categoryId && { categoryIds: [categoryId] }),
+      ...(type && { type: GATHERING_TYPE_PARAM_MAP[type] }),
+      ...(categoryIds.length > 0 && { categoryIds }),
       sort,
       status,
       page,

--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -10,14 +10,8 @@ import { MainGatheringCard } from '@/components/MainGatheringCard';
 import { GatheringFilterBar } from '@/components/Search/GatheringFilterBar';
 import { Pagination } from '@/components/ui/Pagination';
 import { gatheringQueries } from '@/api/gatherings/queries';
+import { GATHERING_TYPE_TO_PARAM } from '@/api/gatherings/types';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
-
-import type { GatheringTypeParam } from '@/api/gatherings/types';
-
-const GATHERING_TYPE_PARAM_MAP: Record<string, GatheringTypeParam> = {
-  스터디: 'STUDY',
-  프로젝트: 'PROJECT',
-};
 
 const PAGE_LIMIT = 12;
 
@@ -28,7 +22,7 @@ export function GatheringList() {
   const { data } = useSuspenseQuery(
     gatheringQueries.list({
       ...(query && { query }),
-      ...(type && { type: GATHERING_TYPE_PARAM_MAP[type] }),
+      ...(type && { type: GATHERING_TYPE_TO_PARAM[type] }),
       ...(categoryIds.length > 0 && { categoryIds }),
       sort,
       status,

--- a/src/components/Search/SearchForm/ActiveFilters.tsx
+++ b/src/components/Search/SearchForm/ActiveFilters.tsx
@@ -8,9 +8,9 @@ import { DEFAULT_CATEGORIES } from '@/constants/gathering';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
 
 export function ActiveFilters() {
-  const { query, type, categoryId, setParams } = useGatheringSearchParams();
+  const { query, type, categoryIds, setParams } = useGatheringSearchParams();
 
-  const hasActiveFilters = query !== '' || type !== null || categoryId !== null;
+  const hasActiveFilters = query !== '' || type !== null || categoryIds.length > 0;
   if (!hasActiveFilters) return null;
 
   const handleRemoveQuery = () => {
@@ -25,15 +25,15 @@ export function ActiveFilters() {
     });
   };
 
-  const handleRemoveCategory = () => {
+  const handleRemoveCategory = (id: number) => {
     startTransition(() => {
-      setParams({ categoryId: null, page: 1 }, { history: 'push' });
+      setParams({ categoryIds: categoryIds.filter((v) => v !== id), page: 1 }, { history: 'push' });
     });
   };
 
   const handleResetFilters = () => {
     startTransition(() => {
-      setParams({ query: '', type: null, categoryId: null, page: 1 }, { history: 'push' });
+      setParams({ query: '', type: null, categoryIds: [], page: 1 }, { history: 'push' });
     });
   };
 
@@ -49,11 +49,11 @@ export function ActiveFilters() {
           {type}
         </Tag>
       )}
-      {categoryId && (
-        <Tag variant='filter' onRemove={handleRemoveCategory}>
-          {DEFAULT_CATEGORIES.find((c) => c.id === categoryId)?.name ?? categoryId}
+      {categoryIds.map((id) => (
+        <Tag key={id} variant='filter' onRemove={() => handleRemoveCategory(id)}>
+          {DEFAULT_CATEGORIES.find((c) => c.id === id)?.name ?? id}
         </Tag>
-      )}
+      ))}
       <button
         type='button'
         onClick={handleResetFilters}

--- a/src/components/Search/SearchForm/CategoryMultiSelect.tsx
+++ b/src/components/Search/SearchForm/CategoryMultiSelect.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { Dropdown } from '@/components/ui/Dropdown';
+import { useDropdown } from '@/components/ui/Dropdown/context';
+import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
+import { cn } from '@/lib/cn';
+
+const MAX_CATEGORIES = 3;
+
+function RotatingArrow() {
+  const { isOpen } = useDropdown();
+  return (
+    <ArrowIcon
+      size={16}
+      className={cn(
+        'shrink-0 rotate-90 text-gray-800 transition-transform duration-200 md:size-6',
+        isOpen && 'rotate-270',
+      )}
+    />
+  );
+}
+
+interface CategoryItem {
+  label: string;
+  value: number;
+}
+
+interface CategoryMultiSelectProps {
+  icon: ReactNode;
+  placeholder: string;
+  selectedValues: number[];
+  items: readonly CategoryItem[];
+  onChange: (values: number[]) => void;
+}
+
+export function CategoryMultiSelect({ icon, placeholder, selectedValues, items, onChange }: CategoryMultiSelectProps) {
+  const displayLabel =
+    selectedValues.length === 0
+      ? null
+      : items
+          .filter((item) => selectedValues.includes(item.value))
+          .map((item) => item.label)
+          .join(', ');
+
+  const handleSelect = (value: number) => {
+    if (selectedValues.length < MAX_CATEGORIES) {
+      onChange([...selectedValues, value]);
+    }
+  };
+
+  const handleRemove = (e: React.MouseEvent, value: number) => {
+    e.stopPropagation();
+    onChange(selectedValues.filter((v) => v !== value));
+  };
+
+  const handleReset = () => {
+    onChange([]);
+  };
+
+  return (
+    <Dropdown className='flex-1 **:[[role=listbox]]:w-full *:[button]:w-full'>
+      <Dropdown.Trigger>
+        <div className='flex w-full items-center justify-between px-5 py-4 md:px-7 md:py-5'>
+          <div className='flex min-w-0 items-center gap-2'>
+            {icon}
+            <span
+              className={cn(
+                'text-small-01-r md:text-body-01-r truncate',
+                displayLabel ? 'text-gray-900' : 'text-gray-400',
+              )}
+            >
+              {displayLabel ?? placeholder}
+            </span>
+          </div>
+          <RotatingArrow />
+        </div>
+      </Dropdown.Trigger>
+      <Dropdown.Menu className='w-full min-w-[160px] overflow-hidden p-2'>
+        <Dropdown.Item
+          onClick={handleReset}
+          className={cn(
+            'cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+            selectedValues.length === 0 && 'bg-blue-100 text-blue-400',
+          )}
+        >
+          전체
+        </Dropdown.Item>
+        {items.map((item) => {
+          const isSelected = selectedValues.includes(item.value);
+          const isDisabled = !isSelected && selectedValues.length >= MAX_CATEGORIES;
+
+          return (
+            <Dropdown.Item
+              key={item.value}
+              closeOnSelect={false}
+              onClick={() => {
+                if (isSelected) return;
+                if (!isDisabled) handleSelect(item.value);
+              }}
+              className={cn(
+                'flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+                isSelected && 'bg-blue-100 text-blue-400',
+                isDisabled && 'cursor-not-allowed opacity-40 hover:bg-transparent hover:text-inherit',
+              )}
+            >
+              {item.label}
+              {isSelected && (
+                <button
+                  type='button'
+                  onClick={(e) => handleRemove(e, item.value)}
+                  className='text-blue-400 hover:text-blue-600'
+                >
+                  &times;
+                </button>
+              )}
+            </Dropdown.Item>
+          );
+        })}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}

--- a/src/components/Search/SearchForm/index.tsx
+++ b/src/components/Search/SearchForm/index.tsx
@@ -9,17 +9,15 @@ import { DEFAULT_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
 
 import { ActiveFilters } from './ActiveFilters';
+import { CategoryMultiSelect } from './CategoryMultiSelect';
 import { FilterDropdown } from './FilterDropdown';
 import { SearchInput } from './SearchInput';
 
 const TYPE_ITEMS = [{ label: '전체', value: null }, ...GATHERING_TYPES.map((t) => ({ label: t, value: t }))] as const;
-const CATEGORY_ITEMS = [
-  { label: '전체', value: null },
-  ...DEFAULT_CATEGORIES.map((c) => ({ label: c.name, value: String(c.id) })),
-] as const;
+const CATEGORY_ITEMS = DEFAULT_CATEGORIES.map((c) => ({ label: c.name, value: c.id }));
 
 export function SearchForm() {
-  const { type, categoryId, setParams } = useGatheringSearchParams();
+  const { type, categoryIds, setParams } = useGatheringSearchParams();
   const [inputValue, setInputValue] = useState('');
 
   const handleSearch = () => {
@@ -44,9 +42,9 @@ export function SearchForm() {
     });
   };
 
-  const handleCategorySelect = (value: string | null) => {
+  const handleCategoryChange = (values: number[]) => {
     startTransition(() => {
-      setParams({ categoryId: value ? Number(value) : null, page: 1 }, { history: 'push' });
+      setParams({ categoryIds: values, page: 1 }, { history: 'push' });
     });
   };
 
@@ -68,12 +66,12 @@ export function SearchForm() {
 
           <div className='mx-5 border-t border-gray-200 md:mx-0 md:my-2 md:border-t-0 md:border-l' />
 
-          <FilterDropdown
+          <CategoryMultiSelect
             icon={<CategoryIcon size={20} className='shrink-0 text-gray-800 md:size-7' />}
             placeholder='카테고리를 선택해주세요'
-            selectedValue={categoryId ? String(categoryId) : null}
+            selectedValues={categoryIds}
             items={CATEGORY_ITEMS}
-            onSelect={handleCategorySelect}
+            onChange={handleCategoryChange}
           />
         </div>
 

--- a/src/hooks/useGatheringSearchParams.ts
+++ b/src/hooks/useGatheringSearchParams.ts
@@ -1,6 +1,12 @@
 'use client';
 
-import { useQueryParams, parseAsString, parseAsStringEnum, parseAsInteger } from '@frontend-toolkit-js/hooks';
+import {
+  useQueryParams,
+  parseAsString,
+  parseAsStringEnum,
+  parseAsInteger,
+  parseAsArray,
+} from '@frontend-toolkit-js/hooks';
 
 import { GATHERING_TYPES } from '@/constants/gathering';
 
@@ -11,7 +17,7 @@ export const useGatheringSearchParams = () => {
   return useQueryParams({
     query: parseAsString.withDefault(''),
     type: parseAsStringEnum(GATHERING_TYPES),
-    categoryId: parseAsInteger,
+    categoryIds: parseAsArray(parseAsInteger).withDefault([]),
     sort: parseAsStringEnum(SORT_OPTIONS).withDefault('latest'),
     status: parseAsStringEnum(STATUS_OPTIONS).withDefault('RECRUITING'),
     page: parseAsInteger.withDefault(1),

--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -15,6 +15,17 @@ const isUnauthorized = (error: unknown) => {
 export const axiosClient: AxiosInstance = axios.create({
   baseURL: '/api',
   withCredentials: true,
+  paramsSerializer: (params) => {
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        value.forEach((v) => searchParams.append(key, String(v)));
+      } else if (value !== undefined && value !== null) {
+        searchParams.append(key, String(value));
+      }
+    });
+    return searchParams.toString();
+  },
 });
 
 axiosClient.interceptors.response.use(


### PR DESCRIPTION
## ❓ 이슈

- close #205 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
백엔드 API 스펙과 프론트엔드 요청 파라미터 불일치로 인한 500 에러를 수정하고, 카테고리 복수 선택 기능을 추가합니다.

  ### 수정 사항
  - **type 파라미터 영어화**: 모임 목록 조회, 생성, 수정 시 `스터디`/`프로젝트` → `STUDY`/`PROJECT`로 변환하여 전송 (응답은 한글 그대로 유지)
  - **paramsSerializer 추가**: `categoryIds[]=2` → `categoryIds=2` 형태로 직렬화하여 Spring Boot 호환
  - **categoryIds 최대 3개 제한**: 모임 생성 스키마에 `.max(3)` 추가
  - **카테고리 복수 선택 UI**: `CategoryMultiSelect` 컴포넌트 추가, 최대 3개까지 선택 가능, x 버튼으로 개별 해제

  ### 변경 파일
  | 파일 | 변경 내용 |
  |------|----------|
  | `src/api/gatherings/types.ts` | `GatheringTypeParam` 타입 및 `GATHERING_TYPE_TO_PARAM` 매핑 상수 추가 |
  | `src/api/gatherings/schemas.ts` | `categoryIds.max(3)` 제한 추가 |
  | `src/api/gatherings/index.ts` | `createGathering`, `updateGathering`에서 type 변환 |
  | `src/lib/axiosClient.ts` | `paramsSerializer` 추가 |
  | `src/hooks/useGatheringSearchParams.ts` | `categoryId` → `categoryIds` 배열로 변경 |
  | `src/components/Search/SearchForm/CategoryMultiSelect.tsx` | 카테고리 멀티셀렉트 컴포넌트 신규 생성 |
  | `src/components/Search/SearchForm/index.tsx` | `CategoryMultiSelect` 적용 |
  | `src/components/Search/SearchForm/ActiveFilters.tsx` | `categoryIds` 배열 대응 |
  | `src/components/Search/GatheringList/index.tsx` | type 매핑 적용 |

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
