### PR TITLE
[SM-128] feat: 마이페이지 나의 모임 탭 구현

### DIFF
--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -27,6 +27,9 @@ export interface MembershipGathering {
   endDate: string;
   status: GatheringStatus;
   myRole: MemberRole;
+  isLiked: boolean;
+  /** 리뷰 작성 여부 — 백엔드 연동 전까지 응답에 포함되지 않으므로 optional. undefined는 미작성(false)으로 처리 */
+  hasReviewed?: boolean;
 }
 
 // GET /users/me/gatherings 응답

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -6,8 +6,6 @@ import { GatheringCard } from '@/components/ui/GatheringCard';
 import { CalendarIcon, ProjectIcon, ReviewIcon, StudyIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { Tag } from '@/components/ui/Tag';
-import { GATHERING_CATEGORY_LABEL, GATHERING_TYPE_LABEL } from '@/constants/gathering';
-
 import type { GatheringStatus, MembershipGathering } from '@/api/memberships/types';
 
 interface MyGatheringsCardProps {
@@ -51,11 +49,8 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
           <Tag
             variant='category'
             icon={<Icon size={14} className='text-blue-200' />}
-            label={GATHERING_TYPE_LABEL[gathering.type as keyof typeof GATHERING_TYPE_LABEL] ?? gathering.type}
-            sublabel={
-              GATHERING_CATEGORY_LABEL[gathering.category as keyof typeof GATHERING_CATEGORY_LABEL] ??
-              gathering.category
-            }
+            label={gathering.type}
+            sublabel={gathering.categories.join(', ')}
           />
           <Tag variant='status' state={STATUS_TAG_STATE[gathering.status]}>
             {STATUS_LABEL[gathering.status]}

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -66,26 +66,26 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
         <div>
           <div className='flex gap-1'>
             {gathering.tags.slice(0, 2).map((tag) => (
-              <span key={tag} className='text-small-01-r text-gray-500'>
+              <span key={tag} className='text-small-02-r md:text-small-01-r text-gray-500'>
                 #{tag}
               </span>
             ))}
           </div>
-          <div className='text-body-01-b text-gray-900'>{gathering.title}</div>
+          <div className='text-body-02-b md:text-body-01-b text-gray-900'>{gathering.title}</div>
           <div className='mt-2 flex items-center gap-2'>
             <CalendarIcon size={16} className='text-gray-600' />
             <div className='flex items-center gap-1'>
-              <span className='text-small-01-r text-gray-600'>
+              <span className='text-small-02-r md:text-small-01-r text-gray-600'>
                 {formatDateDot(gathering.startDate)} ~ {formatDateDot(gathering.endDate)}
               </span>
-              <span className='text-small-01-r text-gray-600'>・</span>
-              <span className='text-small-01-r text-gray-600'>{totalWeeks}주</span>
+              <span className='text-small-02-r md:text-small-01-r text-gray-600'>・</span>
+              <span className='text-small-02-r md:text-small-01-r text-gray-600'>{totalWeeks}주</span>
             </div>
-            <span className='text-small-01-r text-gray-400'>|</span>
+            <span className='text-small-02-r md:text-small-01-r text-gray-400'>|</span>
             <ProjectIcon size={16} className='text-gray-600' />
             <div className='flex items-center'>
-              <span className='text-small-01-r text-gray-600'>{gathering.currentMembers}</span>
-              <span className='text-small-01-r text-gray-400'>/{gathering.maxMembers}</span>
+              <span className='text-small-02-r md:text-small-01-r text-gray-600'>{gathering.currentMembers}</span>
+              <span className='text-small-02-r md:text-small-01-r text-gray-400'>/{gathering.maxMembers}</span>
             </div>
           </div>
           <ProgressBar label='달성률' layout='horizontal' value={progressRate} className='mb-4' />
@@ -93,29 +93,31 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
       </GatheringCard.Body>
       <GatheringCard.Footer>
         {gathering.status === 'IN_PROGRESS' && (
-          <div className='border-gray-150 flex h-[72px] w-full items-center rounded-[8px] border bg-gray-100'>
+          <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
             <div className='flex flex-1 items-center justify-center gap-1.5'>
-              <span className='text-body-01-m text-gray-600'>총</span>
-              <span className='text-body-01-sb text-blue-300'>{totalWeeks}주</span>
+              <span className='text-small-01-m md:text-body-01-m text-gray-600'>총</span>
+              <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>{totalWeeks}주</span>
             </div>
             <div className='bg-gray-150 h-6 w-px' />
             <div className='flex flex-1 items-center justify-center gap-1.5'>
-              <span className='text-body-01-sb text-blue-300'>{getCurrentWeek(gathering.startDate)}주차</span>
-              <span className='text-body-01-m text-gray-600'>진행중</span>
+              <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>
+                {getCurrentWeek(gathering.startDate)}주차
+              </span>
+              <span className='text-small-01-m md:text-body-01-m text-gray-600'>진행중</span>
             </div>
           </div>
         )}
         {gathering.status === 'COMPLETED' && !hasReviewed && (
-          <div className='flex h-[72px] w-full items-center justify-center rounded-[8px] bg-blue-50'>
+          <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
             <div className='flex items-center gap-2'>
-              <ReviewIcon size={24} className='text-blue-300' />
-              <span className='text-body-01-sb text-blue-300'>리뷰 쓰기</span>
+              <ReviewIcon size={16} className='text-blue-300 md:size-6' />
+              <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>리뷰 쓰기</span>
             </div>
           </div>
         )}
         {gathering.status === 'COMPLETED' && hasReviewed && (
-          <div className='flex h-[72px] w-full items-center justify-center rounded-[8px] bg-blue-50'>
-            <span className='text-body-01-sb text-gray-600'>리뷰 작성완료</span>
+          <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
+            <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성완료</span>
           </div>
         )}
       </GatheringCard.Footer>

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -1,0 +1,124 @@
+import { differenceInDays, startOfDay } from 'date-fns';
+
+import { formatDateDot, getCurrentWeek } from '@/lib/formatGatheringDate';
+
+import { GatheringCard } from '@/components/ui/GatheringCard';
+import { CalendarIcon, ProjectIcon, ReviewIcon, StudyIcon } from '@/components/ui/Icon';
+import { ProgressBar } from '@/components/ui/Progress';
+import { Tag } from '@/components/ui/Tag';
+import { GATHERING_CATEGORY_LABEL, GATHERING_TYPE_LABEL } from '@/constants/gathering';
+
+import type { GatheringStatus, MembershipGathering } from '@/api/memberships/types';
+
+interface MyGatheringsCardProps {
+  gathering: MembershipGathering;
+}
+
+const TYPE_ICON = {
+  STUDY: ProjectIcon,
+  PROJECT: StudyIcon,
+} as const;
+
+const STATUS_TAG_STATE: Record<GatheringStatus, 'recruiting' | 'progressing' | 'completed'> = {
+  RECRUITING: 'recruiting',
+  IN_PROGRESS: 'progressing',
+  COMPLETED: 'completed',
+};
+
+const STATUS_LABEL: Record<GatheringStatus, string> = {
+  RECRUITING: '모집중',
+  IN_PROGRESS: '진행중',
+  COMPLETED: '진행완료',
+};
+
+export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
+  const now = startOfDay(new Date());
+  const startDate = new Date(gathering.startDate);
+  const endDate = new Date(gathering.endDate);
+
+  const totalDays = differenceInDays(endDate, startDate);
+  const totalWeeks = Math.max(1, Math.ceil((totalDays + 1) / 7));
+  const passedDays = differenceInDays(now, startDate);
+  const progressRate = totalDays > 0 ? Math.min(100, Math.max(0, Math.floor((passedDays / totalDays) * 100))) : 0;
+
+  const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] ?? ProjectIcon;
+  const hasReviewed = !!gathering.hasReviewed;
+
+  return (
+    <GatheringCard>
+      <GatheringCard.Header className='items-start'>
+        <div className='flex gap-1'>
+          <Tag
+            variant='category'
+            icon={<Icon size={14} className='text-blue-200' />}
+            label={GATHERING_TYPE_LABEL[gathering.type as keyof typeof GATHERING_TYPE_LABEL] ?? gathering.type}
+            sublabel={
+              GATHERING_CATEGORY_LABEL[gathering.category as keyof typeof GATHERING_CATEGORY_LABEL] ??
+              gathering.category
+            }
+          />
+          <Tag variant='status' state={STATUS_TAG_STATE[gathering.status]}>
+            {STATUS_LABEL[gathering.status]}
+          </Tag>
+        </div>
+      </GatheringCard.Header>
+      <GatheringCard.Body>
+        <div>
+          <div className='flex gap-1'>
+            {gathering.tags.slice(0, 2).map((tag) => (
+              <span key={tag} className='text-small-01-r text-gray-500'>
+                #{tag}
+              </span>
+            ))}
+          </div>
+          <div className='text-body-01-b text-gray-900'>{gathering.title}</div>
+          <div className='mt-2 flex items-center gap-2'>
+            <CalendarIcon size={16} className='text-gray-600' />
+            <div className='flex items-center gap-1'>
+              <span className='text-small-01-r text-gray-600'>
+                {formatDateDot(gathering.startDate)} ~ {formatDateDot(gathering.endDate)}
+              </span>
+              <span className='text-small-01-r text-gray-600'>・</span>
+              <span className='text-small-01-r text-gray-600'>{totalWeeks}주</span>
+            </div>
+            <span className='text-small-01-r text-gray-400'>|</span>
+            <ProjectIcon size={16} className='text-gray-600' />
+            <div className='flex items-center'>
+              <span className='text-small-01-r text-gray-600'>{gathering.currentMembers}</span>
+              <span className='text-small-01-r text-gray-400'>/{gathering.maxMembers}</span>
+            </div>
+          </div>
+          <ProgressBar label='달성률' layout='horizontal' value={progressRate} className='mb-4' />
+        </div>
+      </GatheringCard.Body>
+      <GatheringCard.Footer>
+        {gathering.status === 'IN_PROGRESS' && (
+          <div className='border-gray-150 flex h-[72px] w-full items-center rounded-[8px] border bg-gray-100'>
+            <div className='flex flex-1 items-center justify-center gap-1.5'>
+              <span className='text-body-01-m text-gray-600'>총</span>
+              <span className='text-body-01-sb text-blue-300'>{totalWeeks}주</span>
+            </div>
+            <div className='bg-gray-150 h-6 w-px' />
+            <div className='flex flex-1 items-center justify-center gap-1.5'>
+              <span className='text-body-01-sb text-blue-300'>{getCurrentWeek(gathering.startDate)}주차</span>
+              <span className='text-body-01-m text-gray-600'>진행중</span>
+            </div>
+          </div>
+        )}
+        {gathering.status === 'COMPLETED' && !hasReviewed && (
+          <div className='flex h-[72px] w-full items-center justify-center rounded-[8px] bg-blue-50'>
+            <div className='flex items-center gap-2'>
+              <ReviewIcon size={24} className='text-blue-300' />
+              <span className='text-body-01-sb text-blue-300'>리뷰 쓰기</span>
+            </div>
+          </div>
+        )}
+        {gathering.status === 'COMPLETED' && hasReviewed && (
+          <div className='flex h-[72px] w-full items-center justify-center rounded-[8px] bg-blue-50'>
+            <span className='text-body-01-sb text-gray-600'>리뷰 작성완료</span>
+          </div>
+        )}
+      </GatheringCard.Footer>
+    </GatheringCard>
+  );
+}

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -13,8 +13,8 @@ interface MyGatheringsCardProps {
 }
 
 const TYPE_ICON = {
-  STUDY: ProjectIcon,
-  PROJECT: StudyIcon,
+  스터디: StudyIcon,
+  프로젝트: ProjectIcon,
 } as const;
 
 const STATUS_TAG_STATE: Record<GatheringStatus, 'recruiting' | 'progressing' | 'completed'> = {

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -53,12 +53,21 @@ export function MyGatheringsList() {
   const [page, setPage] = useState(1);
   const [isPending, startTransition] = useTransition();
 
-  const { data } = useSuspenseQuery(membershipQueries.my({ status, page, limit }));
+  // status=all: API가 RECRUITING 포함 반환 → 서버 totalPages 신뢰 불가
+  // → 전체를 한 번에 받아(limit=999) 클라이언트에서 필터/페이지네이션
+  // status=in_progress|completed: 서버 필터 정확 → 서버 페이지네이션 그대로 사용
+  const isAll = status === 'all';
+  const { data } = useSuspenseQuery(
+    membershipQueries.my({ status, page: isAll ? 1 : page, limit: isAll ? 999 : limit }),
+  );
 
-  const sortedGatherings = [...data.gatherings].sort((a, b) => {
+  const filtered = isAll ? data.gatherings.filter((g) => g.status !== 'RECRUITING') : data.gatherings;
+  const sorted = [...filtered].sort((a, b) => {
     const diff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
     return sort === 'latest' ? -diff : diff;
   });
+  const totalPages = isAll ? Math.max(1, Math.ceil(sorted.length / limit)) : data.totalPages;
+  const paged = isAll ? sorted.slice((page - 1) * limit, page * limit) : sorted;
 
   const handleFilterChange = (next: Partial<{ status: MyStatusFilter; sort: SortOrder }>) => {
     if (next.sort !== undefined) {
@@ -105,7 +114,7 @@ export function MyGatheringsList() {
               <RotatingArrow />
             </div>
           </Dropdown.Trigger>
-          <Dropdown.Menu className='flex min-w-[100px] flex-col gap-2 overflow-hidden p-2'>
+          <Dropdown.Menu className='flex flex-col gap-2 overflow-hidden p-2 whitespace-nowrap'>
             {STATUS_OPTIONS.map((option) => {
               const isSelected = status === option.value;
               return (
@@ -125,23 +134,23 @@ export function MyGatheringsList() {
         </Dropdown>
       </div>
 
-      {sortedGatherings.length === 0 ? (
+      {paged.length === 0 ? (
         <div className='flex h-40 items-center justify-center'>
           <p className='text-body-02-r text-gray-400'>참여한 모임이 없습니다.</p>
         </div>
       ) : (
         <div className={cn('grid grid-cols-1 gap-4 lg:grid-cols-2', isPending && 'opacity-50')}>
-          {sortedGatherings.map((gathering) => (
+          {paged.map((gathering) => (
             <MyGatheringsCard key={gathering.id} gathering={gathering} />
           ))}
         </div>
       )}
 
-      {data.totalPages > 1 && (
+      {totalPages > 1 && (
         <Pagination
           variant='numbered'
           currentPage={page}
-          totalPages={data.totalPages}
+          totalPages={totalPages}
           onPageChange={(p) => startTransition(() => setPage(p))}
         />
       )}

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -84,6 +84,10 @@ export function MyGatheringsList() {
 
   return (
     <div className='mt-6 flex flex-col gap-6'>
+      <div className='flex items-center gap-2'>
+        <span className='text-body-01-b md:text-h3-b text-gray-900'>{selectedStatusLabel}</span>
+        <span className='text-small-02-r md:text-body-01-r text-gray-500'>총 {sorted.length}건</span>
+      </div>
       <div className='flex items-center justify-between'>
         <div className='flex items-center gap-2 md:gap-4'>
           {SORT_OPTIONS.map((option, index) => {
@@ -122,7 +126,7 @@ export function MyGatheringsList() {
                   key={option.value}
                   onClick={() => handleFilterChange({ status: option.value })}
                   className={cn(
-                    'cursor-pointer rounded-lg px-4 py-2 hover:bg-blue-100 hover:text-blue-400',
+                    'text-small-02-m md:text-body-02-m cursor-pointer rounded-lg px-4 py-2 hover:bg-blue-100 hover:text-blue-400',
                     isSelected && 'bg-blue-100 text-blue-400',
                   )}
                 >

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { cn } from '@/lib/cn';
+import { Dropdown } from '@/components/ui/Dropdown';
+import { useDropdown } from '@/components/ui/Dropdown/context';
+import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
+import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
+import { Pagination } from '@/components/ui/Pagination';
+import { membershipQueries } from '@/api/memberships/queries';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+import { MyGatheringsCard } from '../MyGatheringsCard';
+
+import type { GatheringStatusFilter } from '@/api/memberships/types';
+
+type SortOrder = 'latest' | 'oldest';
+type MyStatusFilter = Extract<GatheringStatusFilter, 'all' | 'in_progress' | 'completed'>;
+
+const SORT_OPTIONS: { label: string; value: SortOrder }[] = [
+  { label: '최신순', value: 'latest' },
+  { label: '과거순', value: 'oldest' },
+];
+
+const STATUS_OPTIONS: { label: string; value: MyStatusFilter }[] = [
+  { label: '전체', value: 'all' },
+  { label: '진행중', value: 'in_progress' },
+  { label: '진행완료', value: 'completed' },
+];
+
+function RotatingArrow() {
+  const { isOpen } = useDropdown();
+  return (
+    <ArrowIcon
+      size={16}
+      className={cn(
+        'shrink-0 rotate-90 text-gray-800 transition-transform duration-200 md:size-5',
+        isOpen && 'rotate-270',
+      )}
+    />
+  );
+}
+
+export function MyGatheringsList() {
+  const isLg = useMediaQuery('(min-width: 1024px)');
+  const limit = isLg ? 6 : 5;
+
+  const [status, setStatus] = useState<MyStatusFilter>('all');
+  const [sort, setSort] = useState<SortOrder>('latest');
+  const [page, setPage] = useState(1);
+  const [isPending, startTransition] = useTransition();
+
+  const { data } = useSuspenseQuery(membershipQueries.my({ status, page, limit }));
+
+  const sortedGatherings = [...data.gatherings].sort((a, b) => {
+    const diff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
+    return sort === 'latest' ? -diff : diff;
+  });
+
+  const handleFilterChange = (next: Partial<{ status: MyStatusFilter; sort: SortOrder }>) => {
+    if (next.sort !== undefined) {
+      setSort(next.sort);
+      return;
+    }
+    startTransition(() => {
+      if (next.status !== undefined) setStatus(next.status);
+      setPage(1);
+    });
+  };
+
+  const selectedStatusLabel = STATUS_OPTIONS.find((o) => o.value === status)?.label ?? '전체';
+
+  return (
+    <div className='mt-6 flex flex-col gap-6'>
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center gap-2 md:gap-4'>
+          {SORT_OPTIONS.map((option, index) => {
+            const isSelected = sort === option.value;
+            return (
+              <div key={option.value} className='flex items-center gap-2 md:gap-4'>
+                {index > 0 && <span className='text-small-02-r md:text-body-02-r text-gray-500'>|</span>}
+                <button
+                  type='button'
+                  onClick={() => handleFilterChange({ sort: option.value })}
+                  className={cn(
+                    'text-small-02-r md:text-body-02-r flex cursor-pointer items-center gap-0.5',
+                    isSelected ? 'font-semibold text-gray-800' : 'text-gray-500',
+                  )}
+                >
+                  <CheckIcon size={16} className={cn('md:size-6', !isSelected && 'hidden')} />
+                  {option.label}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <Dropdown className='**:[[role=listbox]]:right-0'>
+          <Dropdown.Trigger>
+            <div className='flex items-center gap-2'>
+              <span className='text-small-02-m md:text-body-02-m text-gray-800'>{selectedStatusLabel}</span>
+              <RotatingArrow />
+            </div>
+          </Dropdown.Trigger>
+          <Dropdown.Menu className='flex min-w-[100px] flex-col gap-2 overflow-hidden p-2'>
+            {STATUS_OPTIONS.map((option) => {
+              const isSelected = status === option.value;
+              return (
+                <Dropdown.Item
+                  key={option.value}
+                  onClick={() => handleFilterChange({ status: option.value })}
+                  className={cn(
+                    'cursor-pointer rounded-lg px-4 py-2 hover:bg-blue-100 hover:text-blue-400',
+                    isSelected && 'bg-blue-100 text-blue-400',
+                  )}
+                >
+                  {option.label}
+                </Dropdown.Item>
+              );
+            })}
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+
+      {sortedGatherings.length === 0 ? (
+        <div className='flex h-40 items-center justify-center'>
+          <p className='text-body-02-r text-gray-400'>참여한 모임이 없습니다.</p>
+        </div>
+      ) : (
+        <div className={cn('grid grid-cols-1 gap-4 lg:grid-cols-2', isPending && 'opacity-50')}>
+          {sortedGatherings.map((gathering) => (
+            <MyGatheringsCard key={gathering.id} gathering={gathering} />
+          ))}
+        </div>
+      )}
+
+      {data.totalPages > 1 && (
+        <Pagination
+          variant='numbered'
+          currentPage={page}
+          totalPages={data.totalPages}
+          onPageChange={(p) => startTransition(() => setPage(p))}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -13,14 +13,9 @@ export function MyPageContent({ activeTab }: MyPageContentProps) {
     return (
       <SuspenseBoundary
         pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
-        errorFallback={(_, reset) => (
-          <div className='flex h-40 flex-col items-center justify-center gap-2 text-gray-500'>
-            <p>모임을 불러올 수 없습니다.</p>
-            <button onClick={reset} className='text-blue-400 underline'>
-              다시 시도
-            </button>
-          </div>
-        )}
+        errorFallback={
+          <p className='flex h-40 items-center justify-center text-gray-500'>모임을 불러올 수 없습니다.</p>
+        }
       >
         <MyGatheringsList />
       </SuspenseBoundary>

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -1,3 +1,7 @@
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+
+import { MyGatheringsList } from '../MyGatheringsList';
+
 import type { MyPageTab } from '../../_constants';
 
 interface MyPageContentProps {
@@ -5,7 +9,22 @@ interface MyPageContentProps {
 }
 
 export function MyPageContent({ activeTab }: MyPageContentProps) {
-  if (activeTab === 'my-gatherings') return <p>나의 모임</p>;
+  if (activeTab === 'my-gatherings')
+    return (
+      <SuspenseBoundary
+        pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
+        errorFallback={(_, reset) => (
+          <div className='flex h-40 flex-col items-center justify-center gap-2 text-gray-500'>
+            <p>모임을 불러올 수 없습니다.</p>
+            <button onClick={reset} className='text-blue-400 underline'>
+              다시 시도
+            </button>
+          </div>
+        )}
+      >
+        <MyGatheringsList />
+      </SuspenseBoundary>
+    );
   if (activeTab === 'created-gatherings') return <p>만든 모임</p>;
   if (activeTab === 'pending-gatherings') return <p>대기중인 모임</p>;
   if (activeTab === 'received-reviews') return <p>받은 리뷰</p>;

--- a/src/mocks/handlers/memberships.ts
+++ b/src/mocks/handlers/memberships.ts
@@ -34,6 +34,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'IN_PROGRESS',
     myRole: 'LEADER',
+    isLiked: false,
   },
   {
     id: 2,
@@ -48,6 +49,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-05-30',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    isLiked: false,
   },
   {
     id: 3,
@@ -62,6 +64,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-02-28',
     status: 'COMPLETED',
     myRole: 'MEMBER',
+    isLiked: false,
   },
   {
     id: 4,
@@ -76,6 +79,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    isLiked: false,
   },
   {
     id: 5,
@@ -90,6 +94,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    isLiked: false,
   },
   {
     id: 6,
@@ -104,6 +109,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    isLiked: false,
   },
   {
     id: 7,
@@ -118,6 +124,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    isLiked: false,
   },
   {
     id: 8,
@@ -132,6 +139,7 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    isLiked: false,
   },
 ];
 


### PR DESCRIPTION
## ❓ 이슈

- close #190 

## ✍️ Description

마이페이지 "나의 모임" 탭의 placeholder를 실제 기능으로 교체합니다.
참여한 모임 목록을 카드 형태로 표시하며, 상태 필터 / 정렬 / 페이지네이션을 제공합니다.

### 주요 변경사항

**`MyGatheringsCard` (신규)**
- `GatheringCard` compound 컴포넌트 기반으로 구현
- `formatDateDot`, `getCurrentWeek` 유틸 함수 재사용
- 모임 상태별 Footer 분기
  - `IN_PROGRESS`: 총 N주 | M주차 진행중 패널
  - `COMPLETED && !hasReviewed`: 리뷰 쓰기 버튼
  - `COMPLETED && hasReviewed`: 리뷰 작성완료 텍스트
- sm / md 반응형 타이포그래피 적용

**`MyGatheringsList` (신규)**
- 상태 필터: 전체 / 진행중 / 진행완료 (모집중 노출 없음)
- 정렬: 최신순 / 과거순 (클라이언트 정렬, 서버 미지원)
- 페이지네이션: lg 6개(2열×3행), sm·md 5개(1열×5행)
- `status=all` 시 API가 RECRUITING 포함 반환하는 문제 대응
  - `limit=999`로 전체 로드 후 클라이언트에서 RECRUITING 필터 및 페이지네이션 처리
  - `status=in_progress|completed`는 서버 페이지네이션 그대로 사용
- `status` 변경 시 `startTransition` 적용으로 Suspense fallback 깜빡임 방지
- 정렬 변경은 API 재요청 없이 클라이언트 재정렬만 수행 → `startTransition` 불필요

**`MyPageContent` (수정)**
- `my-gatherings` 탭에 `SuspenseBoundary` + `MyGatheringsList` 연결
- `errorFallback`을 JSX 요소로 전달 (서버 컴포넌트에서 함수 prop 직렬화 불가 오류 수정)

**`src/api/memberships/types.ts` (수정)**
- `MembershipGathering`에 `hasReviewed?: boolean` 추가
  - 백엔드 미지원으로 optional 처리, `undefined`는 `false`로 간주
  - 백엔드 연동 시 required로 변경 예정

### 기술적 결정사항

| 항목 | 결정 | 이유 |
|------|------|------|
| `sort` 서버 전송 | 금지 | 백엔드 미지원, `MyGatheringsParams`에 미포함 |
| `status=all` 페이지네이션 | 클라이언트 | API가 RECRUITING 포함 반환 → 서버 totalPages 신뢰 불가 |
| `hasReviewed` 타입 | `optional` | 백엔드 추후 지원, undefined → false 처리 |

## 📸 스크린샷 (UI 변경 시)
<img width="790" height="720" alt="화면 캡처 2026-04-07 155040" src="https://github.com/user-attachments/assets/0b75fb53-9ca5-40ff-8aea-043616f2fa27" />
<img width="812" height="686" alt="화면 캡처 2026-04-07 160129" src="https://github.com/user-attachments/assets/ac582283-6e4a-46cd-b18a-052df78c665b" />
<img width="814" height="588" alt="화면 캡처 2026-04-07 160222" src="https://github.com/user-attachments/assets/9933094b-6dff-4b24-8d2d-ac45337c727c" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] `hasReviewed` 백엔드 연동 시 optional → required 변경 필요
- [ ] `sort` 백엔드 지원 시 `MyGatheringsParams`에 추가 및 queryKey 포함 필요
- [ ] 리뷰 쓰기 미구현
