### PR TITLE
[SM-129] feat: 마이페이지 만든 모임 탭 구현 및 상세페이지 상태 관련 리팩토링

### DIFF
--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -29,6 +29,7 @@ export interface MembershipGathering {
   myRole: MemberRole;
   /** 리뷰 작성 여부 — 백엔드 연동 전까지 응답에 포함되지 않으므로 optional. undefined는 미작성(false)으로 처리 */
   hasReviewed?: boolean;
+  pendingApplicationCount: number;
 }
 
 // GET /users/me/gatherings 응답

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -32,13 +32,7 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const [isFavorite, setIsFavorite] = useState(false);
   const overlay = useOverlay();
 
-  const { isJoinable, isFinished, isFull, isDeadlinePassed } = getGatheringDisplayStatus({
-    status: data.status,
-    currentMembers: data.currentMembers,
-    maxMembers: data.maxMembers,
-    startDate: data.startDate,
-    endDate: data.endDate,
-  });
+  const { isJoinable, isFinished, isFull, isDeadlinePassed } = getGatheringDisplayStatus(data);
 
   const isJoinableStatus = isJoinable && !hasPendingApplication;
 

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -6,6 +6,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { applicationQueries } from '@/api/applications/queries';
+import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 import { AuthModal } from '@/components/AuthModal';
@@ -30,6 +31,16 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const [isFavorite, setIsFavorite] = useState(false);
   const overlay = useOverlay();
+
+  const { isJoinable, isFinished, isFull, isDeadlinePassed } = getGatheringDisplayStatus({
+    status: data.status,
+    currentMembers: data.currentMembers,
+    maxMembers: data.maxMembers,
+    startDate: data.startDate,
+    endDate: data.endDate,
+  });
+
+  const isJoinableStatus = isJoinable && !hasPendingApplication;
 
   return (
     <>
@@ -56,8 +67,8 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
           </Button>
           <Button
             variant='action'
-            className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${hasPendingApplication ? 'bg-gray-300' : ''}`}
-            disabled={hasPendingApplication}
+            className='text-body-01-sb h-13.5 flex-1 md:h-18'
+            disabled={!isJoinableStatus}
             onClick={async () => {
               if (!isLoggedIn) {
                 const isLoginSuccessful = await overlay.open(({ isOpen, close }) => {
@@ -75,7 +86,13 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
               ));
             }}
           >
-            {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
+            {(() => {
+              if (isFinished) return '완료된 모임';
+              if (data.status === 'IN_PROGRESS' || isDeadlinePassed) return '모집 마감';
+              if (isFull) return '모집 완료';
+              if (hasPendingApplication) return '참여 대기중';
+              return '참여 신청하기';
+            })()}
           </Button>
         </div>
       </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -6,7 +6,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { applicationQueries } from '@/api/applications/queries';
-import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
+import { getGatheringDisplayStatus, getJoinButtonText } from '@/lib/gatheringStatus';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
 import { AuthModal } from '@/components/AuthModal';
@@ -80,13 +80,13 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
               ));
             }}
           >
-            {(() => {
-              if (isFinished) return '완료된 모임';
-              if (data.status === 'IN_PROGRESS' || isDeadlinePassed) return '모집 마감';
-              if (isFull) return '모집 완료';
-              if (hasPendingApplication) return '참여 대기중';
-              return '참여 신청하기';
-            })()}
+            {getJoinButtonText({
+              isFinished,
+              isDeadlinePassed,
+              isFull,
+              hasPendingApplication,
+              status: data.status,
+            })}
           </Button>
         </div>
       </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -6,6 +6,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { applicationQueries, useCreateApplication } from '@/api/applications/queries';
+import { getCurrentWeek } from '@/lib/formatGatheringDate';
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
@@ -20,6 +21,8 @@ import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
+
+import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 
 import type { GatheringType } from '@/api/gatherings/types';
 
@@ -56,18 +59,46 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const TypeLabel = data.type;
   const CategoryLabel = data.categories.join(', ');
 
+  const { displayLabel, tagState, isJoinable, isFull, isDeadlinePassed, isFinished } = getGatheringDisplayStatus({
+    status: data.status,
+    currentMembers: data.currentMembers,
+    maxMembers: data.maxMembers,
+    startDate: data.startDate,
+    endDate: data.endDate,
+    recruitDeadline: data.recruitDeadline,
+  });
+
   return (
     <div className='sticky top-[-20px]'>
       {/* 모집 상태 바 - 항상 노출 */}
-      <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
-        <div className='text-body-02-sb flex items-center text-blue-400'>모집중</div>
-        <div className='flex items-center gap-2'>
-          <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
-          <Tag variant='day' state='short'>
-            <DeadlineLabel recruitDeadline={data.recruitDeadline} />
-          </Tag>
+      {tagState === 'recruiting' && (
+        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+          <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
+          <div className='flex items-center gap-2'>
+            <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
+            <Tag variant='day' state='short'>
+              <DeadlineLabel recruitDeadline={data.recruitDeadline} />
+            </Tag>
+          </div>
         </div>
-      </div>
+      )}
+      {tagState === 'progressing' && (
+        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+          <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
+          <div className='flex items-center gap-2'>
+            <span className='text-body-02-sb text-blue-300'>{getCurrentWeek(data.startDate)}주차</span>
+            <span className='text-body-02-m text-gray-700'>진행중 (총 {data.totalWeeks}주)</span>
+          </div>
+        </div>
+      )}
+      {tagState === 'completed' && (
+        <div className='border-gray-150 bg-gray-150 mb-4 flex justify-between rounded-[8px] border px-8 py-2.5'>
+          <div className='text-body-02-sb flex items-center text-gray-600'>{displayLabel}</div>
+          <div className='flex items-center gap-2'>
+            <span className='text-body-02-m text-gray-500'>완료된 모임</span>
+          </div>
+        </div>
+      )}
 
       <Funnel>
         <Step name='APPLY'>
@@ -130,8 +161,8 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
             <Button
               variant='action'
-              className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${hasPendingApplication ? 'bg-gray-300' : ''}`}
-              disabled={hasPendingApplication}
+              className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${!isJoinable || hasPendingApplication ? 'bg-gray-300' : ''}`}
+              disabled={!isJoinable || hasPendingApplication}
               onClick={async () => {
                 if (!isLoggedIn) {
                   const isLoginSuccessful = await overlay.open(({ isOpen, close }) => (
@@ -142,7 +173,15 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                 setStep('APPLY');
               }}
             >
-              {hasPendingApplication ? '참여 대기중' : '참여 신청하기'}
+              {isFinished
+                ? '완료된 모임'
+                : data.status === 'IN_PROGRESS' || isDeadlinePassed
+                  ? '모집 마감'
+                  : isFull
+                    ? '모집 완료'
+                    : hasPendingApplication
+                      ? '참여 대기중'
+                      : '참여 신청하기'}
             </Button>
           </GatheringCard>
         </Step>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -173,15 +173,13 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                 setStep('APPLY');
               }}
             >
-              {isFinished
-                ? '완료된 모임'
-                : data.status === 'IN_PROGRESS' || isDeadlinePassed
-                  ? '모집 마감'
-                  : isFull
-                    ? '모집 완료'
-                    : hasPendingApplication
-                      ? '참여 대기중'
-                      : '참여 신청하기'}
+              {(() => {
+                if (isFinished) return '완료된 모임';
+                if (data.status === 'IN_PROGRESS' || isDeadlinePassed) return '모집 마감';
+                if (isFull) return '모집 완료';
+                if (hasPendingApplication) return '참여 대기중';
+                return '참여 신청하기';
+              })()}
             </Button>
           </GatheringCard>
         </Step>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -59,14 +59,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const TypeLabel = data.type;
   const CategoryLabel = data.categories.join(', ');
 
-  const { displayLabel, tagState, isJoinable, isFull, isDeadlinePassed, isFinished } = getGatheringDisplayStatus({
-    status: data.status,
-    currentMembers: data.currentMembers,
-    maxMembers: data.maxMembers,
-    startDate: data.startDate,
-    endDate: data.endDate,
-    recruitDeadline: data.recruitDeadline,
-  });
+  const { displayLabel, tagState, isJoinable, isFull, isDeadlinePassed, isFinished } = getGatheringDisplayStatus(data);
 
   return (
     <div className='sticky top-[-20px]'>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -22,7 +22,7 @@ import { ParticipantsList } from '../ParticipantsList';
 import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
 
-import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
+import { getGatheringDisplayStatus, getJoinButtonText } from '@/lib/gatheringStatus';
 
 import type { GatheringType } from '@/api/gatherings/types';
 
@@ -166,13 +166,13 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                 setStep('APPLY');
               }}
             >
-              {(() => {
-                if (isFinished) return '완료된 모임';
-                if (data.status === 'IN_PROGRESS' || isDeadlinePassed) return '모집 마감';
-                if (isFull) return '모집 완료';
-                if (hasPendingApplication) return '참여 대기중';
-                return '참여 신청하기';
-              })()}
+              {getJoinButtonText({
+                isFinished,
+                isDeadlinePassed,
+                isFull,
+                hasPendingApplication,
+                status: data.status,
+              })}
             </Button>
           </GatheringCard>
         </Step>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
@@ -4,6 +4,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { Tag } from '@/components/ui/Tag';
+import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
+import { getCurrentWeek } from '@/lib/formatGatheringDate';
 import { InfoAccordion } from '../InfoAccordion';
 import { ParticipantsList } from '../ParticipantsList';
 import { DeadlineLabel } from '../DeadlineLabel';
@@ -15,17 +17,46 @@ interface GatheringInfoCardProps {
 export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
 
+  const { displayLabel, tagState } = getGatheringDisplayStatus({
+    status: data.status,
+    currentMembers: data.currentMembers,
+    maxMembers: data.maxMembers,
+    startDate: data.startDate,
+    endDate: data.endDate,
+  });
+
   return (
     <section className='xl:hidden'>
-      <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
-        <div className='text-body-02-sb flex items-center text-blue-400'>모집중</div>
-        <div className='flex items-center gap-2'>
-          <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
-          <Tag variant='day' state='short'>
-            <DeadlineLabel recruitDeadline={data.recruitDeadline} />
-          </Tag>
+      {tagState === 'recruiting' && (
+        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+          <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
+          <div className='flex items-center gap-2'>
+            <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
+            <Tag variant='day' state='short'>
+              <DeadlineLabel recruitDeadline={data.recruitDeadline} />
+            </Tag>
+          </div>
         </div>
-      </div>
+      )}
+
+      {tagState === 'progressing' && (
+        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+          <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
+          <div className='flex items-center gap-2'>
+            <span className='text-body-02-sb text-blue-300'>{getCurrentWeek(data.startDate)}주차</span>
+            <span className='text-body-02-m text-gray-700'>진행중 (총 {data.totalWeeks}주)</span>
+          </div>
+        </div>
+      )}
+
+      {tagState === 'completed' && (
+        <div className='border-gray-150 bg-gray-150 mb-4 flex justify-between rounded-[8px] border px-8 py-2.5'>
+          <div className='text-body-02-sb flex items-center text-gray-600'>{displayLabel}</div>
+          <div className='flex items-center gap-2'>
+            <span className='text-body-02-m text-gray-500'>완료된 모임</span>
+          </div>
+        </div>
+      )}
 
       {/* 모임 정보 아코디언 */}
       <InfoAccordion data={data} className='mb-4' />

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
@@ -17,13 +17,7 @@ interface GatheringInfoCardProps {
 export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
   const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
 
-  const { displayLabel, tagState } = getGatheringDisplayStatus({
-    status: data.status,
-    currentMembers: data.currentMembers,
-    maxMembers: data.maxMembers,
-    startDate: data.startDate,
-    endDate: data.endDate,
-  });
+  const { displayLabel, tagState } = getGatheringDisplayStatus(data);
 
   return (
     <section className='xl:hidden'>

--- a/src/app/my/_components/MyCreatedGatheringCard/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringCard/index.tsx
@@ -28,13 +28,7 @@ export function MyCreatedGatheringCard({ gathering, className }: MyCreatedGather
 
   const pendingCount = gathering.pendingApplicationCount ?? 0;
 
-  const { displayLabel, tagState } = getGatheringDisplayStatus({
-    status: gathering.status,
-    currentMembers: gathering.currentMembers,
-    maxMembers: gathering.maxMembers,
-    startDate: gathering.startDate,
-    endDate: gathering.endDate,
-  });
+  const { displayLabel, tagState } = getGatheringDisplayStatus(gathering);
 
   return (
     <Link href={`/gatherings/${gathering.id}`}>

--- a/src/app/my/_components/MyCreatedGatheringCard/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringCard/index.tsx
@@ -7,7 +7,7 @@ import { CalendarIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
 import { formatDateDot, getTotalWeeks } from '@/lib/formatGatheringDate';
-import { GATHERING_STATUS_TAG_STATE, GATHERING_STATUS_LABEL } from '@/constants/gathering';
+import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 
 import type { MembershipGathering } from '@/api/memberships/types';
 
@@ -28,8 +28,13 @@ export function MyCreatedGatheringCard({ gathering, className }: MyCreatedGather
 
   const pendingCount = gathering.pendingApplicationCount ?? 0;
 
-  const statusState = GATHERING_STATUS_TAG_STATE[gathering.status];
-  const statusText = GATHERING_STATUS_LABEL[gathering.status];
+  const { displayLabel, tagState } = getGatheringDisplayStatus({
+    status: gathering.status,
+    currentMembers: gathering.currentMembers,
+    maxMembers: gathering.maxMembers,
+    startDate: gathering.startDate,
+    endDate: gathering.endDate,
+  });
 
   return (
     <Link href={`/gatherings/${gathering.id}`}>
@@ -45,8 +50,8 @@ export function MyCreatedGatheringCard({ gathering, className }: MyCreatedGather
               label={gathering.type}
               sublabel={gathering.categories.join(', ')}
             />
-            <Tag variant='status' state={statusState}>
-              {statusText}
+            <Tag variant='status' state={tagState}>
+              {displayLabel}
             </Tag>
           </div>
         </GatheringCard.Header>

--- a/src/app/my/_components/MyCreatedGatheringCard/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringCard/index.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import Link from 'next/link';
+
+import { GatheringCard } from '@/components/ui/GatheringCard';
+import { CalendarIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
+import { Tag } from '@/components/ui/Tag';
+import { cn } from '@/lib/cn';
+import { formatDateDot, getTotalWeeks } from '@/lib/formatGatheringDate';
+import { GATHERING_STATUS_TAG_STATE, GATHERING_STATUS_LABEL } from '@/constants/gathering';
+
+import type { MembershipGathering } from '@/api/memberships/types';
+
+interface MyCreatedGatheringCardProps {
+  gathering: MembershipGathering;
+  className?: string;
+}
+
+const TYPE_ICON = {
+  스터디: StudyIcon,
+  프로젝트: ProjectIcon,
+} as const;
+
+export function MyCreatedGatheringCard({ gathering, className }: MyCreatedGatheringCardProps) {
+  const startDotDate = formatDateDot(gathering.startDate);
+  const endDotDate = formatDateDot(gathering.endDate);
+  const weeks = getTotalWeeks(gathering.startDate, gathering.endDate);
+
+  const pendingCount = gathering.pendingApplicationCount ?? 0;
+
+  const statusState = GATHERING_STATUS_TAG_STATE[gathering.status];
+  const statusText = GATHERING_STATUS_LABEL[gathering.status];
+
+  return (
+    <Link href={`/gatherings/${gathering.id}`}>
+      <GatheringCard className={cn('w-full transition-transform hover:-translate-y-1', className)}>
+        <GatheringCard.Header className='mb-6 items-center'>
+          <div className='flex gap-1'>
+            <Tag
+              variant='category'
+              icon={(() => {
+                const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] || StudyIcon;
+                return <Icon size={14} className='text-blue-200' />;
+              })()}
+              label={gathering.type}
+              sublabel={gathering.categories.join(', ')}
+            />
+            <Tag variant='status' state={statusState}>
+              {statusText}
+            </Tag>
+          </div>
+        </GatheringCard.Header>
+
+        <GatheringCard.Body className='mb-0 gap-2'>
+          <div className='flex flex-col'>
+            <div className='flex flex-wrap gap-1'>
+              {gathering.tags.slice(0, 2).map((tag) => (
+                <span key={tag} className='text-small-02-r md:text-small-01-r text-gray-500'>
+                  #{tag}
+                </span>
+              ))}
+            </div>
+            <div className='text-body-02-b md:text-body-01-b truncate text-gray-900'>{gathering.title}</div>
+          </div>
+
+          <div className='text-small-02-r md:text-small-01-r flex flex-wrap items-center gap-x-2 gap-y-1 text-gray-600'>
+            <div className='flex shrink-0 items-center gap-2'>
+              <CalendarIcon size={16} />
+              <span className='whitespace-nowrap'>
+                {startDotDate} ~ {endDotDate}
+                <span className='mx-1'>・</span>
+                <span className='whitespace-nowrap'>{weeks}주</span>
+              </span>
+            </div>
+            <span className='text-small-02-r md:text-small-01-r text-gray-400'>|</span>
+            <div className='flex shrink-0 items-center gap-2'>
+              <ProjectIcon size={16} className='text-gray-600' />
+              <div className='flex items-center'>
+                <span className='text-small-02-r md:text-small-01-r text-gray-600'>{gathering.currentMembers}</span>
+                <span className='text-small-02-r md:text-small-01-r text-gray-400'>/{gathering.maxMembers}</span>
+              </div>
+            </div>
+          </div>
+        </GatheringCard.Body>
+
+        <GatheringCard.Footer className='mt-4'>
+          <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[64px]'>
+            <div className='flex flex-1 items-center justify-center gap-1.5'>
+              <span className='text-small-01-m md:text-body-01-m text-gray-600'>모집 인원</span>
+              <span className='flex items-center'>
+                <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>{gathering.currentMembers}</span>
+                <span className='text-small-01-sb md:text-body-01-sb text-gray-700'>/{gathering.maxMembers}</span>
+              </span>
+            </div>
+            <div className='bg-gray-150 h-6 w-px' />
+            <div className='flex flex-1 items-center justify-center gap-1.5 text-blue-300'>
+              <span className='text-small-01-m md:text-body-01-m text-gray-600'>신청대기</span>
+              <span className='text-small-01-sb md:text-body-01-sb'>{pendingCount}</span>
+            </div>
+          </div>
+        </GatheringCard.Footer>
+      </GatheringCard>
+    </Link>
+  );
+}

--- a/src/app/my/_components/MyCreatedGatheringList/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringList/index.tsx
@@ -55,6 +55,9 @@ export function MyCreatedGatheringList() {
   // "내 모임"과 달리 "만든 모임"은 모든 상태를 보여주므로 특별한 클라이언트 필터링 없이 서버 응답을 신뢰
   // 단, getMyGatherings API가 참여/생성 구분 없이 가져오므로 프론트엔드에서 LEADER 필터링이 필요함
   // (임시 조치이므로 limit=999로 가져와 처리)
+  // TODO: 서비스 오픈 후 성능 모니터링 필요
+  // - 백엔드 API에 role 파라미터 지원 요청 (GET /users/me/gatherings?role=LEADER)
+  // - 또는 별도 엔드포인트 추가 고려 (GET /users/me/created-gatherings)
   const { data } = useSuspenseQuery({
     ...membershipQueries.my({ status, page: 1, limit: 999 }),
   });

--- a/src/app/my/_components/MyCreatedGatheringList/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringList/index.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { membershipQueries } from '@/api/memberships/queries';
+import { Dropdown } from '@/components/ui/Dropdown';
+import { useDropdown } from '@/components/ui/Dropdown/context';
+import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
+import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
+import { Pagination } from '@/components/ui/Pagination';
+import { cn } from '@/lib/cn';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+import { MyCreatedGatheringCard } from '../MyCreatedGatheringCard';
+
+import type { GatheringStatusFilter } from '@/api/memberships/types';
+
+type SortOrder = 'latest' | 'oldest';
+
+const SORT_OPTIONS: { label: string; value: SortOrder }[] = [
+  { label: '최신순', value: 'latest' },
+  { label: '과거순', value: 'oldest' },
+];
+
+const STATUS_OPTIONS: { label: string; value: GatheringStatusFilter }[] = [
+  { label: '전체', value: 'all' },
+  { label: '모집중', value: 'recruiting' },
+  { label: '진행중', value: 'in_progress' },
+  { label: '진행완료', value: 'completed' },
+];
+
+function RotatingArrow() {
+  const { isOpen } = useDropdown();
+  return (
+    <ArrowIcon
+      size={16}
+      className={cn(
+        'shrink-0 rotate-90 text-gray-800 transition-transform duration-200 md:size-5',
+        isOpen && 'rotate-270',
+      )}
+    />
+  );
+}
+
+export function MyCreatedGatheringList() {
+  const isXl = useMediaQuery('(min-width: 1280px)');
+  const limit = isXl ? 6 : 4;
+
+  const [status, setStatus] = useState<GatheringStatusFilter>('all');
+  const [sort, setSort] = useState<SortOrder>('latest');
+  const [page, setPage] = useState(1);
+  const [isPending, startTransition] = useTransition();
+
+  // "내 모임"과 달리 "만든 모임"은 모든 상태를 보여주므로 특별한 클라이언트 필터링 없이 서버 응답을 신뢰
+  // 단, getMyGatherings API가 참여/생성 구분 없이 가져오므로 프론트엔드에서 LEADER 필터링이 필요함
+  // (임시 조치이므로 limit=999로 가져와 처리)
+  const { data } = useSuspenseQuery({
+    ...membershipQueries.my({ status, page: 1, limit: 999 }),
+  });
+
+  // LEADER인 것만 필터링
+  const myCreated = data.gatherings.filter((g) => g.myRole === 'LEADER');
+
+  // 정렬
+  const sorted = [...myCreated].sort((a, b) => {
+    const diff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
+    return sort === 'latest' ? -diff : diff;
+  });
+
+  // 페이지네이션
+  const totalPages = Math.max(1, Math.ceil(sorted.length / limit));
+  const paged = sorted.slice((page - 1) * limit, page * limit);
+
+  const handleFilterChange = (next: Partial<{ status: GatheringStatusFilter; sort: SortOrder }>) => {
+    if (next.sort !== undefined) {
+      setSort(next.sort);
+      return;
+    }
+    startTransition(() => {
+      if (next.status !== undefined) setStatus(next.status);
+      setPage(1);
+    });
+  };
+
+  const selectedStatusLabel = STATUS_OPTIONS.find((o) => o.value === status)?.label ?? '전체';
+
+  return (
+    <div className='mt-6 flex flex-col gap-6'>
+      <div className='flex items-center gap-2'>
+        <span className='text-body-01-b md:text-h3-b text-gray-900'>{selectedStatusLabel}</span>
+        <span className='text-small-02-r md:text-body-01-r text-gray-500'>총 {sorted.length}건</span>
+      </div>
+
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center gap-2 md:gap-4'>
+          {SORT_OPTIONS.map((option, index) => {
+            const isSelected = sort === option.value;
+            return (
+              <div key={option.value} className='flex items-center gap-2 md:gap-4'>
+                {index > 0 && <span className='text-small-02-r md:text-body-02-r text-gray-500'>|</span>}
+                <button
+                  type='button'
+                  onClick={() => handleFilterChange({ sort: option.value })}
+                  className={cn(
+                    'text-small-02-r md:text-body-02-r flex cursor-pointer items-center gap-0.5',
+                    isSelected ? 'font-semibold text-gray-800' : 'text-gray-500',
+                  )}
+                >
+                  <CheckIcon size={16} className={cn('md:size-6', !isSelected && 'hidden')} />
+                  {option.label}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <Dropdown className='**:[[role=listbox]]:right-0'>
+          <Dropdown.Trigger>
+            <div className='flex cursor-pointer items-center gap-2'>
+              <span className='text-small-02-m md:text-body-02-m text-gray-800'>{selectedStatusLabel}</span>
+              <RotatingArrow />
+            </div>
+          </Dropdown.Trigger>
+          <Dropdown.Menu className='flex min-w-[100px] flex-col gap-2 overflow-hidden p-2 whitespace-nowrap'>
+            {STATUS_OPTIONS.map((option) => {
+              const isSelected = status === option.value;
+              return (
+                <Dropdown.Item
+                  key={option.value}
+                  onClick={() => handleFilterChange({ status: option.value })}
+                  className={cn(
+                    'text-small-02-m md:text-body-02-m cursor-pointer rounded-lg px-4 py-2 hover:bg-blue-100 hover:text-blue-400',
+                    isSelected && 'bg-blue-100 text-blue-400',
+                  )}
+                >
+                  {option.label}
+                </Dropdown.Item>
+              );
+            })}
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+
+      {paged.length === 0 ? (
+        <div className='flex h-40 items-center justify-center'>
+          <p className='text-body-02-r text-gray-400'>만든 모임이 없습니다.</p>
+        </div>
+      ) : (
+        <div className={cn('grid grid-cols-1 gap-4 xl:grid-cols-2', isPending && 'opacity-50')}>
+          {paged.map((gathering) => (
+            <MyCreatedGatheringCard key={gathering.id} gathering={gathering} />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <Pagination
+          variant='numbered'
+          currentPage={page}
+          totalPages={totalPages}
+          onPageChange={(p) => startTransition(() => setPage(p))}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -33,13 +33,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
   const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] ?? ProjectIcon;
   const hasReviewed = !!gathering.hasReviewed;
 
-  const { displayLabel, tagState, isFinished } = getGatheringDisplayStatus({
-    status: gathering.status,
-    currentMembers: gathering.currentMembers,
-    maxMembers: gathering.maxMembers,
-    startDate: gathering.startDate,
-    endDate: gathering.endDate,
-  });
+  const { displayLabel, tagState, isFinished } = getGatheringDisplayStatus(gathering);
 
   return (
     <Link href={`/gatherings/${gathering.id}/dashboard`}>

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -9,6 +9,7 @@ import { Tag } from '@/components/ui/Tag';
 import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 
 import type { MembershipGathering } from '@/api/memberships/types';
+import Link from 'next/link';
 
 interface MyGatheringsCardProps {
   gathering: MembershipGathering;
@@ -41,79 +42,81 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
   });
 
   return (
-    <GatheringCard>
-      <GatheringCard.Header className='items-start'>
-        <div className='flex gap-1'>
-          <Tag
-            variant='category'
-            icon={<Icon size={14} className='text-blue-200' />}
-            label={gathering.type}
-            sublabel={gathering.categories.join(', ')}
-          />
-          <Tag variant='status' state={tagState}>
-            {displayLabel}
-          </Tag>
-        </div>
-      </GatheringCard.Header>
-      <GatheringCard.Body>
-        <div>
+    <Link href={`/gatherings/${gathering.id}/dashboard`}>
+      <GatheringCard>
+        <GatheringCard.Header className='items-start'>
           <div className='flex gap-1'>
-            {gathering.tags.slice(0, 2).map((tag) => (
-              <span key={tag} className='text-small-02-r md:text-small-01-r text-gray-500'>
-                #{tag}
-              </span>
-            ))}
+            <Tag
+              variant='category'
+              icon={<Icon size={14} className='text-blue-200' />}
+              label={gathering.type}
+              sublabel={gathering.categories.join(', ')}
+            />
+            <Tag variant='status' state={tagState}>
+              {displayLabel}
+            </Tag>
           </div>
-          <div className='text-body-02-b md:text-body-01-b text-gray-900'>{gathering.title}</div>
-          <div className='mt-2 flex items-center gap-2'>
-            <CalendarIcon size={16} className='text-gray-600' />
-            <div className='flex items-center gap-1'>
-              <span className='text-small-02-r md:text-small-01-r text-gray-600'>
-                {formatDateDot(gathering.startDate)} ~ {formatDateDot(gathering.endDate)}
-              </span>
-              <span className='text-small-02-r md:text-small-01-r text-gray-600'>・</span>
-              <span className='text-small-02-r md:text-small-01-r text-gray-600'>{totalWeeks}주</span>
+        </GatheringCard.Header>
+        <GatheringCard.Body>
+          <div>
+            <div className='flex gap-1'>
+              {gathering.tags.slice(0, 2).map((tag) => (
+                <span key={tag} className='text-small-02-r md:text-small-01-r text-gray-500'>
+                  #{tag}
+                </span>
+              ))}
             </div>
-            <span className='text-small-02-r md:text-small-01-r text-gray-400'>|</span>
-            <ProjectIcon size={16} className='text-gray-600' />
-            <div className='flex items-center'>
-              <span className='text-small-02-r md:text-small-01-r text-gray-600'>{gathering.currentMembers}</span>
-              <span className='text-small-02-r md:text-small-01-r text-gray-400'>/{gathering.maxMembers}</span>
+            <div className='text-body-02-b md:text-body-01-b text-gray-900'>{gathering.title}</div>
+            <div className='mt-2 flex items-center gap-2'>
+              <CalendarIcon size={16} className='text-gray-600' />
+              <div className='flex items-center gap-1'>
+                <span className='text-small-02-r md:text-small-01-r text-gray-600'>
+                  {formatDateDot(gathering.startDate)} ~ {formatDateDot(gathering.endDate)}
+                </span>
+                <span className='text-small-02-r md:text-small-01-r text-gray-600'>・</span>
+                <span className='text-small-02-r md:text-small-01-r text-gray-600'>{totalWeeks}주</span>
+              </div>
+              <span className='text-small-02-r md:text-small-01-r text-gray-400'>|</span>
+              <ProjectIcon size={16} className='text-gray-600' />
+              <div className='flex items-center'>
+                <span className='text-small-02-r md:text-small-01-r text-gray-600'>{gathering.currentMembers}</span>
+                <span className='text-small-02-r md:text-small-01-r text-gray-400'>/{gathering.maxMembers}</span>
+              </div>
             </div>
+            <ProgressBar label='달성률' layout='horizontal' value={progressRate} className='mb-4' />
           </div>
-          <ProgressBar label='달성률' layout='horizontal' value={progressRate} className='mb-4' />
-        </div>
-      </GatheringCard.Body>
-      <GatheringCard.Footer>
-        {gathering.status === 'IN_PROGRESS' && (
-          <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
-            <div className='flex flex-1 items-center justify-center gap-1.5'>
-              <span className='text-small-01-m md:text-body-01-m text-gray-600'>총</span>
-              <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>{totalWeeks}주</span>
+        </GatheringCard.Body>
+        <GatheringCard.Footer>
+          {gathering.status === 'IN_PROGRESS' && (
+            <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
+              <div className='flex flex-1 items-center justify-center gap-1.5'>
+                <span className='text-small-01-m md:text-body-01-m text-gray-600'>총</span>
+                <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>{totalWeeks}주</span>
+              </div>
+              <div className='bg-gray-150 h-6 w-px' />
+              <div className='flex flex-1 items-center justify-center gap-1.5'>
+                <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>
+                  {getCurrentWeek(gathering.startDate)}주차
+                </span>
+                <span className='text-small-01-m md:text-body-01-m text-gray-600'>진행중</span>
+              </div>
             </div>
-            <div className='bg-gray-150 h-6 w-px' />
-            <div className='flex flex-1 items-center justify-center gap-1.5'>
-              <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>
-                {getCurrentWeek(gathering.startDate)}주차
-              </span>
-              <span className='text-small-01-m md:text-body-01-m text-gray-600'>진행중</span>
+          )}
+          {gathering.status === 'COMPLETED' && !hasReviewed && (
+            <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
+              <div className='flex items-center gap-2'>
+                <ReviewIcon size={16} className='text-blue-300 md:size-6' />
+                <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>리뷰 쓰기</span>
+              </div>
             </div>
-          </div>
-        )}
-        {gathering.status === 'COMPLETED' && !hasReviewed && (
-          <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
-            <div className='flex items-center gap-2'>
-              <ReviewIcon size={16} className='text-blue-300 md:size-6' />
-              <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>리뷰 쓰기</span>
+          )}
+          {gathering.status === 'COMPLETED' && hasReviewed && (
+            <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
+              <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성완료</span>
             </div>
-          </div>
-        )}
-        {gathering.status === 'COMPLETED' && hasReviewed && (
-          <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
-            <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성완료</span>
-          </div>
-        )}
-      </GatheringCard.Footer>
-    </GatheringCard>
+          )}
+        </GatheringCard.Footer>
+      </GatheringCard>
+    </Link>
   );
 }

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -6,7 +6,9 @@ import { GatheringCard } from '@/components/ui/GatheringCard';
 import { CalendarIcon, ProjectIcon, ReviewIcon, StudyIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { Tag } from '@/components/ui/Tag';
-import type { GatheringStatus, MembershipGathering } from '@/api/memberships/types';
+import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
+
+import type { MembershipGathering } from '@/api/memberships/types';
 
 interface MyGatheringsCardProps {
   gathering: MembershipGathering;
@@ -16,18 +18,6 @@ const TYPE_ICON = {
   스터디: StudyIcon,
   프로젝트: ProjectIcon,
 } as const;
-
-const STATUS_TAG_STATE: Record<GatheringStatus, 'recruiting' | 'progressing' | 'completed'> = {
-  RECRUITING: 'recruiting',
-  IN_PROGRESS: 'progressing',
-  COMPLETED: 'completed',
-};
-
-const STATUS_LABEL: Record<GatheringStatus, string> = {
-  RECRUITING: '모집중',
-  IN_PROGRESS: '진행중',
-  COMPLETED: '진행완료',
-};
 
 export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
   const now = startOfDay(new Date());
@@ -42,6 +32,14 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
   const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] ?? ProjectIcon;
   const hasReviewed = !!gathering.hasReviewed;
 
+  const { displayLabel, tagState, isFinished } = getGatheringDisplayStatus({
+    status: gathering.status,
+    currentMembers: gathering.currentMembers,
+    maxMembers: gathering.maxMembers,
+    startDate: gathering.startDate,
+    endDate: gathering.endDate,
+  });
+
   return (
     <GatheringCard>
       <GatheringCard.Header className='items-start'>
@@ -52,8 +50,8 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
             label={gathering.type}
             sublabel={gathering.categories.join(', ')}
           />
-          <Tag variant='status' state={STATUS_TAG_STATE[gathering.status]}>
-            {STATUS_LABEL[gathering.status]}
+          <Tag variant='status' state={tagState}>
+            {displayLabel}
           </Tag>
         </div>
       </GatheringCard.Header>

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -143,7 +143,7 @@ export function MyGatheringsList() {
           <p className='text-body-02-r text-gray-400'>참여한 모임이 없습니다.</p>
         </div>
       ) : (
-        <div className={cn('grid grid-cols-1 gap-4 lg:grid-cols-2', isPending && 'opacity-50')}>
+        <div className={cn('grid grid-cols-1 gap-4 xl:grid-cols-2', isPending && 'opacity-50')}>
           {paged.map((gathering) => (
             <MyGatheringsCard key={gathering.id} gathering={gathering} />
           ))}

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -3,6 +3,7 @@ import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { MyGatheringsList } from '../MyGatheringsList';
 
 import type { MyPageTab } from '../../_constants';
+import { MyCreatedGatheringList } from '../MyCreatedGatheringList';
 
 interface MyPageContentProps {
   activeTab: MyPageTab;
@@ -20,7 +21,17 @@ export function MyPageContent({ activeTab }: MyPageContentProps) {
         <MyGatheringsList />
       </SuspenseBoundary>
     );
-  if (activeTab === 'created-gatherings') return <p>만든 모임</p>;
+  if (activeTab === 'created-gatherings')
+    return (
+      <SuspenseBoundary
+        pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
+        errorFallback={
+          <p className='flex h-40 items-center justify-center text-gray-500'>모임을 불러올 수 없습니다.</p>
+        }
+      >
+        <MyCreatedGatheringList />
+      </SuspenseBoundary>
+    );
   if (activeTab === 'pending-gatherings') return <p>대기중인 모임</p>;
   if (activeTab === 'received-reviews') return <p>받은 리뷰</p>;
   if (activeTab === 'liked-gatherings') return <p>찜한 모임</p>;

--- a/src/constants/gathering.ts
+++ b/src/constants/gathering.ts
@@ -1,6 +1,19 @@
 export const GATHERING_TYPES = ['스터디', '프로젝트'] as const;
 
-/** 카테고리 기본값 (서버에서 GET /gatherings/categories로 동적 조회 가능) */
+/** 모임 상태 → Tag variant state 매핑 */
+export const GATHERING_STATUS_TAG_STATE = {
+  RECRUITING: 'recruiting',
+  IN_PROGRESS: 'progressing',
+  COMPLETED: 'completed',
+} as const;
+
+/** 모임 상태 → 한글 라벨 매핑 */
+export const GATHERING_STATUS_LABEL = {
+  RECRUITING: '모집중',
+  IN_PROGRESS: '진행중',
+  COMPLETED: '진행완료',
+} as const;
+
 export const DEFAULT_CATEGORIES = [
   { id: 1, name: '개발' },
   { id: 2, name: '어학' },

--- a/src/lib/formatGatheringDate.ts
+++ b/src/lib/formatGatheringDate.ts
@@ -28,3 +28,11 @@ export const formatDday = (targetDateString: string): string => {
   if (diff === 0) return 'D-Day';
   return `D+${Math.abs(diff)}`;
 };
+
+/** 시작일과 종료일 사이의 총 주차 반환 */
+export const getTotalWeeks = (startDate: string, endDate: string): number => {
+  const start = startOfDay(new Date(startDate));
+  const end = startOfDay(new Date(endDate));
+  const diffDays = Math.max(0, differenceInDays(end, start));
+  return Math.max(1, Math.ceil(diffDays / 7));
+};

--- a/src/lib/gatheringStatus.ts
+++ b/src/lib/gatheringStatus.ts
@@ -1,0 +1,63 @@
+import { isPast, parseISO } from 'date-fns';
+import { GATHERING_STATUS_LABEL } from '@/constants/gathering';
+import type { GatheringStatus } from '@/api/gatherings/types';
+
+interface GetGatheringDisplayStatusParams {
+  status: GatheringStatus;
+  currentMembers: number;
+  maxMembers: number;
+  startDate: string;
+  endDate: string;
+  recruitDeadline?: string | null;
+}
+
+/**
+ * 모임의 실시간 상태와 시각적 태그 정보를 판별하는 공통 유틸리티
+ */
+export const getGatheringDisplayStatus = ({
+  status,
+  currentMembers,
+  maxMembers,
+  startDate,
+  endDate,
+  recruitDeadline,
+}: GetGatheringDisplayStatusParams) => {
+  const isFull = currentMembers >= maxMembers;
+  // recruitDeadline이 없으면 startDate를 모집 마감일로 간주
+  const deadlineDate = recruitDeadline ? parseISO(recruitDeadline) : parseISO(startDate);
+  // date-fns의 isPast는 현재 시점(오늘)보다 이전인지 체크
+  const isDeadlinePassed = isPast(deadlineDate);
+  const isFinished = status === 'COMPLETED' || isPast(parseISO(endDate));
+
+  // 1. 시각적 태그 상태 (recruiting | progressing | completed)
+  let tagState: 'recruiting' | 'progressing' | 'completed' = 'recruiting';
+
+  // 2. 표시용 텍스트
+  let displayLabel: string = GATHERING_STATUS_LABEL[status];
+
+  // 상세 분기 로직
+  if (isFinished) {
+    displayLabel = '진행완료';
+    tagState = 'completed';
+  } else if (status === 'IN_PROGRESS' || isDeadlinePassed || isFull) {
+    // 이미 시작했거나, 모집 기한이 지났거나, 정원이 찬 경우 모두 '진행중'으로 통일
+    displayLabel = '진행중';
+    tagState = 'progressing';
+  } else {
+    // 순수하게 모집 중인 경우
+    displayLabel = '모집중';
+    tagState = 'recruiting';
+  }
+
+  // 참가 가능 여부 (참여 신청 버튼 활성화용)
+  const isJoinable = status === 'RECRUITING' && !isFull && !isDeadlinePassed;
+
+  return {
+    displayLabel,
+    tagState,
+    isJoinable,
+    isFull,
+    isDeadlinePassed,
+    isFinished,
+  };
+};

--- a/src/lib/gatheringStatus.ts
+++ b/src/lib/gatheringStatus.ts
@@ -1,5 +1,7 @@
-import { isPast, parseISO } from 'date-fns';
+import { endOfDay, isPast, parseISO } from 'date-fns';
+
 import { GATHERING_STATUS_LABEL } from '@/constants/gathering';
+
 import type { GatheringStatus } from '@/api/gatherings/types';
 
 interface GetGatheringDisplayStatusParams {
@@ -14,20 +16,20 @@ interface GetGatheringDisplayStatusParams {
 /**
  * 모임의 실시간 상태와 시각적 태그 정보를 판별하는 공통 유틸리티
  */
-export const getGatheringDisplayStatus = ({
-  status,
-  currentMembers,
-  maxMembers,
-  startDate,
-  endDate,
-  recruitDeadline,
-}: GetGatheringDisplayStatusParams) => {
+export const getGatheringDisplayStatus = (params: GetGatheringDisplayStatusParams) => {
+  const { status, currentMembers, maxMembers, startDate, endDate, recruitDeadline } = params;
+
   const isFull = currentMembers >= maxMembers;
+
   // recruitDeadline이 없으면 startDate를 모집 마감일로 간주
-  const deadlineDate = recruitDeadline ? parseISO(recruitDeadline) : parseISO(startDate);
+  // 날짜만 있는 경우(00:00:00) 해당 일자가 끝날 때까지 유효하도록 endOfDay 처리
+  const deadlineDate = recruitDeadline ? endOfDay(parseISO(recruitDeadline)) : endOfDay(parseISO(startDate));
+
   // date-fns의 isPast는 현재 시점(오늘)보다 이전인지 체크
   const isDeadlinePassed = isPast(deadlineDate);
-  const isFinished = status === 'COMPLETED' || isPast(parseISO(endDate));
+
+  // 모임 종료일도 당일 끝까지 포함되도록 endOfDay 처리
+  const isFinished = status === 'COMPLETED' || isPast(endOfDay(parseISO(endDate)));
 
   // 1. 시각적 태그 상태 (recruiting | progressing | completed)
   let tagState: 'recruiting' | 'progressing' | 'completed' = 'recruiting';

--- a/src/lib/gatheringStatus.ts
+++ b/src/lib/gatheringStatus.ts
@@ -4,7 +4,7 @@ import { GATHERING_STATUS_LABEL } from '@/constants/gathering';
 
 import type { GatheringStatus } from '@/api/gatherings/types';
 
-interface GetGatheringDisplayStatusParams {
+export interface GatheringDisplayStatusInput {
   status: GatheringStatus;
   currentMembers: number;
   maxMembers: number;
@@ -16,9 +16,14 @@ interface GetGatheringDisplayStatusParams {
 /**
  * 모임의 실시간 상태와 시각적 태그 정보를 판별하는 공통 유틸리티
  */
-export const getGatheringDisplayStatus = (params: GetGatheringDisplayStatusParams) => {
-  const { status, currentMembers, maxMembers, startDate, endDate, recruitDeadline } = params;
-
+export const getGatheringDisplayStatus = ({
+  status,
+  currentMembers,
+  maxMembers,
+  startDate,
+  endDate,
+  recruitDeadline,
+}: GatheringDisplayStatusInput) => {
   const isFull = currentMembers >= maxMembers;
 
   // recruitDeadline이 없으면 startDate를 모집 마감일로 간주
@@ -62,4 +67,20 @@ export const getGatheringDisplayStatus = (params: GetGatheringDisplayStatusParam
     isDeadlinePassed,
     isFinished,
   };
+};
+
+export const getJoinButtonText = (params: {
+  isFinished: boolean;
+  isDeadlinePassed: boolean;
+  isFull: boolean;
+  hasPendingApplication: boolean;
+  status: GatheringStatus;
+}) => {
+  const { isFinished, isDeadlinePassed, isFull, hasPendingApplication, status } = params;
+
+  if (isFinished) return '완료된 모임';
+  if (status === 'IN_PROGRESS' || isDeadlinePassed) return '모집 마감';
+  if (isFull) return '모집 완료';
+  if (hasPendingApplication) return '참여 대기중';
+  return '참여 신청하기';
 };

--- a/src/mocks/handlers/memberships.ts
+++ b/src/mocks/handlers/memberships.ts
@@ -34,6 +34,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'IN_PROGRESS',
     myRole: 'LEADER',
+    hasReviewed: false,
+    pendingApplicationCount: 2,
   },
   {
     id: 2,
@@ -48,6 +50,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-05-30',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    hasReviewed: false,
+    pendingApplicationCount: 2,
   },
   {
     id: 3,
@@ -62,6 +66,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-02-28',
     status: 'COMPLETED',
     myRole: 'MEMBER',
+    hasReviewed: false,
+    pendingApplicationCount: 9,
   },
   {
     id: 4,
@@ -76,6 +82,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    hasReviewed: false,
+    pendingApplicationCount: 1,
   },
   {
     id: 5,
@@ -90,6 +98,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    hasReviewed: false,
+    pendingApplicationCount: 5,
   },
   {
     id: 6,
@@ -104,6 +114,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    hasReviewed: false,
+    pendingApplicationCount: 7,
   },
   {
     id: 7,
@@ -118,6 +130,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    hasReviewed: false,
+    pendingApplicationCount: 1,
   },
   {
     id: 8,
@@ -132,6 +146,8 @@ const mockGatherings: MembershipGathering[] = [
     endDate: '2025-04-19',
     status: 'RECRUITING',
     myRole: 'MEMBER',
+    hasReviewed: true,
+    pendingApplicationCount: 4,
   },
 ];
 


### PR DESCRIPTION
## ❓ 이슈

- close #191

## ✍️ Description

상세 페이지와 마이페이지에서 서로 다르게 처리되던 모임 상태 판별 로직을 공통 유틸리티로 통합하고, 서버 데이터 업데이트 전이라도 프론트엔드에서 실시간 상태(인원 초과, 모집 기간 만료 등)를 정확하게 반영할 수 있도록 개선했습니다. 또한, 마이페이지의 '만든 모임' 탭 기능 구현과 내 모임 카드 링크 연동 작업을 완료했습니다.

## 📸 스크린샷 (UI 변경 시)

마이페이지 만든 모임에서 진행중인 모임과 완료된 모임 모두 상세페이지에서 신청하기 버튼인 경우가 있어 이를 수정한 모습입니다.

https://github.com/user-attachments/assets/bc1a8727-5d3a-4f0e-858d-5bce626e1e3a


## ✅ Checklist
- [x] 마이페이지 '만든 모임' 기능 구현
  - [x] MyCreatedGatheringList 및 MyCreatedGatheringCard 컴포넌트를 신규 구현했습니다.
  - [x] 만든 모임 목록에서 상태별 필터링 및 정렬 기능을 제공합니다.

- [x] 상태 판별 로직 공통화 및 '진행중' 라벨 통합
  - [x] src/lib/gatheringStatus.ts 신규 유틸리티 구현: status, currentMembers, maxMembers, startDate, endDate 등을 조합하여 실시간 상태(displayLabel, tagState, isJoinable)를 판별합니다.
  - [x] 사용자의 피드백을 반영하여, 모집 완료, 모집 기한 만료, 실제 진행 중인 상태를 모두 시각적/라벨상으로 '진행중'으로 통일하여 직관성을 높였습니다.

- [x] 컴포넌트 리팩토링 및 방어 로직 강화
  - [x] GatheringInfoAside: 공통 유틸리티를 적용하여 상단 상태 바 및 신청 버튼의 활성화 로직을 단순화하고 정확도를 높였습니다.
  - [x] MyGatheringsCard: 공통 유틸리티를 적용하고, 카드 클릭 시 해당 모임의 **대시보드(.../dashboard)**로 이동하도록 링크를 연동했습니다.
  - [x] 타입 및 목 데이터 정규화: MembershipGathering 타입에 hasReviewed, pendingApplicationCount를 추가하고 MSW 목 데이터를 이에 맞춰 업데이트했습니다.

- [x] UI/UX 최적화
  - [x] 마이페이지 카드 리스트의 그리드 레이아웃 피봇 포인트를 조정(lg -> xl)하여 대화면에서의 시인성을 개선했습니다.
  - [x] GatheringInfoAside 상단 바에서 불필요한 조건부 메시지를 제거하고 주차 정보를 일관되게 보여주도록 수정했습니다.

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] 추후 메인페이지에서도 마감된 모임에 참여하기 버튼 대신 모집마감/완료됨 등 수정 해야함
