### PR TITLE
[SM-138] feat: 모임 상세 페이지 - 모임장 신청 대기자 관리 기능 구현

### DIFF
--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -76,7 +76,9 @@ export const useUpdateApplicationStatus = (
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all });
       queryClient.invalidateQueries({ queryKey: gatheringKeys.detail(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.applicationStatus(gatheringId) });
 
+      invalidateServerCache(GATHERING_TAGS.all);
       invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
 
       options?.onSuccess?.(data, variables, onMutateResult, context);

--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -11,6 +11,7 @@ import {
 import { invalidateServerCache } from '@/lib/invalidateServerCache';
 
 import { GATHERING_TAGS } from '../gatherings';
+import { gatheringKeys } from '../gatherings/queries';
 
 import {
   ApplyGatheringForm,
@@ -74,6 +75,10 @@ export const useUpdateApplicationStatus = (
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all });
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.detail(gatheringId) });
+
+      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
+
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { cn } from '@/lib/cn';
 import { formatDateDot, formatDday } from '@/lib/formatGatheringDate';
 import { useAuth } from '@/hooks/useAuth';
@@ -11,6 +12,8 @@ import { GatheringDescription } from '../GatheringDescription';
 import { ImageCarousel } from '../ImageCarousel';
 import { InfoCard } from '../InfoCard';
 import { MembersStatus } from '../MembersStatus';
+import { PendingApplications } from '../PendingApplications';
+import { PendingApplicationsSkeleton } from '../PendingApplications/Skeleton';
 import { WeeklyPlanAccordion } from '../WeeklyPlanAccordion';
 
 interface GatheringDetailContentProps {
@@ -29,12 +32,16 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
     <div className='flex flex-col'>
       {isLeader && (
         <section id='pending-applications' className='scroll-mt-10 xl:scroll-mt-12'>
-          <div className='flex flex-col gap-4'>
-            <h2 className='text-body-01-sb xl:text-h5-sb text-gray-900'>신청 대기자 👑</h2>
-            <div className='border-gray-150 rounded-lg border bg-gray-50 px-4 py-6'>
-              <p className='text-body-02-r text-gray-500'>신청 대기자 관리 기능은 준비 중입니다</p>
-            </div>
-          </div>
+          <SuspenseBoundary
+            pendingFallback={<PendingApplicationsSkeleton />}
+            errorFallback={
+              <div className='rounded-lg border border-gray-200 bg-gray-50 px-4 py-6'>
+                <p className='text-body-02-r text-gray-500'>신청 대기자 목록을 불러올 수 없습니다</p>
+              </div>
+            }
+          >
+            <PendingApplications gatheringId={gatheringId} />
+          </SuspenseBoundary>
         </section>
       )}
 

--- a/src/app/gatherings/[id]/_components/PendingApplications/ApplicationCard.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/ApplicationCard.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useUpdateApplicationStatus } from '@/api/applications/queries';
+import { Button } from '@/components/ui/Button';
+import { CheckIcon, CloseIcon, ArrowIcon } from '@/components/ui/Icon';
+import { Profile } from '@/components/ui/Profile';
+import { Tag } from '@/components/ui/Tag';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { cn } from '@/lib/cn';
+import { getReputationLabel } from '@/lib/getReputationLabel';
+import { useOverlay } from '@/hooks/useOverlay';
+
+import { RejectConfirmModal } from './RejectConfirmModal';
+
+import type { ApplicationDetail } from '@/api/applications/types';
+
+interface ApplicationCardProps {
+  gatheringId: number;
+  application: ApplicationDetail;
+}
+
+export function ApplicationCard({ gatheringId, application }: ApplicationCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { showToast } = useToastStore();
+  const overlay = useOverlay();
+
+  const { mutate, isPending } = useUpdateApplicationStatus(gatheringId, application.id);
+
+  const handleApprove = () => {
+    mutate(
+      { status: 'ACCEPTED' },
+      {
+        onSuccess: () => {
+          showToast({ variant: 'success', title: '승인되었습니다' });
+        },
+      },
+    );
+  };
+
+  const handleReject = async () => {
+    const confirmed = await overlay.open(({ isOpen, close }) => (
+      <RejectConfirmModal isOpen={isOpen} onClose={() => close(false)} onConfirm={() => close(true)} />
+    ));
+
+    if (!confirmed) return;
+
+    mutate(
+      { status: 'REJECTED' },
+      {
+        onSuccess: () => {
+          showToast({ variant: 'success', title: '거부되었습니다' });
+        },
+      },
+    );
+  };
+
+  const { applicant, personalGoal, selfIntroduction } = application;
+
+  return (
+    <div className={cn('rounded-lg border bg-white', isExpanded ? 'border-gray-200' : 'border-gray-150')}>
+      <div className='px-4 py-4 md:px-7'>
+        {/* 프로필 헤더 */}
+        <button
+          type='button'
+          onClick={() => setIsExpanded((prev) => !prev)}
+          aria-expanded={isExpanded}
+          aria-label={`${applicant.nickname} 상세 정보`}
+          className='flex w-full items-center justify-between'
+        >
+          <div className='flex items-center gap-2 md:gap-4'>
+            <Profile imageUrl={applicant.profileImage} className='size-8 rounded-lg md:size-12' />
+            <span className='text-small-01-m md:text-body-01-m text-gray-900'>{applicant.nickname}</span>
+          </div>
+          <div className='flex items-center gap-2 md:gap-4'>
+            <div className='flex items-center gap-2 md:gap-4'>
+              <Tag variant='mate'>{getReputationLabel(applicant.reputationScore)}</Tag>
+              <div className='flex items-center gap-2'>
+                <span className='text-small-01-r md:text-body-01-r text-gray-900'>활동 에너지</span>
+                <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>{applicant.reputationScore}점</span>
+              </div>
+            </div>
+            <ArrowIcon
+              size={24}
+              className={cn('text-gray-700 transition-transform md:size-8', isExpanded ? '-rotate-90' : 'rotate-90')}
+            />
+          </div>
+        </button>
+
+        {/* 확장 영역 */}
+        {isExpanded && (
+          <div className='mt-5 flex flex-col items-end gap-5'>
+            {/* 목표 + 한 줄 소개 */}
+            <div className='w-full rounded-lg bg-gray-100 p-7'>
+              <div className='flex flex-col gap-7'>
+                <div className='flex flex-col gap-2'>
+                  <span className='text-small-01-sb md:text-body-01-sb text-gray-900'>목표</span>
+                  <p className='text-small-02-r md:text-body-01-r text-gray-700'>{personalGoal}</p>
+                </div>
+                {selfIntroduction && (
+                  <>
+                    <hr className='border-gray-150' />
+                    <div className='flex flex-col gap-2'>
+                      <span className='text-small-01-sb md:text-body-01-sb text-gray-900'>한 줄 소개</span>
+                      <p className='text-small-02-r md:text-body-01-r text-gray-700'>{selfIntroduction}</p>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {/* 승인/거부 버튼 */}
+            <div className='flex items-center gap-2 md:gap-4'>
+              <Button variant='approve' size='approve-reject' onClick={handleApprove} disabled={isPending}>
+                <CheckIcon size={32} />
+                승인
+              </Button>
+              <Button variant='reject' size='approve-reject' onClick={handleReject} disabled={isPending}>
+                <CloseIcon size={32} />
+                거부
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/PendingApplications/RejectConfirmModal.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/RejectConfirmModal.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Button } from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
+
+interface RejectConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function RejectConfirmModal({ isOpen, onClose, onConfirm }: RejectConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal.Header>
+        <h2 className='text-body-02-sb text-gray-900'>신청을 거부하시겠습니까?</h2>
+      </Modal.Header>
+      <Modal.Body>
+        <p className='text-small-02-r text-gray-500'>거부한 신청은 되돌릴 수 없습니다.</p>
+      </Modal.Body>
+      <Modal.Footer className='flex gap-2'>
+        <Button variant='cancel' size='cancel' onClick={onClose} className='h-14 w-full'>
+          취소
+        </Button>
+        <Button variant='primary' size='action-sm' onClick={onConfirm} className='h-14 w-full'>
+          확인
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/app/gatherings/[id]/_components/PendingApplications/Skeleton.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/Skeleton.tsx
@@ -1,0 +1,49 @@
+const SKELETON_COUNT = 3;
+
+function CardSkeleton() {
+  return (
+    <div className='border-gray-150 rounded-lg border bg-white'>
+      <div className='flex items-center justify-between px-4 py-4 md:px-7'>
+        <div className='flex items-center gap-2 md:gap-4'>
+          {/* 아바타 */}
+          <div className='bg-gray-150 size-8 animate-pulse rounded-lg md:size-12' />
+          {/* 닉네임 */}
+          <div className='bg-gray-150 h-[22px] w-14 animate-pulse rounded md:h-[26px] md:w-16' />
+        </div>
+        <div className='flex items-center gap-2 md:gap-4'>
+          <div className='flex items-center gap-2 md:gap-4'>
+            {/* 메이트 태그 */}
+            <div className='bg-gray-150 h-[26px] w-[72px] animate-pulse rounded-lg' />
+            {/* 활동 에너지 + 점수 */}
+            <div className='flex items-center gap-2'>
+              <div className='bg-gray-150 h-[22px] w-[60px] animate-pulse rounded md:h-[26px] md:w-[72px]' />
+              <div className='bg-gray-150 h-[22px] w-[32px] animate-pulse rounded md:h-[26px] md:w-[40px]' />
+            </div>
+          </div>
+          {/* 화살표 */}
+          <div className='bg-gray-150 size-6 animate-pulse rounded md:size-8' />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PendingApplicationsSkeleton() {
+  return (
+    <div className='flex flex-col gap-4'>
+      {/* 헤더: "신청 대기자" + 카운트 */}
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center gap-2'>
+          <div className='bg-gray-150 h-[26px] w-[88px] animate-pulse rounded lg:h-[30px] lg:w-[104px]' />
+          <div className='bg-gray-150 h-[26px] w-[16px] animate-pulse rounded lg:h-[30px]' />
+        </div>
+      </div>
+      {/* 카드 목록 */}
+      <div className='flex flex-col gap-2 md:gap-4'>
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <CardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/PendingApplications/index.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/index.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { applicationQueries } from '@/api/applications/queries';
+import { Pagination } from '@/components/ui/Pagination';
+
+import { ApplicationCard } from './ApplicationCard';
+
+const ITEMS_PER_PAGE = 5;
+
+interface PendingApplicationsProps {
+  gatheringId: number;
+}
+
+export function PendingApplications({ gatheringId }: PendingApplicationsProps) {
+  const { data } = useSuspenseQuery(applicationQueries.list(gatheringId));
+  const [page, setPage] = useState(1);
+
+  const pendingApplications = useMemo(
+    () => data.applications.filter((app) => app.status === 'PENDING'),
+    [data.applications],
+  );
+
+  const totalCount = pendingApplications.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / ITEMS_PER_PAGE));
+  const currentPage = Math.min(page, totalPages);
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+  const currentItems = pendingApplications.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+  };
+
+  if (totalCount === 0) {
+    return (
+      <div className='rounded-lg border border-gray-200 bg-gray-50 px-4 py-6'>
+        <p className='text-body-02-r text-gray-500'>아직 신청자가 없습니다</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {/* 헤더 */}
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center gap-2'>
+          <h2 className='text-body-01-sb lg:text-h5-sb text-gray-900'>신청 대기자</h2>
+          <span className='text-body-01-sb lg:text-h5-sb text-blue-300'>{totalCount}</span>
+        </div>
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className='flex items-center gap-6'>
+            <span className='text-small-02-m text-gray-500'>
+              {currentPage}/{totalPages}
+            </span>
+            <Pagination
+              variant='simple'
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 카드 목록 */}
+      <div className='flex flex-col gap-2 md:gap-4'>
+        {currentItems.map((application) => (
+          <ApplicationCard key={application.id} gatheringId={gatheringId} application={application} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -42,6 +42,10 @@ export const buttonVariants = cva('cursor-pointer transition-colors disabled:cur
       /** 랜딩 Hero — 둘러보기: 기본 아웃라인, hover 시 그라데이션 채움 */
       'landing-browse':
         'inline-flex items-center justify-center bg-gray-0 text-gradient-primary border-gradient-primary shadow-01 transition-colors hover:bg-gradient-primary hover:text-gray-0 hover:[-webkit-background-clip:border-box] hover:[background-clip:border-box] hover:[-webkit-text-fill-color:var(--color-gray-0)] hover:shadow-03',
+      approve:
+        'rounded-lg flex items-center justify-center gap-1 text-body-01-sb text-blue-300 bg-blue-100 disabled:opacity-50',
+      reject:
+        'rounded-lg flex items-center justify-center gap-1 text-body-01-sb text-gray-700 bg-gray-150 disabled:opacity-50',
     },
     size: {
       'join-login': 'h-14 w-124',
@@ -74,6 +78,7 @@ export const buttonVariants = cva('cursor-pointer transition-colors disabled:cur
       /** Hero CTA: 모바일 Small, md 이상 Big */
       'landing-hero':
         'h-12 w-[120px] rounded-[33.333px] text-body-02-sb md:h-[72px] md:w-[179px] md:rounded-full md:text-h5-b',
+      'approve-reject': 'px-6 py-2',
     },
   },
   defaultVariants: {

--- a/src/lib/getReputationLabel.ts
+++ b/src/lib/getReputationLabel.ts
@@ -1,0 +1,11 @@
+const REPUTATION_THRESHOLDS = [
+  { min: 70, label: '불꽃 메이트' },
+  { min: 50, label: '신뢰 메이트' },
+  { min: 30, label: '불씨 메이트' },
+] as const;
+
+const DEFAULT_LABEL = '참여 메이트';
+
+export const getReputationLabel = (score: number): string => {
+  return REPUTATION_THRESHOLDS.find((t) => score >= t.min)?.label ?? DEFAULT_LABEL;
+};

--- a/src/mocks/handlers/applications.ts
+++ b/src/mocks/handlers/applications.ts
@@ -5,6 +5,7 @@ import { createApiResponse } from '../utils';
 import type {
   ApplicationListResponse,
   CreateApplicationResponse,
+  MyApplicationListResponse,
   UpdateApplicationStatusRequest,
   UpdateApplicationStatusResponse,
 } from '@/api/applications/types';
@@ -16,31 +17,143 @@ const mockApplicationListResponse: ApplicationListResponse = {
     {
       id: 1,
       applicant: {
-        id: 1,
-        nickname: '김선장',
-        profileImage: 'https://example.com/profile.jpg',
-        reputationScore: 36.5,
+        id: 20,
+        nickname: '이수정',
+        profileImage: 'https://avatars.githubusercontent.com/u/20?v=4',
+        reputationScore: 70,
         reviewSummary: {
           reviewCount: 12,
-          topTags: ['성실해요', '소통이 좋아요'],
+          topTags: ['불꽃 메이트', '소통이 좋아요'],
         },
-        recentReviews: [
-          {
-            id: 1,
-            comment: '항상 열심히 참여해주셨어요!',
-            tags: ['성실해요', '소통이 좋아요'],
-          },
-          {
-            id: 2,
-            comment: '시간 약속을 잘 지켜요',
-            tags: ['시간을 잘 지켜요'],
-          },
-        ],
+        recentReviews: [{ id: 1, comment: '항상 열심히 참여해주셨어요!', tags: ['성실해요', '소통이 좋아요'] }],
       },
-      personalGoal: 'React 기초 완벽 이해',
-      selfIntroduction: '안녕하세요! React 기초를 배우고 싶어서 신청했습니다. 잘 부탁드립니다.',
-      status: 'PENDING', // 'PENDING' | 'ACCEPTED' | 'REJECTED'
+      personalGoal: '비전공생으로 피그마 기초를 마스터하는 걸 목표로 합니다.',
+      selfIntroduction: '디자인 분야로 직무 전환을 준비하는 취업 준비생입니다. 열심히 활동하겠습니다.',
+      status: 'PENDING',
       createdAt: '2026-03-24T18:24:00Z',
+    },
+    {
+      id: 2,
+      applicant: {
+        id: 21,
+        nickname: '김민수',
+        profileImage: 'https://avatars.githubusercontent.com/u/21?v=4',
+        reputationScore: 80,
+        reviewSummary: {
+          reviewCount: 8,
+          topTags: ['불꽃 메이트'],
+        },
+        recentReviews: [{ id: 3, comment: '시간 약속을 잘 지켜요', tags: ['시간을 잘 지켜요'] }],
+      },
+      personalGoal: 'UI/UX 디자인 포트폴리오를 완성하고 싶습니다.',
+      selfIntroduction: '현직 프론트엔드 개발자이고, 디자인 역량을 키우고 싶어서 신청합니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-25T10:00:00Z',
+    },
+    {
+      id: 3,
+      applicant: {
+        id: 22,
+        nickname: '박지영',
+        profileImage: 'https://avatars.githubusercontent.com/u/22?v=4',
+        reputationScore: 55,
+        reviewSummary: {
+          reviewCount: 5,
+          topTags: ['성실해요'],
+        },
+        recentReviews: [],
+      },
+      personalGoal: '피그마 기본 기능을 익혀서 실무에 바로 적용하고 싶습니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-25T14:30:00Z',
+    },
+    {
+      id: 4,
+      applicant: {
+        id: 23,
+        nickname: '최현우',
+        profileImage: 'https://avatars.githubusercontent.com/u/23?v=4',
+        reputationScore: 92,
+        reviewSummary: {
+          reviewCount: 20,
+          topTags: ['불꽃 메이트', '잘 도와줘요'],
+        },
+        recentReviews: [{ id: 4, comment: '덕분에 많이 배웠습니다.', tags: ['잘 도와줘요', '다시 함께하고 싶어요'] }],
+      },
+      personalGoal: '디자인 시스템 구축 경험을 쌓고 싶습니다.',
+      selfIntroduction: 'IT 스타트업에서 PM으로 일하고 있습니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-26T09:15:00Z',
+    },
+    {
+      id: 5,
+      applicant: {
+        id: 24,
+        nickname: '정다은',
+        profileImage: 'https://avatars.githubusercontent.com/u/24?v=4',
+        reputationScore: 45,
+        reviewSummary: {
+          reviewCount: 3,
+          topTags: ['소통이 좋아요'],
+        },
+        recentReviews: [],
+      },
+      personalGoal: '웹 디자인 기초부터 차근차근 배우고 싶어요.',
+      selfIntroduction: '디자인 전공 대학생입니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-26T16:00:00Z',
+    },
+    {
+      id: 6,
+      applicant: {
+        id: 25,
+        nickname: '한승민',
+        profileImage: 'https://avatars.githubusercontent.com/u/25?v=4',
+        reputationScore: 63,
+        reviewSummary: {
+          reviewCount: 7,
+          topTags: ['시간을 잘 지켜요'],
+        },
+        recentReviews: [],
+      },
+      personalGoal: '피그마 플러그인 개발까지 도전해보고 싶습니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-27T11:45:00Z',
+    },
+    {
+      id: 7,
+      applicant: {
+        id: 26,
+        nickname: '윤서아',
+        profileImage: '',
+        reputationScore: 38,
+        reviewSummary: {
+          reviewCount: 2,
+          topTags: ['성실해요'],
+        },
+        recentReviews: [],
+      },
+      personalGoal: '협업 도구로서의 피그마 활용법을 배우고 싶습니다.',
+      selfIntroduction: '백엔드 개발자인데 디자이너와 소통을 잘 하고 싶어서 신청합니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-28T08:30:00Z',
+    },
+    {
+      id: 8,
+      applicant: {
+        id: 27,
+        nickname: '송태호',
+        profileImage: 'https://avatars.githubusercontent.com/u/27?v=4',
+        reputationScore: 75,
+        reviewSummary: {
+          reviewCount: 15,
+          topTags: ['불꽃 메이트', '성실해요'],
+        },
+        recentReviews: [{ id: 5, comment: '리더십이 좋아요!', tags: ['성실해요', '잘 도와줘요'] }],
+      },
+      personalGoal: '디자인 툴 숙련도를 높여서 1인 개발에 활용하고 싶습니다.',
+      status: 'PENDING',
+      createdAt: '2026-03-28T20:00:00Z',
     },
   ],
 };
@@ -106,6 +219,22 @@ export const applicationsHandlers = [
   /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
   http.get(`/api/v1/users/me/applications`, async () => {
     await delay(MOCK_DELAY);
-    return HttpResponse.json(createApiResponse(mockApplicationListResponse));
+    const myApplicationListResponse: MyApplicationListResponse = {
+      applications: [
+        {
+          id: 101,
+          gathering: {
+            id: 1,
+            title: '피그마 기초 스터디',
+            type: 'STUDY',
+            status: 'RECRUITING',
+          },
+          personalGoal: 'React 기초 완벽 이해',
+          status: 'PENDING',
+          createdAt: '2026-03-24T18:24:00Z',
+        },
+      ],
+    };
+    return HttpResponse.json(createApiResponse(myApplicationListResponse));
   }),
 ];


### PR DESCRIPTION
## ❓ 이슈

- close #211

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
모임 상세 페이지(/gatherings/[id])에서 모임장일 때 신청 대기자 목록을 조회하고 승인/거부할 수 있는 기능을 구현했습니다.

기존에는 "신청 대기자 관리 기능은 준비 중입니다" 플레이스홀더만 있었으며, 이번 PR에서 실제 기능으로 교체합니다. 모임장 전용 기능 중 신청 대기자 관리만 이번 PR 스코프이며, 더보기 드롭다운(수정/삭제)은 별도 PR에서 진행합니다.

 주요 변경사항

  신규 컴포넌트
  - PendingApplications/index.tsx — 대기자 목록 컨테이너, 페이지네이션, 빈 상태 처리
  - PendingApplications/ApplicationCard.tsx — 신청자 카드 (프로필, 활동 에너지, 메이트 태그, 확장/접기, 승인/거부)
  - PendingApplications/RejectConfirmModal.tsx — 거부 확인 모달
  - PendingApplications/Skeleton.tsx — 로딩 스켈레톤 (레이아웃 시프트 방지)

  유틸/공통
  - getReputationLabel.ts — 활동 에너지 점수 → 메이트 라벨 매핑 (70+: 불꽃, 50+: 신뢰, 30+: 불씨, 그 외: 참여)
  - Button 컴포넌트에 approve/reject variant 추가

  버그 수정
  - MSW /users/me/applications 핸들러가 ApplicationListResponse(모임장용)를 반환하던 버그 → MyApplicationListResponse(신청자용)로 수정

| 결정 | 이유 |
  |------|------|
  | `useSuspenseQuery` + `SuspenseBoundary` | 신청 대기자는 인증 필요한 유저별 데이터 → prefetch 없이 클라이언트 전용 페칭, 프로젝트 렌더링 규칙 준수 |
  | `invalidateQueries`만 사용 (`updateTag` 미사용) | 서버 캐시가 없는 클라이언트 전용 데이터이므로 서버 캐시 무효화 불필요 |
  | 승인은 바로 실행, 거부만 확인 모달 | 승인은 긍정적 액션이라 되돌리기 부담 적음 / 거부는 비가역적이므로 한 번 더 확인 필요 |
  | 클라이언트 사이드 페이지네이션 | 서버에서 페이지네이션 관련 필드를 내려주지 않아 전체 목록을 받아서 클라이언트에서 slice 처리, `Pagination` 컴포넌트 재사용 |
  | 점수 기반 라벨 매핑 (`getReputationLabel`) | `Applicant` 타입에 `reputationLabel` 필드가 없어 백엔드 변경 없이 프론트에서 매핑 |
  | 별도 Button variant 추가 | 피그마 시안의 승인/거부 버튼 스타일이 기존 variant와 불일치, 프로젝트 일관성을 위해 variant로 관리 |

## 📸 스크린샷 (UI 변경 시)
<img width="1920" height="2634" alt="screencapture-localhost-3000-gatherings-1-2026-04-08-16_41_35" src="https://github.com/user-attachments/assets/0f215fee-16e8-49a2-bff9-c52f24013702" />

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
