### PR TITLE
[SM-137] fix: 인증 토큰 리프레시 로직 수정 및 인증 상태 기반 UI/라우팅 개선

### DIFF
--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -27,7 +27,6 @@ export interface MembershipGathering {
   endDate: string;
   status: GatheringStatus;
   myRole: MemberRole;
-  isLiked: boolean;
   /** 리뷰 작성 여부 — 백엔드 연동 전까지 응답에 포함되지 않으므로 optional. undefined는 미작성(false)으로 처리 */
   hasReviewed?: boolean;
 }

--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -1,12 +1,8 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { getExpirationDate } from '@/lib/getExpirationDate';
+
+import { deleteAuthCookies, setAuthCookies } from '@/lib/authCookies';
 import { requestBackend } from '@/lib/serverFetch';
 import { isJsonResponse, extractTokens } from '@/lib/tokenUtils';
-
-const ACCESS_TOKEN_COOKIE = 'accessToken';
-const REFRESH_TOKEN_COOKIE = 'refreshToken';
-const AUTH_HINT_COOKIE = 'has-session';
-const isSecureCookie = process.env.NODE_ENV === 'production';
 
 const isAuthEndpoint = (endpoint: string) => {
   const normalized = endpoint.replace(/^\/+/, '');
@@ -53,9 +49,7 @@ async function proxy(request: NextRequest, params: { endpoint: string[] }) {
     });
 
     if (isLogoutSuccess) {
-      response.cookies.delete(ACCESS_TOKEN_COOKIE);
-      response.cookies.delete(REFRESH_TOKEN_COOKIE);
-      response.cookies.delete(AUTH_HINT_COOKIE);
+      deleteAuthCookies(response);
     }
 
     return response;
@@ -74,39 +68,11 @@ async function proxy(request: NextRequest, params: { endpoint: string[] }) {
   });
 
   if (isLogoutSuccess) {
-    response.cookies.delete(ACCESS_TOKEN_COOKIE);
-    response.cookies.delete(REFRESH_TOKEN_COOKIE);
-    response.cookies.delete(AUTH_HINT_COOKIE);
+    deleteAuthCookies(response);
+    return response;
   }
 
-  if (nextAccessToken) {
-    const expires = getExpirationDate(nextAccessToken) ?? undefined;
-    response.cookies.set(ACCESS_TOKEN_COOKIE, nextAccessToken, {
-      httpOnly: true,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires,
-    });
-    response.cookies.set(AUTH_HINT_COOKIE, '1', {
-      httpOnly: false,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires,
-    });
-  }
-
-  if (nextRefreshToken) {
-    const expires = getExpirationDate(nextRefreshToken) ?? undefined;
-    response.cookies.set(REFRESH_TOKEN_COOKIE, nextRefreshToken, {
-      httpOnly: true,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires,
-    });
-  }
+  setAuthCookies(response, { accessToken: nextAccessToken, refreshToken: nextRefreshToken });
 
   return response;
 }

--- a/src/app/api/[...endpoint]/route.ts
+++ b/src/app/api/[...endpoint]/route.ts
@@ -5,6 +5,7 @@ import { isJsonResponse, extractTokens } from '@/lib/tokenUtils';
 
 const ACCESS_TOKEN_COOKIE = 'accessToken';
 const REFRESH_TOKEN_COOKIE = 'refreshToken';
+const AUTH_HINT_COOKIE = 'has-session';
 const isSecureCookie = process.env.NODE_ENV === 'production';
 
 const isAuthEndpoint = (endpoint: string) => {
@@ -54,6 +55,7 @@ async function proxy(request: NextRequest, params: { endpoint: string[] }) {
     if (isLogoutSuccess) {
       response.cookies.delete(ACCESS_TOKEN_COOKIE);
       response.cookies.delete(REFRESH_TOKEN_COOKIE);
+      response.cookies.delete(AUTH_HINT_COOKIE);
     }
 
     return response;
@@ -74,12 +76,20 @@ async function proxy(request: NextRequest, params: { endpoint: string[] }) {
   if (isLogoutSuccess) {
     response.cookies.delete(ACCESS_TOKEN_COOKIE);
     response.cookies.delete(REFRESH_TOKEN_COOKIE);
+    response.cookies.delete(AUTH_HINT_COOKIE);
   }
 
   if (nextAccessToken) {
     const expires = getExpirationDate(nextAccessToken) ?? undefined;
     response.cookies.set(ACCESS_TOKEN_COOKIE, nextAccessToken, {
       httpOnly: true,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires,
+    });
+    response.cookies.set(AUTH_HINT_COOKIE, '1', {
+      httpOnly: false,
       secure: isSecureCookie,
       sameSite: 'lax',
       path: '/',

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -5,6 +5,7 @@ import { isJsonResponse, extractTokens } from '@/lib/tokenUtils';
 
 const ACCESS_TOKEN_COOKIE = 'accessToken';
 const REFRESH_TOKEN_COOKIE = 'refreshToken';
+const AUTH_HINT_COOKIE = 'has-session';
 const isSecureCookie = process.env.NODE_ENV === 'production';
 
 const clearAuthCookies = (response: NextResponse) => {
@@ -17,6 +18,13 @@ const clearAuthCookies = (response: NextResponse) => {
   });
   response.cookies.set(REFRESH_TOKEN_COOKIE, '', {
     httpOnly: true,
+    secure: isSecureCookie,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  response.cookies.set(AUTH_HINT_COOKIE, '', {
+    httpOnly: false,
     secure: isSecureCookie,
     sameSite: 'lax',
     path: '/',
@@ -40,7 +48,7 @@ export async function POST(request: NextRequest) {
   if (!baseUrl) throw new Error('BACKEND_BASE_URL is not defined');
   const backendBaseUrl = baseUrl.replace(/\/+$/, '');
 
-  const backendResponse = await fetch(`${backendBaseUrl}/auth/refresh`, {
+  const backendResponse = await fetch(`${backendBaseUrl}/v1/auth/refresh`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -71,6 +79,13 @@ export async function POST(request: NextRequest) {
     const expires = getExpirationDate(nextAccessToken) ?? undefined;
     response.cookies.set(ACCESS_TOKEN_COOKIE, nextAccessToken, {
       httpOnly: true,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires,
+    });
+    response.cookies.set(AUTH_HINT_COOKIE, '1', {
+      httpOnly: false,
       secure: isSecureCookie,
       sameSite: 'lax',
       path: '/',

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,36 +1,9 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-import { getExpirationDate } from '@/lib/getExpirationDate';
+import { clearAuthCookies, setAuthCookies } from '@/lib/authCookies';
 import { isJsonResponse, extractTokens } from '@/lib/tokenUtils';
 
-const ACCESS_TOKEN_COOKIE = 'accessToken';
 const REFRESH_TOKEN_COOKIE = 'refreshToken';
-const AUTH_HINT_COOKIE = 'has-session';
-const isSecureCookie = process.env.NODE_ENV === 'production';
-
-const clearAuthCookies = (response: NextResponse) => {
-  response.cookies.set(ACCESS_TOKEN_COOKIE, '', {
-    httpOnly: true,
-    secure: isSecureCookie,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 0,
-  });
-  response.cookies.set(REFRESH_TOKEN_COOKIE, '', {
-    httpOnly: true,
-    secure: isSecureCookie,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 0,
-  });
-  response.cookies.set(AUTH_HINT_COOKIE, '', {
-    httpOnly: false,
-    secure: isSecureCookie,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 0,
-  });
-};
 
 export async function POST(request: NextRequest) {
   const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE)?.value ?? null;
@@ -75,34 +48,7 @@ export async function POST(request: NextRequest) {
     return response;
   }
 
-  if (nextAccessToken) {
-    const expires = getExpirationDate(nextAccessToken) ?? undefined;
-    response.cookies.set(ACCESS_TOKEN_COOKIE, nextAccessToken, {
-      httpOnly: true,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires,
-    });
-    response.cookies.set(AUTH_HINT_COOKIE, '1', {
-      httpOnly: false,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires,
-    });
-  }
-
-  if (nextRefreshToken) {
-    const expires = getExpirationDate(nextRefreshToken) ?? undefined;
-    response.cookies.set(REFRESH_TOKEN_COOKIE, nextRefreshToken, {
-      httpOnly: true,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires,
-    });
-  }
+  setAuthCookies(response, { accessToken: nextAccessToken, refreshToken: nextRefreshToken });
   // 새로 발급받은 토큰은 프론트엔드에 주는 대신, Next.js 서버가 다시 httpOnly 쿠키로 브라우저에 심어줍니다.
 
   return response;

--- a/src/app/gatherings/[id]/_components/AnchorTabNav/index.tsx
+++ b/src/app/gatherings/[id]/_components/AnchorTabNav/index.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { cn } from '@/lib/cn';
+import { useAuth } from '@/hooks/useAuth';
 
-const TAB_ITEMS = [
+const BASE_TAB_ITEMS = [
   { id: 'description', label: '모임 설명' },
   { id: 'recruit-period', label: '모집 기간' },
   { id: 'activity-period', label: '활동 기간' },
@@ -13,12 +17,24 @@ const TAB_ITEMS = [
   { id: 'members', label: '모집 인원 현황' },
 ] as const;
 
-type SectionId = (typeof TAB_ITEMS)[number]['id'];
+const LEADER_TAB_ITEM = { id: 'pending-applications', label: '신청 대기자' } as const;
+
+type SectionId = (typeof BASE_TAB_ITEMS)[number]['id'] | typeof LEADER_TAB_ITEM.id;
+
+interface AnchorTabNavProps {
+  gatheringId: number;
+}
 
 const SCROLL_LOCK_MS = 500;
 
-export function AnchorTabNav() {
-  const [activeSectionId, setActiveSectionId] = useState<SectionId>(TAB_ITEMS[0].id);
+export function AnchorTabNav({ gatheringId }: AnchorTabNavProps) {
+  const { user } = useAuth();
+  const { data } = useQuery(gatheringQueries.detail(gatheringId));
+
+  const isLeader = data?.members.some((m) => m.userId === user?.id && m.role === 'LEADER') ?? false;
+
+  const tabItems = useMemo(() => (isLeader ? [LEADER_TAB_ITEM, ...BASE_TAB_ITEMS] : [...BASE_TAB_ITEMS]), [isLeader]);
+  const [activeSectionId, setActiveSectionId] = useState<SectionId>(tabItems[0].id);
   const isScrollingRef = useRef(false);
 
   useEffect(() => {
@@ -40,13 +56,13 @@ export function AnchorTabNav() {
       },
     );
 
-    TAB_ITEMS.forEach(({ id }) => {
+    tabItems.forEach(({ id }) => {
       const el = document.getElementById(id);
       if (el) observer.observe(el);
     });
 
     return () => observer.disconnect();
-  }, []);
+  }, [tabItems]);
 
   const handleTabClick = (sectionId: SectionId) => {
     isScrollingRef.current = true;
@@ -63,7 +79,7 @@ export function AnchorTabNav() {
     <nav className='bg-gray-0 border-gray-150 sticky top-0 z-20 border-b px-4 md:px-7 xl:px-30'>
       <div className='mx-auto max-w-[1680px]'>
         <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
-          {TAB_ITEMS.map(({ id, label }) => {
+          {tabItems.map(({ id, label }) => {
             const isActive = activeSectionId === id;
 
             return (

--- a/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
@@ -3,7 +3,9 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
+import { cn } from '@/lib/cn';
 import { formatDateDot, formatDday } from '@/lib/formatGatheringDate';
+import { useAuth } from '@/hooks/useAuth';
 
 import { GatheringDescription } from '../GatheringDescription';
 import { ImageCarousel } from '../ImageCarousel';
@@ -16,13 +18,27 @@ interface GatheringDetailContentProps {
 }
 
 export function GatheringDetailContent({ gatheringId }: GatheringDetailContentProps) {
+  const { user } = useAuth();
   const { data } = useQuery(gatheringQueries.detail(gatheringId));
 
   if (!data) return null;
 
+  const isLeader = data.members.some((m) => m.userId === user?.id && m.role === 'LEADER');
+
   return (
     <div className='flex flex-col'>
-      <section id='description' className='scroll-mt-10 xl:scroll-mt-12'>
+      {isLeader && (
+        <section id='pending-applications' className='scroll-mt-10 xl:scroll-mt-12'>
+          <div className='flex flex-col gap-4'>
+            <h2 className='text-body-01-sb xl:text-h5-sb text-gray-900'>신청 대기자 👑</h2>
+            <div className='border-gray-150 rounded-lg border bg-gray-50 px-4 py-6'>
+              <p className='text-body-02-r text-gray-500'>신청 대기자 관리 기능은 준비 중입니다</p>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section id='description' className={cn('scroll-mt-10 xl:scroll-mt-12', isLeader && 'mt-15')}>
         <GatheringDescription description={data.description} />
       </section>
 

--- a/src/app/gatherings/[id]/dashboard/page.tsx
+++ b/src/app/gatherings/[id]/dashboard/page.tsx
@@ -1,4 +1,9 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { fetchGatheringDetail } from '@/api/gatherings';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+import { getUserIdFromToken } from '@/lib/getUserIdFromToken';
 
 import { DashboardContent } from './_components/DashboardContent';
 import { DashboardHeader } from './_components/DashboardHeader';
@@ -18,6 +23,24 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
   const { tab } = await searchParams;
   const gatheringId = Number(id);
   const activeTab = tab ?? DEFAULT_TAB;
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  const hasRefreshToken = cookieStore.has('refreshToken');
+  const userId = getUserIdFromToken(accessToken);
+
+  // accessToken 없지만 refreshToken 있으면 클라이언트에서 리프레시 처리 → 검증 스킵
+  if (userId !== null) {
+    try {
+      const gathering = await fetchGatheringDetail(gatheringId);
+      const isMember = gathering.members.some((m) => m.userId === userId);
+      if (!isMember) redirect(`/gatherings/${gatheringId}`);
+    } catch {
+      redirect(`/gatherings/${gatheringId}`);
+    }
+  } else if (!hasRefreshToken) {
+    redirect(`/gatherings/${gatheringId}`);
+  }
 
   return (
     <main className='min-h-screen bg-gray-50'>

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -39,7 +39,7 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
 
           {/* TODO: [이슈 3] 앵커 탭 네비게이션 */}
 
-          <AnchorTabNav />
+          <AnchorTabNav gatheringId={gatheringId} />
 
           <div className='px-4 pt-10 md:px-7 xl:flex xl:gap-20 xl:px-30'>
             <section className='min-w-0 flex-1'>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,8 +10,18 @@ interface AuthState {
   isLoading: boolean;
 }
 
+const hasSessionHint = () => typeof document !== 'undefined' && document.cookie.includes('has-session=');
+
 export const useAuth = (): AuthState => {
-  const { data, isError, isLoading } = useQuery(userQueries.me());
+  const enabled = hasSessionHint();
+  const { data, isError, isLoading } = useQuery({
+    ...userQueries.me(),
+    enabled,
+  });
+
+  if (!enabled) {
+    return { user: null, isLoggedIn: false, isLoading: false };
+  }
 
   const isLoggedIn = !isLoading && !isError && data !== undefined;
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { useIsMounted } from '@frontend-toolkit-js/hooks';
+
 import { userQueries } from '@/api/users/queries';
 
 import type { User } from '@/api/users/types';
@@ -10,16 +12,16 @@ interface AuthState {
   isLoading: boolean;
 }
 
-const hasSessionHint = () => typeof document !== 'undefined' && document.cookie.includes('has-session=');
-
 export const useAuth = (): AuthState => {
-  const enabled = hasSessionHint();
+  const isMounted = useIsMounted();
+  const hasSession = isMounted && document.cookie.includes('has-session=');
+
   const { data, isError, isLoading } = useQuery({
     ...userQueries.me(),
-    enabled,
+    enabled: hasSession,
   });
 
-  if (!enabled) {
+  if (!hasSession) {
     return { user: null, isLoggedIn: false, isLoading: false };
   }
 

--- a/src/lib/authCookies.ts
+++ b/src/lib/authCookies.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+
+import { getExpirationDate } from './getExpirationDate';
+
+const ACCESS_TOKEN_COOKIE = 'accessToken';
+const REFRESH_TOKEN_COOKIE = 'refreshToken';
+const AUTH_HINT_COOKIE = 'has-session';
+const isSecureCookie = process.env.NODE_ENV === 'production';
+
+export const setAuthCookies = (
+  response: NextResponse,
+  tokens: { accessToken: string | null; refreshToken: string | null },
+) => {
+  if (tokens.accessToken) {
+    const expires = getExpirationDate(tokens.accessToken) ?? undefined;
+    response.cookies.set(ACCESS_TOKEN_COOKIE, tokens.accessToken, {
+      httpOnly: true,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires,
+    });
+    response.cookies.set(AUTH_HINT_COOKIE, '1', {
+      httpOnly: false,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires,
+    });
+  }
+
+  if (tokens.refreshToken) {
+    const expires = getExpirationDate(tokens.refreshToken) ?? undefined;
+    response.cookies.set(REFRESH_TOKEN_COOKIE, tokens.refreshToken, {
+      httpOnly: true,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires,
+    });
+  }
+};
+
+export const clearAuthCookies = (response: NextResponse) => {
+  response.cookies.set(ACCESS_TOKEN_COOKIE, '', {
+    httpOnly: true,
+    secure: isSecureCookie,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  response.cookies.set(REFRESH_TOKEN_COOKIE, '', {
+    httpOnly: true,
+    secure: isSecureCookie,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  response.cookies.set(AUTH_HINT_COOKIE, '', {
+    httpOnly: false,
+    secure: isSecureCookie,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+};
+
+export const deleteAuthCookies = (response: NextResponse) => {
+  response.cookies.delete(ACCESS_TOKEN_COOKIE);
+  response.cookies.delete(REFRESH_TOKEN_COOKIE);
+  response.cookies.delete(AUTH_HINT_COOKIE);
+};

--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -7,10 +7,16 @@ const refreshClient = axios.create({
   withCredentials: true,
 });
 
-const isUnauthorized = (error: unknown) => {
+// TODO: 백엔드에서 인증 없는 요청에 401 통일 후 500 조건 제거
+const shouldAttemptRefresh = (error: unknown) => {
   if (!axios.isAxiosError(error)) return false;
-  return error.response?.status === 401;
+  const status = error.response?.status;
+  if (status === 401) return true;
+  if (status === 500 && !error.config?.headers?.Authorization) return true;
+  return false;
 };
+
+let refreshPromise: Promise<unknown> | null = null;
 
 export const axiosClient: AxiosInstance = axios.create({
   baseURL: '/api',
@@ -31,7 +37,7 @@ export const axiosClient: AxiosInstance = axios.create({
 axiosClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
-    if (!isUnauthorized(error)) throw error;
+    if (!shouldAttemptRefresh(error)) throw error;
 
     const config = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined;
     if (!config || config._retry) throw error;
@@ -42,10 +48,18 @@ axiosClient.interceptors.response.use(
     config._retry = true;
 
     try {
-      await refreshClient.post(REFRESH_PATH);
+      if (!refreshPromise) {
+        refreshPromise = refreshClient.post(REFRESH_PATH).finally(() => {
+          refreshPromise = null;
+        });
+      }
+      await refreshPromise;
       return await axiosClient.request(config);
-    } catch (refreshError) {
-      throw refreshError;
+    } catch {
+      if (!window.location.pathname.startsWith('/login')) {
+        window.location.href = '/login';
+      }
+      throw error;
     }
   },
 );

--- a/src/lib/decodeBase64Url.ts
+++ b/src/lib/decodeBase64Url.ts
@@ -1,0 +1,5 @@
+export const decodeBase64Url = (input: string) => {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('binary');
+};

--- a/src/lib/getExpirationDate.ts
+++ b/src/lib/getExpirationDate.ts
@@ -1,9 +1,4 @@
-const decodeBase64Url = (input: string) => {
-  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
-  const decoded = typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('binary');
-  return decoded;
-};
+import { decodeBase64Url } from './decodeBase64Url';
 
 export const getExpirationDate = (jwt: string): Date | null => {
   const parts = jwt.split('.');

--- a/src/lib/getUserIdFromToken.ts
+++ b/src/lib/getUserIdFromToken.ts
@@ -1,8 +1,4 @@
-const decodeBase64Url = (input: string) => {
-  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
-  return typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('binary');
-};
+import { decodeBase64Url } from './decodeBase64Url';
 
 export const getUserIdFromToken = (token: string | undefined): number | null => {
   if (!token) return null;

--- a/src/lib/getUserIdFromToken.ts
+++ b/src/lib/getUserIdFromToken.ts
@@ -1,0 +1,18 @@
+const decodeBase64Url = (input: string) => {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('binary');
+};
+
+export const getUserIdFromToken = (token: string | undefined): number | null => {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+
+  try {
+    const payload = JSON.parse(decodeBase64Url(parts[1])) as { sub?: string };
+    return payload.sub ? Number(payload.sub) : null;
+  } catch {
+    return null;
+  }
+};

--- a/src/mocks/handlers/memberships.ts
+++ b/src/mocks/handlers/memberships.ts
@@ -34,7 +34,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'IN_PROGRESS',
     myRole: 'LEADER',
-    isLiked: false,
   },
   {
     id: 2,
@@ -49,7 +48,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-05-30',
     status: 'RECRUITING',
     myRole: 'MEMBER',
-    isLiked: false,
   },
   {
     id: 3,
@@ -64,7 +62,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-02-28',
     status: 'COMPLETED',
     myRole: 'MEMBER',
-    isLiked: false,
   },
   {
     id: 4,
@@ -79,7 +76,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
-    isLiked: false,
   },
   {
     id: 5,
@@ -94,7 +90,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
-    isLiked: false,
   },
   {
     id: 6,
@@ -109,7 +104,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
-    isLiked: false,
   },
   {
     id: 7,
@@ -124,7 +118,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
-    isLiked: false,
   },
   {
     id: 8,
@@ -139,7 +132,6 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
-    isLiked: false,
   },
 ];
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -81,7 +81,7 @@ export const proxy = async (request: NextRequest) => {
       if (isAuthRoute) {
         const redirect = NextResponse.redirect(new URL('/', request.url));
         refreshed.cookies.getAll().forEach((cookie) => {
-          redirect.cookies.set(cookie.name, cookie.value);
+          redirect.cookies.set(cookie);
         });
         return redirect;
       }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -76,8 +76,13 @@ export const proxy = async (request: NextRequest) => {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 
-  // 인증 라우트: accessToken 있으면 홈으로
+  // 인증 라우트: accessToken 있으면 /main으로
   if (isAuthRoute && hasAccessToken) {
+    return NextResponse.redirect(new URL('/main', request.url));
+  }
+
+  // 랜딩 페이지: 로그인 상태면 /main으로
+  if (pathname === '/' && hasAccessToken) {
     return NextResponse.redirect(new URL('/main', request.url));
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getExpirationDate } from '@/lib/getExpirationDate';
+import { setAuthCookies } from '@/lib/authCookies';
 import { extractTokens } from '@/lib/tokenUtils';
 
-const PROTECTED_ROUTES = ['/my', '/gatherings/new', '/gathering/dashboard'];
+const PROTECTED_ROUTES = ['/my', '/gatherings/new'];
+const PROTECTED_PATTERNS = [/^\/gatherings\/\d+\/dashboard/];
 const AUTH_ROUTES = ['/login', '/register'];
-
-const isSecureCookie = process.env.NODE_ENV === 'production';
 
 const tryRefreshToken = async (request: NextRequest): Promise<NextResponse | null> => {
   const refreshToken = request.cookies.get('refreshToken')?.value;
@@ -30,34 +29,7 @@ const tryRefreshToken = async (request: NextRequest): Promise<NextResponse | nul
     if (!nextAccessToken) return null;
 
     const response = NextResponse.next();
-    const accessTokenExpires = getExpirationDate(nextAccessToken) ?? undefined;
-
-    response.cookies.set('accessToken', nextAccessToken, {
-      httpOnly: true,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires: accessTokenExpires,
-    });
-
-    response.cookies.set('has-session', '1', {
-      httpOnly: false,
-      secure: isSecureCookie,
-      sameSite: 'lax',
-      path: '/',
-      expires: accessTokenExpires,
-    });
-
-    if (nextRefreshToken) {
-      const refreshTokenExpires = getExpirationDate(nextRefreshToken) ?? undefined;
-      response.cookies.set('refreshToken', nextRefreshToken, {
-        httpOnly: true,
-        secure: isSecureCookie,
-        sameSite: 'lax',
-        path: '/',
-        expires: refreshTokenExpires,
-      });
-    }
+    setAuthCookies(response, { accessToken: nextAccessToken, refreshToken: nextRefreshToken });
 
     return response;
   } catch {
@@ -69,7 +41,9 @@ export const proxy = async (request: NextRequest) => {
   const { pathname } = request.nextUrl;
   const hasAccessToken = request.cookies.has('accessToken');
   const hasRefreshToken = request.cookies.has('refreshToken');
-  const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+  const isProtectedRoute =
+    PROTECTED_ROUTES.some((route) => pathname.startsWith(route)) ||
+    PROTECTED_PATTERNS.some((pattern) => pattern.test(pathname));
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
 
   // accessToken 없고 refreshToken만 있으면 → 갱신 시도
@@ -104,7 +78,7 @@ export const proxy = async (request: NextRequest) => {
 
   // 인증 라우트: accessToken 있으면 홈으로
   if (isAuthRoute && hasAccessToken) {
-    return NextResponse.redirect(new URL('/', request.url));
+    return NextResponse.redirect(new URL('/main', request.url));
   }
 
   return NextResponse.next();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,22 +1,109 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { getExpirationDate } from '@/lib/getExpirationDate';
+import { extractTokens } from '@/lib/tokenUtils';
+
 const PROTECTED_ROUTES = ['/my', '/gatherings/new', '/gathering/dashboard'];
 const AUTH_ROUTES = ['/login', '/register'];
 
-export const proxy = (request: NextRequest) => {
+const isSecureCookie = process.env.NODE_ENV === 'production';
+
+const tryRefreshToken = async (request: NextRequest): Promise<NextResponse | null> => {
+  const refreshToken = request.cookies.get('refreshToken')?.value;
+  if (!refreshToken) return null;
+
+  const backendBaseUrl = process.env.BACKEND_BASE_URL?.replace(/\/+$/, '');
+  if (!backendBaseUrl) return null;
+
+  try {
+    const backendResponse = await fetch(`${backendBaseUrl}/v1/auth/refresh`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+      cache: 'no-store',
+    });
+
+    if (!backendResponse.ok) return null;
+
+    const json = (await backendResponse.json()) as unknown;
+    const { accessToken: nextAccessToken, refreshToken: nextRefreshToken } = extractTokens(json);
+    if (!nextAccessToken) return null;
+
+    const response = NextResponse.next();
+    const accessTokenExpires = getExpirationDate(nextAccessToken) ?? undefined;
+
+    response.cookies.set('accessToken', nextAccessToken, {
+      httpOnly: true,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires: accessTokenExpires,
+    });
+
+    response.cookies.set('has-session', '1', {
+      httpOnly: false,
+      secure: isSecureCookie,
+      sameSite: 'lax',
+      path: '/',
+      expires: accessTokenExpires,
+    });
+
+    if (nextRefreshToken) {
+      const refreshTokenExpires = getExpirationDate(nextRefreshToken) ?? undefined;
+      response.cookies.set('refreshToken', nextRefreshToken, {
+        httpOnly: true,
+        secure: isSecureCookie,
+        sameSite: 'lax',
+        path: '/',
+        expires: refreshTokenExpires,
+      });
+    }
+
+    return response;
+  } catch {
+    return null;
+  }
+};
+
+export const proxy = async (request: NextRequest) => {
   const { pathname } = request.nextUrl;
   const hasAccessToken = request.cookies.has('accessToken');
   const hasRefreshToken = request.cookies.has('refreshToken');
-  const hasAuth = hasAccessToken || hasRefreshToken;
-
   const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
 
-  if (isProtectedRoute && !hasAuth) {
+  // accessToken 없고 refreshToken만 있으면 → 갱신 시도
+  if (!hasAccessToken && hasRefreshToken) {
+    const refreshed = await tryRefreshToken(request);
+
+    if (refreshed) {
+      // 인증 라우트면 홈으로 (이미 로그인된 상태)
+      if (isAuthRoute) {
+        const redirect = NextResponse.redirect(new URL('/', request.url));
+        refreshed.cookies.getAll().forEach((cookie) => {
+          redirect.cookies.set(cookie.name, cookie.value);
+        });
+        return redirect;
+      }
+      // 그 외 페이지는 갱신된 쿠키를 실어서 계속 진행
+      return refreshed;
+    }
+
+    // 갱신 실패: 보호 라우트면 로그인으로
+    if (isProtectedRoute) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+    // 공개 라우트면 그냥 진행 (비로그인 상태로)
+    return NextResponse.next();
+  }
+
+  // 보호 라우트: 토큰 하나도 없으면 로그인으로
+  if (isProtectedRoute && !hasAccessToken) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 
-  if (isAuthRoute && hasAuth) {
+  // 인증 라우트: accessToken 있으면 홈으로
+  if (isAuthRoute && hasAccessToken) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 


### PR DESCRIPTION
## ❓ 이슈

- close #207 

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
  accessToken 만료 시 refreshToken으로 재발급하는 로직이 동작하지 않는 버그가 발견되었습니다.
근본 원인은 `refresh/route.ts`에서 백엔드 요청 경로에 `/v1` prefix가 누락된 것이었고,
추가로 인증 인터셉터, proxy 라우팅, 비로그인 최적화 등 인증 전반에 개선이 필요했습니다.

  ### 변경사항

  #### 1. 토큰 리프레시 API 경로 수정 (`refresh/route.ts`)
  - `${backendBaseUrl}/auth/refresh` → `${backendBaseUrl}/v1/auth/refresh`
  - 다른 API는 `[...endpoint]/route.ts`가 클라이언트 경로를 그대로 전달하지만, refresh route만 경로를 하드코딩하고 있어서 `/v1`이 빠져있었음
  - **이것이 리프레시 실패(403)의 근본 원인**

  #### 2. 인증 인터셉터 개선 (`axiosClient.ts`)
  - **500 응답 대응 (임시)**: 백엔드가 인증 없는 요청에 스펙(401)과 다르게 500을 반환하는 경우가 있어, Authorization 헤더 없이 500이면 리프레시 시도. 백엔드에서 401 통일 후 제거 예정 (TODO 주석)
  - **리프레시 Promise 공유**: 동시에 여러 요청이 401을 받으면 각각 리프레시를 호출하던 문제 해결. 모듈 레벨 `refreshPromise` 변수로 첫 요청만 리프레시 실행, 나머지는 동일 Promise 대기
  - **리프레시 실패 시 `/login` 리다이렉트**: refreshToken도 만료되면 에러만 throw하고 방치하던 것을 로그인 페이지로 안내. 이미 `/login`이면 리다이렉트하지 않음 (무한 루프 방지)

  #### 3. proxy에서 refreshToken 기반 자동 토큰 갱신 (`proxy.ts`)
  - accessToken 없고 refreshToken만 있을 때, 백엔드에 직접 리프레시 요청 (Supabase SSR 공식 패턴)
  - 성공 시: 새 토큰을 쿠키에 설정하고 페이지 진행. 인증 라우트(`/login`)면 홈으로 리다이렉트
  - 실패 시: 보호 라우트면 로그인으로 리다이렉트, 공개 라우트면 비로그인 상태로 진행
  - 기존 `hasAuth = hasAccessToken || hasRefreshToken` 단순 판단을 세분화된 조건으로 개선

  #### 4. Auth Hint Cookie로 비로그인 시 불필요한 요청 제거
  - **문제**: 비로그인 사용자가 매 페이지마다 실패할 요청 2개(users/me + auth/refresh)를 보냄. httpOnly 쿠키라 클라이언트에서 토큰 존재 여부를 알 수 없어서 useAuth가 무조건 요청
  - **해결**: 로그인/리프레시 성공 시 `has-session=1` (non-httpOnly) 힌트 쿠키를 토큰과 함께 설정, 로그아웃/실패 시 삭제
  - `useAuth.ts`에서 `document.cookie`로 힌트 쿠키 확인 → 없으면 `enabled: false` → 요청 0개
  - 좋은 방법인지는 모르겠으나 조사했을 때 우선 React Starter Kit, Supabase 등에서 사용되는 패턴이라고 나와 우선 임시로 선택
  - **Static 렌더링 유지** (layout.tsx에서 `cookies()` 호출 불필요)
  - 적용 파일: `[...endpoint]/route.ts`, `refresh/route.ts`, `useAuth.ts`

  #### 5. 대시보드 비멤버 접근 차단 (`dashboard/page.tsx`)
  - 서버에서 accessToken의 JWT payload(`sub`)에서 userId 추출 → 모임 상세의 members와 비교
  - 비멤버면 모임 상세 페이지로 리다이렉트
  - accessToken 없고 refreshToken만 있으면 검증 스킵 → 클라이언트에서 리프레시 후 정상 접근
  - `getUserIdFromToken.ts` 유틸 신규 생성 (서명 검증 없이 디코딩만, 보안 검증은 백엔드 담당)

  #### 6. 모임 상세 모임장 UI 분기 (`AnchorTabNav`, `GatheringDetailContent`)
  - 클라이언트에서 `useAuth()` + `useQuery(detail)` 캐시 히트로 모임장 판별 (추가 API 요청 없음)
  - 모임장이면 앵커 탭에 "신청 대기자" 탭 첫 번째 추가 + 모임 설명 위에 신청 대기자 섹션 표시
  - 신청 대기자 관리 기능은 플레이스홀더 (추후 구현)

  #### 7. 로컬 코드 리뷰 반영
  - `proxy.ts`: 리다이렉트 시 쿠키 객체 전체 전달 (속성 누락 방지)
  - `decodeBase64Url`: `getExpirationDate.ts`와 `getUserIdFromToken.ts`에 중복되던 함수를 공통 유틸로 추출


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
