### PR TITLE
[SM-131] feat: 마이페이지 받은 리뷰 탭 구현

### DIFF
--- a/src/api/reviews/types.ts
+++ b/src/api/reviews/types.ts
@@ -37,8 +37,15 @@ export interface Review {
   createdAt: string;
 }
 
+/** GET `/users/:userId/reviews` 응답 내 활동 에너지 항목 */
+export interface MatesTagCount {
+  tag: string; // 에너지 레벨 (연기, 불씨, 불꽃, 태양)
+  count: number;
+}
+
 /** GET `/users/:userId/reviews` 응답 */
 export interface UserReviewListResponse {
   reviews: Review[];
   totalCount: number;
+  matesTagCounts: MatesTagCount[];
 }

--- a/src/api/reviews/types.ts
+++ b/src/api/reviews/types.ts
@@ -25,6 +25,7 @@ export interface UserReviewsParams {
 export interface ReviewerInfo {
   id: number;
   nickname: string;
+  profileImage?: string;
 }
 
 /** GET `/users/:userId/reviews` 응답 내 리뷰 항목 */

--- a/src/app/my/_components/ActivityEnergyCard/index.tsx
+++ b/src/app/my/_components/ActivityEnergyCard/index.tsx
@@ -1,25 +1,26 @@
 import { CloseIcon, IllustrationIcon } from '@/components/ui/Icon';
 import type { IllustrationIconVariant } from '@/components/ui/Icon/IllustrationIcon';
 
-interface EnergyItem {
-  label: string;
-  variant: IllustrationIconVariant;
-  count: number;
-}
+import type { MatesTagCount } from '@/api/reviews/types';
 
-const ENERGY_ITEMS: EnergyItem[] = [
-  { label: '연기', variant: 'smoke', count: 0 },
-  { label: '불씨', variant: 'firestart', count: 0 },
-  { label: '불꽃', variant: 'fire', count: 0 },
-  { label: '태양', variant: 'sun', count: 0 },
+const ENERGY_ITEMS: { label: string; variant: IllustrationIconVariant }[] = [
+  { label: '연기', variant: 'smoke' },
+  { label: '불씨', variant: 'firestart' },
+  { label: '불꽃', variant: 'fire' },
+  { label: '태양', variant: 'sun' },
 ];
 
-export function ActivityEnergyCard() {
+interface ActivityEnergyCardProps {
+  matesTagCounts: MatesTagCount[];
+}
+
+export function ActivityEnergyCard({ matesTagCounts }: ActivityEnergyCardProps) {
+  const countMap = Object.fromEntries(matesTagCounts.map(({ tag, count }) => [tag, count]));
   return (
     <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
       <span className='text-body-02-sb md:text-h5-sb text-gray-900'>활동 에너지 평가</span>
       <div className='flex items-stretch rounded-lg bg-gray-100 px-4 py-3'>
-        {ENERGY_ITEMS.map(({ label, variant, count }, index) => [
+        {ENERGY_ITEMS.map(({ label, variant }, index) => [
           index > 0 && (
             <span key={`divider-${variant}`} className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />
           ),
@@ -28,7 +29,9 @@ export function ActivityEnergyCard() {
             <div className='flex items-center gap-1 md:contents'>
               <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
               <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
-              <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>{count}</span>
+              <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>
+                {countMap[label] ?? 0}
+              </span>
             </div>
           </div>,
         ])}

--- a/src/app/my/_components/ActivityEnergyCard/index.tsx
+++ b/src/app/my/_components/ActivityEnergyCard/index.tsx
@@ -1,0 +1,38 @@
+import { CloseIcon, IllustrationIcon } from '@/components/ui/Icon';
+import type { IllustrationIconVariant } from '@/components/ui/Icon/IllustrationIcon';
+
+interface EnergyItem {
+  label: string;
+  variant: IllustrationIconVariant;
+  count: number;
+}
+
+const ENERGY_ITEMS: EnergyItem[] = [
+  { label: '연기', variant: 'smoke', count: 0 },
+  { label: '불씨', variant: 'firestart', count: 0 },
+  { label: '불꽃', variant: 'fire', count: 0 },
+  { label: '태양', variant: 'sun', count: 0 },
+];
+
+export function ActivityEnergyCard() {
+  return (
+    <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
+      <span className='text-h5-sb text-gray-900'>활동 에너지 평가</span>
+      <div className='flex items-stretch rounded-lg bg-gray-100 px-4 py-3'>
+        {ENERGY_ITEMS.map(({ label, variant, count }, index) => (
+          <>
+            {index > 0 && (
+              <span key={`divider-${variant}`} className='bg-gray-150 mx-4 w-px self-stretch' aria-hidden />
+            )}
+            <div key={variant} className='flex flex-1 items-center justify-center gap-2'>
+              <IllustrationIcon variant={variant} className='size-6 shrink-0' aria-hidden />
+              <span className='text-body-01-sb text-gray-800'>{label}</span>
+              <CloseIcon className='size-4 text-gray-300' aria-hidden />
+              <span className='text-body-01-r text-gray-600'>{count}</span>
+            </div>
+          </>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/my/_components/ActivityEnergyCard/index.tsx
+++ b/src/app/my/_components/ActivityEnergyCard/index.tsx
@@ -17,18 +17,23 @@ const ENERGY_ITEMS: EnergyItem[] = [
 export function ActivityEnergyCard() {
   return (
     <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
-      <span className='text-h5-sb text-gray-900'>활동 에너지 평가</span>
+      <span className='text-body-02-sb md:text-h5-sb text-gray-900'>활동 에너지 평가</span>
       <div className='flex items-stretch rounded-lg bg-gray-100 px-4 py-3'>
         {ENERGY_ITEMS.map(({ label, variant, count }, index) => (
           <>
             {index > 0 && (
-              <span key={`divider-${variant}`} className='bg-gray-150 mx-4 w-px self-stretch' aria-hidden />
+              <span key={`divider-${variant}`} className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />
             )}
-            <div key={variant} className='flex flex-1 items-center justify-center gap-2'>
-              <IllustrationIcon variant={variant} className='size-6 shrink-0' aria-hidden />
-              <span className='text-body-01-sb text-gray-800'>{label}</span>
-              <CloseIcon className='size-4 text-gray-300' aria-hidden />
-              <span className='text-body-01-r text-gray-600'>{count}</span>
+            <div
+              key={variant}
+              className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2'
+            >
+              <IllustrationIcon variant={variant} className='size-5 shrink-0 md:size-6' aria-hidden />
+              <div className='flex items-center gap-1 md:contents'>
+                <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
+                <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
+                <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>{count}</span>
+              </div>
             </div>
           </>
         ))}

--- a/src/app/my/_components/ActivityEnergyCard/index.tsx
+++ b/src/app/my/_components/ActivityEnergyCard/index.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { CloseIcon, IllustrationIcon } from '@/components/ui/Icon';
 import type { IllustrationIconVariant } from '@/components/ui/Icon/IllustrationIcon';
 
@@ -20,24 +22,21 @@ export function ActivityEnergyCard({ matesTagCounts }: ActivityEnergyCardProps) 
     <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
       <span className='text-body-02-sb md:text-h5-sb text-gray-900'>활동 에너지 평가</span>
       <div className='flex items-stretch rounded-lg bg-gray-100 px-4 py-3'>
-        {ENERGY_ITEMS.map(({ label, variant }, index) => [
-          index > 0 && (
-            <span key={`divider-${variant}`} className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />
-          ),
-          <div
-            key={variant}
-            className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2 lg:flex-col lg:justify-normal lg:gap-1 xl:flex-row xl:justify-center xl:gap-2'
-          >
-            <IllustrationIcon variant={variant} className='size-5 shrink-0 md:size-6' aria-hidden />
-            <div className='flex items-center gap-1 md:contents lg:flex lg:items-center lg:gap-1 xl:contents'>
-              <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
-              <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
-              <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>
-                {countMap[label] ?? 0}
-              </span>
+        {ENERGY_ITEMS.map(({ label, variant }, index) => (
+          <Fragment key={variant}>
+            {index > 0 && <span className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />}
+            <div className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2 lg:flex-col lg:justify-normal lg:gap-1 xl:flex-row xl:justify-center xl:gap-2'>
+              <IllustrationIcon variant={variant} className='size-5 shrink-0 md:size-6' aria-hidden />
+              <div className='flex items-center gap-1 md:contents lg:flex lg:items-center lg:gap-1 xl:contents'>
+                <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
+                <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
+                <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>
+                  {countMap[label] ?? 0}
+                </span>
+              </div>
             </div>
-          </div>,
-        ])}
+          </Fragment>
+        ))}
       </div>
     </div>
   );

--- a/src/app/my/_components/ActivityEnergyCard/index.tsx
+++ b/src/app/my/_components/ActivityEnergyCard/index.tsx
@@ -19,24 +19,19 @@ export function ActivityEnergyCard() {
     <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
       <span className='text-body-02-sb md:text-h5-sb text-gray-900'>활동 에너지 평가</span>
       <div className='flex items-stretch rounded-lg bg-gray-100 px-4 py-3'>
-        {ENERGY_ITEMS.map(({ label, variant, count }, index) => (
-          <>
-            {index > 0 && (
-              <span key={`divider-${variant}`} className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />
-            )}
-            <div
-              key={variant}
-              className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2'
-            >
-              <IllustrationIcon variant={variant} className='size-5 shrink-0 md:size-6' aria-hidden />
-              <div className='flex items-center gap-1 md:contents'>
-                <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
-                <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
-                <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>{count}</span>
-              </div>
+        {ENERGY_ITEMS.map(({ label, variant, count }, index) => [
+          index > 0 && (
+            <span key={`divider-${variant}`} className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />
+          ),
+          <div key={variant} className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2'>
+            <IllustrationIcon variant={variant} className='size-5 shrink-0 md:size-6' aria-hidden />
+            <div className='flex items-center gap-1 md:contents'>
+              <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
+              <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
+              <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>{count}</span>
             </div>
-          </>
-        ))}
+          </div>,
+        ])}
       </div>
     </div>
   );

--- a/src/app/my/_components/ActivityEnergyCard/index.tsx
+++ b/src/app/my/_components/ActivityEnergyCard/index.tsx
@@ -24,9 +24,12 @@ export function ActivityEnergyCard({ matesTagCounts }: ActivityEnergyCardProps) 
           index > 0 && (
             <span key={`divider-${variant}`} className='bg-gray-150 mx-2 w-px self-stretch md:mx-4' aria-hidden />
           ),
-          <div key={variant} className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2'>
+          <div
+            key={variant}
+            className='flex flex-1 flex-col items-center gap-1 md:flex-row md:justify-center md:gap-2 lg:flex-col lg:justify-normal lg:gap-1 xl:flex-row xl:justify-center xl:gap-2'
+          >
             <IllustrationIcon variant={variant} className='size-5 shrink-0 md:size-6' aria-hidden />
-            <div className='flex items-center gap-1 md:contents'>
+            <div className='flex items-center gap-1 md:contents lg:flex lg:items-center lg:gap-1 xl:contents'>
               <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>{label}</span>
               <CloseIcon className='size-3 text-gray-300 md:size-4' aria-hidden />
               <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-600'>

--- a/src/app/my/_components/KeywordSummaryCard/index.tsx
+++ b/src/app/my/_components/KeywordSummaryCard/index.tsx
@@ -1,4 +1,4 @@
-import { Tag } from '@/components/ui/Tag';
+import { CloseIcon } from '@/components/ui/Icon';
 import { REVIEW_TAGS } from '@/api/reviews/schemas';
 import type { ReviewTag } from '@/api/reviews/types';
 
@@ -19,13 +19,15 @@ export function KeywordSummaryCard({ reviews }: KeywordSummaryCardProps) {
 
   return (
     <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
-      <span className='text-h5-sb text-gray-900'>키워드 평가</span>
+      <span className='text-body-02-sb md:text-h5-sb text-gray-900'>키워드 평가</span>
       <div className='rounded-lg bg-gray-100 p-4'>
         <div className='flex flex-wrap gap-2'>
           {REVIEW_TAGS.map((tag) => (
-            <Tag key={tag} variant='bad' count={counts[tag]}>
-              {tag}
-            </Tag>
+            <span key={tag} className='bg-gray-150 inline-flex items-center gap-1 rounded-lg px-3 py-1'>
+              <span className='text-small-02-m md:text-body-02-m text-gray-600'>{tag}</span>
+              <CloseIcon className='size-4 text-gray-400 md:size-6' aria-hidden />
+              <span className='text-small-02-m md:text-body-02-m text-gray-700'>{counts[tag]}</span>
+            </span>
           ))}
         </div>
       </div>

--- a/src/app/my/_components/KeywordSummaryCard/index.tsx
+++ b/src/app/my/_components/KeywordSummaryCard/index.tsx
@@ -1,0 +1,34 @@
+import { Tag } from '@/components/ui/Tag';
+import { REVIEW_TAGS } from '@/api/reviews/schemas';
+import type { ReviewTag } from '@/api/reviews/types';
+
+interface KeywordSummaryCardProps {
+  reviews: { tags: ReviewTag[] }[];
+}
+
+export function KeywordSummaryCard({ reviews }: KeywordSummaryCardProps) {
+  const counts = REVIEW_TAGS.reduce<Record<ReviewTag, number>>(
+    (acc, tag) => ({ ...acc, [tag]: 0 }),
+    {} as Record<ReviewTag, number>,
+  );
+  reviews.forEach(({ tags }) =>
+    tags.forEach((tag) => {
+      counts[tag] += 1;
+    }),
+  );
+
+  return (
+    <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
+      <span className='text-h5-sb text-gray-900'>키워드 평가</span>
+      <div className='rounded-lg bg-gray-100 p-4'>
+        <div className='flex flex-wrap gap-2'>
+          {REVIEW_TAGS.map((tag) => (
+            <Tag key={tag} variant='bad' count={counts[tag]}>
+              {tag}
+            </Tag>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -4,6 +4,7 @@ import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import type { MyPageTab, PendingGatheringSort } from '../../_constants';
 
 import { MyGatheringsList } from '../MyGatheringsList';
+import { ReceivedReviewsList } from '../ReceivedReviewsList';
 
 import { MyCreatedGatheringList } from '../MyCreatedGatheringList';
 
@@ -58,6 +59,17 @@ export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
       </SuspenseBoundary>
     );
   }
-  if (activeTab === 'received-reviews') return <p>받은 리뷰</p>;
+
+  if (activeTab === 'received-reviews')
+    return (
+      <SuspenseBoundary
+        pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
+        errorFallback={
+          <p className='flex h-40 items-center justify-center text-gray-500'>리뷰를 불러올 수 없습니다.</p>
+        }
+      >
+        <ReceivedReviewsList />
+      </SuspenseBoundary>
+    );
   if (activeTab === 'liked-gatherings') return <p>찜한 모임</p>;
 }

--- a/src/app/my/_components/ReceivedReviewCard/index.tsx
+++ b/src/app/my/_components/ReceivedReviewCard/index.tsx
@@ -1,0 +1,38 @@
+import { Profile } from '@/components/ui/Profile';
+import type { Review } from '@/api/reviews/types';
+
+interface ReceivedReviewCardProps {
+  review: Review;
+  profileImage?: string;
+}
+
+const getDaysAgo = (dateStr: string): string => {
+  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24));
+  return `${diff}일전`;
+};
+
+export function ReceivedReviewCard({ review, profileImage }: ReceivedReviewCardProps) {
+  const { reviewer, gatheringTitle, comment, createdAt } = review;
+
+  return (
+    <div className='flex flex-col gap-3 p-4'>
+      <div className='flex items-start justify-between'>
+        <div className='flex items-center gap-2'>
+          <Profile imageUrl={profileImage} className='size-8 rounded-full' />
+          <div className='flex flex-col'>
+            <span className='text-body-02-sb text-gray-800'>{reviewer.nickname}</span>
+            <p className='text-small-02-r text-gray-600'>{gatheringTitle}</p>
+          </div>
+        </div>
+        <span className='text-small-01-r text-gray-400'>{getDaysAgo(createdAt)}</span>
+      </div>
+
+      {comment && (
+        <>
+          <hr className='border-gray-150 border-t' />
+          <p className='text-body-02-r text-gray-700'>{comment}</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/my/_components/ReceivedReviewCard/index.tsx
+++ b/src/app/my/_components/ReceivedReviewCard/index.tsx
@@ -15,13 +15,13 @@ export function ReceivedReviewCard({ review, profileImage }: ReceivedReviewCardP
   const { reviewer, gatheringTitle, comment, createdAt } = review;
 
   return (
-    <div className='flex flex-col gap-3 p-4'>
+    <div className='border-gray-150 flex flex-col gap-3 rounded-lg border bg-gray-100 p-4'>
       <div className='flex items-start justify-between'>
         <div className='flex items-center gap-2'>
           <Profile imageUrl={profileImage} className='size-8 rounded-full' />
           <div className='flex flex-col'>
-            <span className='text-body-02-sb text-gray-800'>{reviewer.nickname}</span>
-            <p className='text-small-02-r text-gray-600'>{gatheringTitle}</p>
+            <span className='text-small-02-sb md:text-body-02-sb text-gray-800'>{reviewer.nickname}</span>
+            <p className='text-small-01-r md:text-small-02-r text-gray-600'>{gatheringTitle}</p>
           </div>
         </div>
         <span className='text-small-01-r text-gray-400'>{getDaysAgo(createdAt)}</span>
@@ -30,7 +30,7 @@ export function ReceivedReviewCard({ review, profileImage }: ReceivedReviewCardP
       {comment && (
         <>
           <hr className='border-gray-150 border-t' />
-          <p className='text-body-02-r text-gray-700'>{comment}</p>
+          <p className='text-small-02-r md:text-body-02-r text-gray-700'>{comment}</p>
         </>
       )}
     </div>

--- a/src/app/my/_components/ReceivedReviewCard/index.tsx
+++ b/src/app/my/_components/ReceivedReviewCard/index.tsx
@@ -1,4 +1,8 @@
+import { formatDistanceToNow } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
 import { Profile } from '@/components/ui/Profile';
+
 import type { Review } from '@/api/reviews/types';
 
 interface ReceivedReviewCardProps {
@@ -6,10 +10,7 @@ interface ReceivedReviewCardProps {
   profileImage?: string;
 }
 
-const getDaysAgo = (dateStr: string): string => {
-  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24));
-  return `${diff}일전`;
-};
+const getDaysAgo = (dateStr: string): string => formatDistanceToNow(new Date(dateStr), { addSuffix: true, locale: ko });
 
 export function ReceivedReviewCard({ review, profileImage }: ReceivedReviewCardProps) {
   const { reviewer, gatheringTitle, comment, createdAt } = review;

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -51,8 +51,8 @@ const PAGE_SIZE_DEFAULT = 3;
 const PAGE_SIZE_LG = 6;
 
 function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
-  const isLg = useMediaQuery('(min-width: 1024px)');
-  const pageSize = isLg ? PAGE_SIZE_LG : PAGE_SIZE_DEFAULT;
+  const isXl = useMediaQuery('(min-width: 1280px)');
+  const pageSize = isXl ? PAGE_SIZE_LG : PAGE_SIZE_DEFAULT;
   const [page, setPage] = useState(1);
   const [, startTransition] = useTransition();
 

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+
+import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
+
+import { reviewQueries } from '@/api/reviews/queries';
+import { userQueries } from '@/api/users/queries';
+import { useAuth } from '@/hooks/useAuth';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { Pagination } from '@/components/ui/Pagination';
+
+import { ActivityEnergyCard } from '../ActivityEnergyCard';
+import { KeywordSummaryCard } from '../KeywordSummaryCard';
+import { ReceivedReviewCard } from '../ReceivedReviewCard';
+
+export function ReceivedReviewsList() {
+  const { user } = useAuth();
+  if (!user) return null;
+  return <ReceivedReviewsContent userId={user.id} />;
+}
+
+interface ReceivedReviewsContentProps {
+  userId: number;
+}
+
+function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
+  const isLg = useMediaQuery('(min-width: 1024px)');
+  const pageSize = isLg ? 6 : 3;
+  const [page, setPage] = useState(1);
+  const [, startTransition] = useTransition();
+
+  const { data } = useSuspenseQuery(reviewQueries.list(userId));
+  const { reviews, totalCount } = data;
+
+  const reviewerProfileQueries = useSuspenseQueries({
+    queries: reviews.map((review) => userQueries.userId(review.reviewer.id)),
+  });
+
+  const reviewerProfilesMap = reviewerProfileQueries.reduce<Record<number, string>>((acc, query, index) => {
+    const review = reviews[index];
+    if (review && query.data?.profileImage) {
+      acc[review.reviewer.id] = query.data.profileImage;
+    }
+    return acc;
+  }, {});
+
+  const paged = reviews.slice((page - 1) * pageSize, page * pageSize);
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  return (
+    <div className='mt-6 flex flex-col gap-6'>
+      <ActivityEnergyCard />
+      <KeywordSummaryCard reviews={reviews} />
+      <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
+        <div className='flex items-center gap-2'>
+          <span className='text-h5-sb text-gray-900'>받은 리뷰</span>
+          <span className='text-h5-sb text-gray-600'>{totalCount}</span>
+        </div>
+        {reviews.length === 0 ? (
+          <div className='flex h-40 items-center justify-center'>
+            <p className='text-body-02-r text-gray-400'>받은 리뷰가 없습니다.</p>
+          </div>
+        ) : (
+          <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+            {paged.map((review) => (
+              <ReceivedReviewCard
+                key={review.id}
+                review={review}
+                profileImage={reviewerProfilesMap[review.reviewer.id]}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      {totalPages > 1 && (
+        <Pagination
+          variant='numbered'
+          currentPage={page}
+          totalPages={totalPages}
+          onPageChange={(p) => startTransition(() => setPage(p))}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -41,7 +41,7 @@ function ReviewsGrid({ paged, reviewerProfilesMap }: ReviewsGridProps) {
   }
 
   return (
-    <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+    <div className='grid grid-cols-1 gap-4 xl:grid-cols-2'>
       {paged.map((review) => (
         <ReceivedReviewCard key={review.id} review={review} profileImage={reviewerProfilesMap[review.reviewer.id]} />
       ))}

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -24,9 +24,12 @@ interface ReceivedReviewsContentProps {
   userId: number;
 }
 
+const PAGE_SIZE_DEFAULT = 3;
+const PAGE_SIZE_LG = 6;
+
 function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
   const isLg = useMediaQuery('(min-width: 1024px)');
-  const pageSize = isLg ? 6 : 3;
+  const pageSize = isLg ? PAGE_SIZE_LG : PAGE_SIZE_DEFAULT;
   const [page, setPage] = useState(1);
   const [, startTransition] = useTransition();
 
@@ -35,20 +38,20 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
 
   const reviewsWithComment = reviews.filter((r) => !!r.comment);
 
+  const paged = reviewsWithComment.slice((page - 1) * pageSize, page * pageSize);
+  const totalPages = Math.max(1, Math.ceil(reviewsWithComment.length / pageSize));
+
   const reviewerProfileQueries = useSuspenseQueries({
-    queries: reviews.map((review) => userQueries.userId(review.reviewer.id)),
+    queries: paged.map((review) => userQueries.userId(review.reviewer.id)),
   });
 
   const reviewerProfilesMap = reviewerProfileQueries.reduce<Record<number, string>>((acc, query, index) => {
-    const review = reviews[index];
+    const review = paged[index];
     if (review && query.data?.profileImage) {
       acc[review.reviewer.id] = query.data.profileImage;
     }
     return acc;
   }, {});
-
-  const paged = reviewsWithComment.slice((page - 1) * pageSize, page * pageSize);
-  const totalPages = Math.max(1, Math.ceil(reviewsWithComment.length / pageSize));
 
   return (
     <div className='mt-6 flex flex-col gap-6'>

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -61,8 +61,10 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
   const { data } = useSuspenseQuery(reviewQueries.list(userId));
   const { reviews } = data;
 
+  // 받은 리뷰 섹션에는 comment가 있는 리뷰만 표시되므로, comment가 있는 리뷰를 따로 구분
   const reviewsWithComment = reviews.filter((r) => !!r.comment);
 
+  // 현재 페이지에 해당하는 리뷰만 슬라이싱 — 페이지별로 프로필 이미지를 fetch하기 위해 구분
   const paged = reviewsWithComment.slice((page - 1) * pageSize, page * pageSize);
   const totalPages = Math.max(1, Math.ceil(reviewsWithComment.length / pageSize));
 

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -31,7 +31,9 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
   const [, startTransition] = useTransition();
 
   const { data } = useSuspenseQuery(reviewQueries.list(userId));
-  const { reviews, totalCount } = data;
+  const { reviews } = data;
+
+  const reviewsWithComment = reviews.filter((r) => !!r.comment);
 
   const reviewerProfileQueries = useSuspenseQueries({
     queries: reviews.map((review) => userQueries.userId(review.reviewer.id)),
@@ -45,8 +47,8 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
     return acc;
   }, {});
 
-  const paged = reviews.slice((page - 1) * pageSize, page * pageSize);
-  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const paged = reviewsWithComment.slice((page - 1) * pageSize, page * pageSize);
+  const totalPages = Math.max(1, Math.ceil(reviewsWithComment.length / pageSize));
 
   return (
     <div className='mt-6 flex flex-col gap-6'>
@@ -54,12 +56,12 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
       <KeywordSummaryCard reviews={reviews} />
       <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
         <div className='flex items-center gap-2'>
-          <span className='text-h5-sb text-gray-900'>받은 리뷰</span>
-          <span className='text-h5-sb text-gray-600'>{totalCount}</span>
+          <span className='text-body-02-sb md:text-h5-sb text-gray-900'>받은 리뷰</span>
+          <span className='text-body-02-sb md:text-h5-sb text-gray-600'>{reviewsWithComment.length}</span>
         </div>
-        {reviews.length === 0 ? (
+        {reviewsWithComment.length === 0 ? (
           <div className='flex h-40 items-center justify-center'>
-            <p className='text-body-02-r text-gray-400'>받은 리뷰가 없습니다.</p>
+            <p className='text-small-02-r md:text-body-02-r text-gray-400'>받은 리뷰가 없습니다.</p>
           </div>
         ) : (
           <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -2,10 +2,9 @@
 
 import { useState, useTransition } from 'react';
 
-import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { reviewQueries } from '@/api/reviews/queries';
-import { userQueries } from '@/api/users/queries';
 import { useAuth } from '@/hooks/useAuth';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { Pagination } from '@/components/ui/Pagination';
@@ -28,10 +27,9 @@ interface ReceivedReviewsContentProps {
 
 interface ReviewsGridProps {
   paged: Review[];
-  reviewerProfilesMap: Record<number, string>;
 }
 
-function ReviewsGrid({ paged, reviewerProfilesMap }: ReviewsGridProps) {
+function ReviewsGrid({ paged }: ReviewsGridProps) {
   if (paged.length === 0) {
     return (
       <div className='flex h-40 items-center justify-center'>
@@ -43,7 +41,7 @@ function ReviewsGrid({ paged, reviewerProfilesMap }: ReviewsGridProps) {
   return (
     <div className='grid grid-cols-1 gap-4 xl:grid-cols-2'>
       {paged.map((review) => (
-        <ReceivedReviewCard key={review.id} review={review} profileImage={reviewerProfilesMap[review.reviewer.id]} />
+        <ReceivedReviewCard key={review.id} review={review} profileImage={review.reviewer.profileImage} />
       ))}
     </div>
   );
@@ -64,21 +62,8 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
   // 받은 리뷰 섹션에는 comment가 있는 리뷰만 표시되므로, comment가 있는 리뷰를 따로 구분
   const reviewsWithComment = reviews.filter((r) => !!r.comment);
 
-  // 현재 페이지에 해당하는 리뷰만 슬라이싱 — 페이지별로 프로필 이미지를 fetch하기 위해 구분
   const paged = reviewsWithComment.slice((page - 1) * pageSize, page * pageSize);
   const totalPages = Math.max(1, Math.ceil(reviewsWithComment.length / pageSize));
-
-  const reviewerProfileQueries = useSuspenseQueries({
-    queries: paged.map((review) => userQueries.userId(review.reviewer.id)),
-  });
-
-  const reviewerProfilesMap = reviewerProfileQueries.reduce<Record<number, string>>((acc, query, index) => {
-    const review = paged[index];
-    if (review && query.data?.profileImage) {
-      acc[review.reviewer.id] = query.data.profileImage;
-    }
-    return acc;
-  }, {});
 
   return (
     <div className='mt-6 flex flex-col gap-6'>
@@ -89,7 +74,7 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
           <span className='text-body-02-sb md:text-h5-sb text-gray-900'>받은 리뷰</span>
           <span className='text-body-02-sb md:text-h5-sb text-gray-600'>{reviewsWithComment.length}</span>
         </div>
-        <ReviewsGrid paged={paged} reviewerProfilesMap={reviewerProfilesMap} />
+        <ReviewsGrid paged={paged} />
       </div>
       {totalPages > 1 && (
         <Pagination

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -14,6 +14,8 @@ import { ActivityEnergyCard } from '../ActivityEnergyCard';
 import { KeywordSummaryCard } from '../KeywordSummaryCard';
 import { ReceivedReviewCard } from '../ReceivedReviewCard';
 
+import type { Review } from '@/api/reviews/types';
+
 export function ReceivedReviewsList() {
   const { user } = useAuth();
   if (!user) return null;
@@ -22,6 +24,29 @@ export function ReceivedReviewsList() {
 
 interface ReceivedReviewsContentProps {
   userId: number;
+}
+
+interface ReviewsGridProps {
+  paged: Review[];
+  reviewerProfilesMap: Record<number, string>;
+}
+
+function ReviewsGrid({ paged, reviewerProfilesMap }: ReviewsGridProps) {
+  if (paged.length === 0) {
+    return (
+      <div className='flex h-40 items-center justify-center'>
+        <p className='text-small-02-r md:text-body-02-r text-gray-400'>받은 리뷰가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
+      {paged.map((review) => (
+        <ReceivedReviewCard key={review.id} review={review} profileImage={reviewerProfilesMap[review.reviewer.id]} />
+      ))}
+    </div>
+  );
 }
 
 const PAGE_SIZE_DEFAULT = 3;
@@ -62,21 +87,7 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
           <span className='text-body-02-sb md:text-h5-sb text-gray-900'>받은 리뷰</span>
           <span className='text-body-02-sb md:text-h5-sb text-gray-600'>{reviewsWithComment.length}</span>
         </div>
-        {reviewsWithComment.length === 0 ? (
-          <div className='flex h-40 items-center justify-center'>
-            <p className='text-small-02-r md:text-body-02-r text-gray-400'>받은 리뷰가 없습니다.</p>
-          </div>
-        ) : (
-          <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
-            {paged.map((review) => (
-              <ReceivedReviewCard
-                key={review.id}
-                review={review}
-                profileImage={reviewerProfilesMap[review.reviewer.id]}
-              />
-            ))}
-          </div>
-        )}
+        <ReviewsGrid paged={paged} reviewerProfilesMap={reviewerProfilesMap} />
       </div>
       {totalPages > 1 && (
         <Pagination

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -57,7 +57,7 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
   const [, startTransition] = useTransition();
 
   const { data } = useSuspenseQuery(reviewQueries.list(userId));
-  const { reviews, matesTagCounts } = data;
+  const { reviews, matesTagCounts = [] } = data;
 
   // 받은 리뷰 섹션에는 comment가 있는 리뷰만 표시되므로, comment가 있는 리뷰를 따로 구분
   const reviewsWithComment = reviews.filter((r) => !!r.comment);

--- a/src/app/my/_components/ReceivedReviewsList/index.tsx
+++ b/src/app/my/_components/ReceivedReviewsList/index.tsx
@@ -59,7 +59,7 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
   const [, startTransition] = useTransition();
 
   const { data } = useSuspenseQuery(reviewQueries.list(userId));
-  const { reviews } = data;
+  const { reviews, matesTagCounts } = data;
 
   // 받은 리뷰 섹션에는 comment가 있는 리뷰만 표시되므로, comment가 있는 리뷰를 따로 구분
   const reviewsWithComment = reviews.filter((r) => !!r.comment);
@@ -82,7 +82,7 @@ function ReceivedReviewsContent({ userId }: ReceivedReviewsContentProps) {
 
   return (
     <div className='mt-6 flex flex-col gap-6'>
-      <ActivityEnergyCard />
+      <ActivityEnergyCard matesTagCounts={matesTagCounts} />
       <KeywordSummaryCard reviews={reviews} />
       <div className='border-gray-150 bg-gray-0 shadow-02 flex flex-col gap-4 rounded-lg border p-6'>
         <div className='flex items-center gap-2'>

--- a/src/mocks/handlers/reviews.ts
+++ b/src/mocks/handlers/reviews.ts
@@ -64,7 +64,7 @@ export const reviewsHandlers = [
 
     const reviews = Array.from({ length: totalCount }).map((_, index) => ({
       id: userId * 100 + index,
-      reviewer: { id: index + 10, nickname: `닉네임${index + 10}` },
+      reviewer: { id: index + 10, nickname: `닉네임${index + 10}`, profileImage: undefined },
       gatheringTitle: MOCK_TITLES[index % MOCK_TITLES.length],
       tags: [MOCK_TAGS[index % MOCK_TAGS.length], MOCK_TAGS[(index + 1) % MOCK_TAGS.length]],
       matesTag: MOCK_MATES_TAGS[index % MOCK_MATES_TAGS.length],

--- a/src/mocks/handlers/reviews.ts
+++ b/src/mocks/handlers/reviews.ts
@@ -26,6 +26,12 @@ const mockUserReviewListResponse: UserReviewListResponse = {
     },
   ],
   totalCount: 12,
+  matesTagCounts: [
+    { tag: '연기', count: 3 },
+    { tag: '불씨', count: 2 },
+    { tag: '불꽃', count: 4 },
+    { tag: '태양', count: 1 },
+  ],
 };
 
 const MOCK_TITLES = ['React 완전 정복 스터디', 'JavaScript 딥다이브', 'Next.js 프로그래밍', '실전 TypeScript'];
@@ -36,6 +42,7 @@ const MOCK_COMMENTS = [
   '함께 협업하면서 배울 점이 많았던 팀원입니다.',
 ];
 const MOCK_TAGS = ['성실해요', '소통이 좋아요', '잘 도와줘요', '시간을 잘 지켜요', '다시 함께하고 싶어요'];
+const MOCK_MATES_TAGS = ['연기', '불씨', '불꽃', '태양'];
 
 export const reviewsHandlers = [
   /** POST v1/gatherings/:gatheringId/reviews — 리뷰 작성 */
@@ -60,8 +67,14 @@ export const reviewsHandlers = [
       reviewer: { id: index + 10, nickname: `닉네임${index + 10}` },
       gatheringTitle: MOCK_TITLES[index % MOCK_TITLES.length],
       tags: [MOCK_TAGS[index % MOCK_TAGS.length], MOCK_TAGS[(index + 1) % MOCK_TAGS.length]],
+      matesTag: MOCK_MATES_TAGS[index % MOCK_MATES_TAGS.length],
       comment: MOCK_COMMENTS[index % MOCK_COMMENTS.length],
       createdAt: new Date(Date.now() - index * 86400000).toISOString(),
+    }));
+
+    const matesTagCounts = MOCK_MATES_TAGS.map((tag) => ({
+      tag,
+      count: reviews.filter((r) => r.matesTag === tag).length,
     }));
 
     const startIndex = (page - 1) * limit;
@@ -71,6 +84,7 @@ export const reviewsHandlers = [
       createApiResponse({
         reviews: paginatedReviews,
         totalCount,
+        matesTagCounts,
       }),
     );
   }),


### PR DESCRIPTION
## ❓ 이슈

- close #193 

## ✍️ Description
마이페이지 "받은 리뷰" 탭의 placeholder(`<p>받은 리뷰</p>`)를 실제 구현으로 교체합니다.

### 구현 범위

**포함**
- 활동 에너지 평가 (백엔드 연동 완료)
- 키워드 집계 섹션 (`KeywordSummaryCard`)
- 리뷰 목록 (`ReceivedReviewCard`) — comment 있는 리뷰만 표시
- 리뷰어 프로필 이미지 (현재 페이지 기준 fetch)
- 클라이언트 사이드 페이지네이션

---

### 변경 파일

#### 수정
- `src/app/my/_components/MyPageContent/index.tsx`
  - `activeTab === 'received-reviews'` 분기를 `<SuspenseBoundary>` + `<ReceivedReviewsList />`로 교체
- `src/api/reviews/types.ts`
  - `ReviewerInfo`에 `profileImage?: string` 추가
  - `MatesTagCount` 인터페이스 추가
  - `UserReviewListResponse`에 `matesTagCounts` 필드 추가

#### 신규 생성

| 파일 | 역할 |
|---|---|
| `ActivityEnergyCard/index.tsx` | 활동 에너지 평가 UI (연기·불씨·불꽃·태양 메이트, 백엔드 카운트 연동) |
| `ReceivedReviewsList/index.tsx` | 리뷰 목록 총괄 — 데이터 fetch, 페이지네이션, 레이아웃 |
| `ReceivedReviewCard/index.tsx` | 개별 리뷰 카드 (이미지, 닉네임, 모임명, 코멘트, 상대 시간) |
| `KeywordSummaryCard/index.tsx` | 전체 리뷰의 태그 집계 및 카운트 표시 |

---

### 주요 구현 사항

**데이터 패칭**
- `useSuspenseQuery(reviewQueries.list(user.id))` 로 전체 리뷰 fetch
- comment 없는 리뷰는 받은 리뷰 섹션에서 목록·카운트·페이지네이션에서 제외 — 키워드 집계는 전체 리뷰 대상
- ~~`useSuspenseQueries` 로 **현재 페이지(`paged`) 기준**으로만 리뷰어 프로필 병렬 fetch → 불필요한 요청 방지~~
- 리뷰어 프로필 이미지는 reviews 응답의 `reviewer.profileImage` 직접 사용 — 개별 `/users/:userId` fetch 제거
- `SuspenseBoundary` 가 로딩/에러 처리를 담당하므로 컴포넌트 내 `isLoading` / `isError` 분기 없음

**페이지네이션**
- 리뷰 목록: 전체 fetch 후 클라이언트 슬라이싱 방식 (리뷰 수가 많지 않을 것으로 가정)
- 프로필 이미지: 현재 페이지 기준으로만 fetch → 불필요한 요청 방지
- `useMediaQuery('(min-width: 1024px)')` 로 `pageSize` 결정
  - lg(PC) : 2열 × 3행 = **6개/페이지**
  - 태블릿·모바일 : 1열 × 3행 = **3개/페이지**
- 페이지 변경 시 `startTransition` 으로 감싸 Suspense fallback 깜빡임 방지

**반응형**
- `ActivityEnergyCard`: lg 구간(1024~1280px)에서 세로 배치로 전환해 깨짐 방지

**상대 시간 표시**
- `date-fns formatDistanceToNow` + 한국어 locale 적용
- 예: "3일 전", "약 2시간 전"

**빈 상태**
- comment 있는 리뷰가 0개일 경우 `받은 리뷰가 없습니다.` 메시지 표시
- 총 페이지가 1 이하일 경우 Pagination 미노출

---


## 📸 스크린샷 (UI 변경 시)
<img width="1284" height="786" alt="image" src="https://github.com/user-attachments/assets/422694e1-743e-4717-8fff-147fce4f01e8" />

활동 에너지 평가 백엔드 연동
<img width="1996" height="408" alt="image" src="https://github.com/user-attachments/assets/4de66227-731a-476e-96ad-40a50db371b1" />




## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [x] ~~활동 에너지 카운트는 백엔드 연동 예정 → 현재 0 하드코딩~~ 연동 완료
- [x] ~~현재 받은 리뷰 목록 조회 시 현재 페이지 리뷰어의 프로필 이미지를 유저별로 개별 fetch (GET /users/:userId) — 백엔드가 reviews 응답에 reviewer.profileImage 필드를 추가하면 별도 fetch 제거 예정~~reviews 응답 직접 사용으로 교체 완료
- [ ] 전체 fetch 후 클라이언트 슬라이싱 방식 채택 → 백엔드 페이지 사이즈 확정 시 서버 페이지네이션으로 전환 검토

