### PR TITLE
[SM-130] feat: 마이페이지 대기중인 모임 탭

### DIFF
--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -99,6 +99,10 @@ export const useDeleteApplication = (
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all });
+      queryClient.invalidateQueries({ queryKey: gatheringKeys.detail(gatheringId) });
+
+      invalidateServerCache(GATHERING_TAGS.detail(gatheringId));
+
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -12,12 +12,14 @@ interface MyPageContentProps {
   pendingSort: PendingGatheringSort;
 }
 
-const PendingGatheringsSkeleton = () => (
-  <div className='mt-6 space-y-4' aria-busy>
-    <div className='bg-gray-150 h-9 w-48 max-w-full animate-pulse rounded-md' />
-    <div className='bg-gray-0 border-gray-150 h-72 w-full animate-pulse rounded-lg border' />
-  </div>
-);
+function PendingGatheringsSkeleton() {
+  return (
+    <div className='mt-6 space-y-4' aria-busy>
+      <div className='bg-gray-150 h-9 w-48 max-w-full animate-pulse rounded-md' />
+      <div className='bg-gray-0 border-gray-150 h-72 w-full animate-pulse rounded-lg border' />
+    </div>
+  );
+}
 
 export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'my-gatherings')

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -1,15 +1,25 @@
+import { PendingGatheringsSection } from '../PendingGatheringsSection';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+
+import type { MyPageTab, PendingGatheringSort } from '../../_constants';
 
 import { MyGatheringsList } from '../MyGatheringsList';
 
-import type { MyPageTab } from '../../_constants';
 import { MyCreatedGatheringList } from '../MyCreatedGatheringList';
 
 interface MyPageContentProps {
   activeTab: MyPageTab;
+  pendingSort: PendingGatheringSort;
 }
 
-export function MyPageContent({ activeTab }: MyPageContentProps) {
+const PendingGatheringsSkeleton = () => (
+  <div className='mt-6 space-y-4' aria-busy>
+    <div className='bg-gray-150 h-9 w-48 max-w-full animate-pulse rounded-md' />
+    <div className='bg-gray-0 border-gray-150 h-72 w-full animate-pulse rounded-lg border' />
+  </div>
+);
+
+export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'my-gatherings')
     return (
       <SuspenseBoundary
@@ -32,7 +42,20 @@ export function MyPageContent({ activeTab }: MyPageContentProps) {
         <MyCreatedGatheringList />
       </SuspenseBoundary>
     );
-  if (activeTab === 'pending-gatherings') return <p>대기중인 모임</p>;
+  if (activeTab === 'pending-gatherings') {
+    return (
+      <SuspenseBoundary
+        pendingFallback={<PendingGatheringsSkeleton />}
+        errorFallback={
+          <p className='text-body-02-r mt-6 py-10 text-center text-gray-500'>
+            대기 중인 모임 목록을 불러오지 못했습니다.
+          </p>
+        }
+      >
+        <PendingGatheringsSection key={pendingSort} pendingSort={pendingSort} />
+      </SuspenseBoundary>
+    );
+  }
   if (activeTab === 'received-reviews') return <p>받은 리뷰</p>;
   if (activeTab === 'liked-gatherings') return <p>찜한 모임</p>;
 }

--- a/src/app/my/_components/MyPageTabs/index.tsx
+++ b/src/app/my/_components/MyPageTabs/index.tsx
@@ -4,13 +4,21 @@ import { cn } from '@/lib/cn';
 
 import { MY_PAGE_TAB_ITEMS } from '../../_constants';
 
-import type { MyPageTab } from '../../_constants';
+import type { MyPageTab, PendingGatheringSort } from '../../_constants';
 
 interface MyPageTabsProps {
   activeTab: MyPageTab;
+  pendingSort: PendingGatheringSort;
 }
 
-export function MyPageTabs({ activeTab }: MyPageTabsProps) {
+const buildTabHref = (key: MyPageTab, pendingSort: PendingGatheringSort) => {
+  if (key === 'pending-gatherings') {
+    return `/my?tab=${key}&pendingSort=${pendingSort}`;
+  }
+  return `/my?tab=${key}`;
+};
+
+export function MyPageTabs({ activeTab, pendingSort }: MyPageTabsProps) {
   return (
     <nav>
       <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
@@ -20,7 +28,7 @@ export function MyPageTabs({ activeTab }: MyPageTabsProps) {
           return (
             <li key={key} className='shrink-0'>
               <Link
-                href={`/my?tab=${key}`}
+                href={buildTabHref(key, pendingSort)}
                 replace
                 scroll={false}
                 className={cn(

--- a/src/app/my/_components/PendingGatheringsSection/PendingGatheringCard.tsx
+++ b/src/app/my/_components/PendingGatheringsSection/PendingGatheringCard.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { GatheringCard } from '@/components/ui/GatheringCard';
+import { CalendarIcon, PersonIcon, ProjectIcon, StudyIcon } from '@/components/ui/Icon';
+import { Modal } from '@/components/ui/Modal';
+import { Tag } from '@/components/ui/Tag';
+import { useDeleteApplication } from '@/api/applications/queries';
+
+import type { MyApplication } from '@/api/applications/types';
+import type { GatheringDetail } from '@/api/gatherings/types';
+
+interface PendingGatheringCardProps {
+  application: MyApplication;
+  gathering: GatheringDetail;
+}
+
+const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
+
+const formatDate = (isoDate: string) => isoDate.slice(0, 10);
+
+const TYPE_ICON = {
+  스터디: StudyIcon,
+  프로젝트: ProjectIcon,
+} as const;
+
+const toWeeksLabel = (startDate: string, endDate: string) => {
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const diffDays = Math.max(0, Math.ceil((end.getTime() - start.getTime()) / MILLISECONDS_IN_A_DAY));
+  const weeks = Math.max(1, Math.ceil(diffDays / 7));
+  return `${weeks}주`;
+};
+
+export function PendingGatheringCard({ application, gathering }: PendingGatheringCardProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const gatheringId = application.gathering.id;
+  const applicationId = application.id;
+
+  const { mutate, isPending } = useDeleteApplication(gatheringId, applicationId, {
+    onSuccess: () => {
+      setIsModalOpen(false);
+    },
+  });
+
+  const totalWeeksLabel = toWeeksLabel(gathering.startDate, gathering.endDate);
+  const dateRangeLabel = `${formatDate(gathering.startDate)} ~ ${formatDate(gathering.endDate)}`;
+  const hashtagLabel = gathering.tags.map((t) => `#${t}`).join(' ');
+
+  return (
+    <>
+      <GatheringCard className='shadow-01 w-full'>
+        <GatheringCard.Header className='items-center'>
+          <Tag
+            variant='category'
+            icon={(() => {
+              const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] || ProjectIcon;
+              return <Icon size={14} className='text-blue-300' />;
+            })()}
+            label={gathering.type}
+            sublabel={gathering.categories.join(', ')}
+          />
+        </GatheringCard.Header>
+        <GatheringCard.Body className='gap-0'>
+          {hashtagLabel.length > 0 && <p className='text-small-02-r text-gray-500'>{hashtagLabel}</p>}
+          <p className='md:text-body-01-b text-body-02-b text-gray-900'>{gathering.title}</p>
+
+          <div className='md:text-small-01-r text-small-02-r mt-2 flex flex-wrap items-center gap-2 text-gray-600'>
+            <div className='flex items-center gap-1.5'>
+              <CalendarIcon size={16} className='text-gray-600' />
+              <span>{dateRangeLabel}</span>
+            </div>
+            <div className='flex items-center gap-1.5'>
+              <span>・ {totalWeeksLabel}</span>
+            </div>
+            <div className='flex items-center gap-2'>
+              <PersonIcon size={16} className='text-gray-600' />
+              <span>
+                {gathering.currentMembers}
+                <span className='text-gray-400'>/{gathering.maxMembers}</span>
+              </span>
+            </div>
+          </div>
+        </GatheringCard.Body>
+        <GatheringCard.Footer className='mt-4 items-center'>
+          <Button
+            variant='cancel'
+            size='cancel'
+            className='w-full'
+            type='button'
+            onClick={() => setIsModalOpen(true)}
+            disabled={isPending}
+          >
+            {isPending ? '처리 중…' : '참여 취소하기'}
+          </Button>
+        </GatheringCard.Footer>
+      </GatheringCard>
+
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <Modal.Header>
+          <h2 className='text-body-01-b text-gray-900'>참여 신청을 취소할까요?</h2>
+        </Modal.Header>
+        <Modal.Body>
+          <p className='text-body-02-r text-gray-600'>
+            취소하면 이 모임의 대기 목록에서 제거되며, 다시 참여하려면 신청해야 합니다.
+          </p>
+        </Modal.Body>
+        <Modal.Footer className='flex flex-wrap justify-end gap-2'>
+          <Button
+            variant='cancel'
+            size='login-sm'
+            type='button'
+            className='w-auto min-w-20 px-4'
+            onClick={() => setIsModalOpen(false)}
+            disabled={isPending}
+          >
+            닫기
+          </Button>
+          <Button
+            variant='participation'
+            size='participation-sm'
+            type='button'
+            className='w-auto max-w-full min-w-24 px-5'
+            disabled={isPending}
+            onClick={() => mutate()}
+          >
+            {isPending ? '처리 중…' : '취소하기'}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/src/app/my/_components/PendingGatheringsSection/index.tsx
+++ b/src/app/my/_components/PendingGatheringsSection/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useQueries, useSuspenseQuery } from '@tanstack/react-query';
 
@@ -10,11 +10,11 @@ import { gatheringQueries } from '@/api/gatherings/queries';
 import { Pagination } from '@/components/ui/Pagination';
 import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
 import { cn } from '@/lib/cn';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 
 import { PendingGatheringCard } from './PendingGatheringCard';
 
 import type { MyApplication } from '@/api/applications/types';
-
 import type { PendingGatheringSort } from '../../_constants';
 
 interface PendingGatheringsSectionProps {
@@ -31,30 +31,25 @@ const sortPendingApplications = (applications: MyApplication[], sort: PendingGat
   return next;
 };
 
-const PendingGatheringRowSkeleton = () => (
-  <div className='bg-gray-0 border-gray-150 h-72 w-full animate-pulse rounded-lg border' aria-hidden />
-);
+function PendingGatheringRowSkeleton() {
+  return <div className='bg-gray-0 border-gray-150 h-72 w-full animate-pulse rounded-lg border' aria-hidden />;
+}
 
-const PendingGatheringRowError = ({ message }: { message: string }) => (
-  <div
-    className='border-gray-150 text-small-01-r bg-gray-0 flex min-h-24 items-center justify-center rounded-lg border px-4 py-6 text-gray-600'
-    role='status'
-  >
-    {message}
-  </div>
-);
-
-const LG_BREAKPOINT_MEDIA_QUERY = '(min-width: 1024px)';
-const PAGE_SIZE_TWO_COLUMN = 6;
-const PAGE_SIZE_ONE_COLUMN = 5;
+function PendingGatheringRowError({ message }: { message: string }) {
+  return (
+    <div
+      className='border-gray-150 text-small-01-r bg-gray-0 flex min-h-24 items-center justify-center rounded-lg border px-4 py-6 text-gray-600'
+      role='status'
+    >
+      {message}
+    </div>
+  );
+}
 
 export function PendingGatheringsSection({ pendingSort }: PendingGatheringsSectionProps) {
   const { data: myList } = useSuspenseQuery(applicationQueries.myList());
   const [currentPage, setCurrentPage] = useState(1);
-  const [isTwoColumnLayout, setIsTwoColumnLayout] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia(LG_BREAKPOINT_MEDIA_QUERY).matches;
-  });
+  const isTwoColumnLayout = useMediaQuery('(min-width: 1024px)');
 
   const pendingApplications = useMemo(
     () => myList.applications.filter((a) => a?.status === 'PENDING' && typeof a?.gathering?.id === 'number'),
@@ -68,17 +63,7 @@ export function PendingGatheringsSection({ pendingSort }: PendingGatheringsSecti
     [pendingApplications, pendingSort],
   );
 
-  useEffect(() => {
-    const media = window.matchMedia(LG_BREAKPOINT_MEDIA_QUERY);
-
-    const handleChange = () => setIsTwoColumnLayout(media.matches);
-    media.addEventListener('change', handleChange);
-    return () => {
-      media.removeEventListener('change', handleChange);
-    };
-  }, []);
-
-  const pageSize = isTwoColumnLayout ? PAGE_SIZE_TWO_COLUMN : PAGE_SIZE_ONE_COLUMN;
+  const pageSize = isTwoColumnLayout ? 6 : 5;
   const totalPages = Math.max(1, Math.ceil(sortedApplications.length / pageSize));
   const effectivePage = Math.min(currentPage, totalPages);
 

--- a/src/app/my/_components/PendingGatheringsSection/index.tsx
+++ b/src/app/my/_components/PendingGatheringsSection/index.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+
+import { useQueries, useSuspenseQuery } from '@tanstack/react-query';
+
+import { applicationQueries } from '@/api/applications/queries';
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { Pagination } from '@/components/ui/Pagination';
+import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
+import { cn } from '@/lib/cn';
+
+import { PendingGatheringCard } from './PendingGatheringCard';
+
+import type { MyApplication } from '@/api/applications/types';
+
+import type { PendingGatheringSort } from '../../_constants';
+
+interface PendingGatheringsSectionProps {
+  pendingSort: PendingGatheringSort;
+}
+
+const sortPendingApplications = (applications: MyApplication[], sort: PendingGatheringSort): MyApplication[] => {
+  const next = [...applications];
+  next.sort((a, b) => {
+    const ta = new Date(a.createdAt).getTime();
+    const tb = new Date(b.createdAt).getTime();
+    return sort === 'latest' ? tb - ta : ta - tb;
+  });
+  return next;
+};
+
+const PendingGatheringRowSkeleton = () => (
+  <div className='bg-gray-0 border-gray-150 h-72 w-full animate-pulse rounded-lg border' aria-hidden />
+);
+
+const PendingGatheringRowError = ({ message }: { message: string }) => (
+  <div
+    className='border-gray-150 text-small-01-r bg-gray-0 flex min-h-24 items-center justify-center rounded-lg border px-4 py-6 text-gray-600'
+    role='status'
+  >
+    {message}
+  </div>
+);
+
+const LG_BREAKPOINT_MEDIA_QUERY = '(min-width: 1024px)';
+const PAGE_SIZE_TWO_COLUMN = 6;
+const PAGE_SIZE_ONE_COLUMN = 5;
+
+export function PendingGatheringsSection({ pendingSort }: PendingGatheringsSectionProps) {
+  const { data: myList } = useSuspenseQuery(applicationQueries.myList());
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isTwoColumnLayout, setIsTwoColumnLayout] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(LG_BREAKPOINT_MEDIA_QUERY).matches;
+  });
+
+  const pendingApplications = useMemo(
+    () => myList.applications.filter((a) => a?.status === 'PENDING' && typeof a?.gathering?.id === 'number'),
+    [myList.applications],
+  );
+
+  const totalCount = pendingApplications.length;
+
+  const sortedApplications = useMemo(
+    () => sortPendingApplications(pendingApplications, pendingSort),
+    [pendingApplications, pendingSort],
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(LG_BREAKPOINT_MEDIA_QUERY);
+
+    const handleChange = () => setIsTwoColumnLayout(media.matches);
+    media.addEventListener('change', handleChange);
+    return () => {
+      media.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const pageSize = isTwoColumnLayout ? PAGE_SIZE_TWO_COLUMN : PAGE_SIZE_ONE_COLUMN;
+  const totalPages = Math.max(1, Math.ceil(sortedApplications.length / pageSize));
+  const effectivePage = Math.min(currentPage, totalPages);
+
+  const pagedApplications = useMemo(() => {
+    const startIndex = (effectivePage - 1) * pageSize;
+    return sortedApplications.slice(startIndex, startIndex + pageSize);
+  }, [effectivePage, pageSize, sortedApplications]);
+
+  const uniqueGatheringIds = useMemo(
+    () => [...new Set(pendingApplications.map((a) => a.gathering.id))],
+    [pendingApplications],
+  );
+
+  const detailQueries = useQueries({
+    queries: uniqueGatheringIds.map((id) => ({
+      ...gatheringQueries.detail(id),
+    })),
+  });
+
+  const gatheringIdToQueryIndex = useMemo(() => {
+    const map = new Map<number, number>();
+    uniqueGatheringIds.forEach((id, index) => {
+      map.set(id, index);
+    });
+    return map;
+  }, [uniqueGatheringIds]);
+
+  const sortHref = (sort: PendingGatheringSort) => `/my?tab=pending-gatherings&pendingSort=${sort}`;
+
+  return (
+    <div className='mt-8 flex flex-col md:mt-10'>
+      <div className='mb-10 flex flex-col md:mb-12'>
+        <div className='mb-5.5 flex items-center gap-4 md:mb-4'>
+          <h2 className='text-body-01-b md:text-h3-b text-gray-900'>대기중</h2>
+          <span className='text-small-02-r md:text-body-01-r text-gray-500'>총 {totalCount}건</span>
+        </div>
+
+        <div className='flex items-center gap-2 md:gap-4'>
+          <Link
+            href={sortHref('latest')}
+            replace
+            scroll={false}
+            className={cn(
+              'md:text-body-02-r text-small-02-r flex items-center text-gray-500',
+              pendingSort === 'latest' && 'md:text-body-02-r text-small-02-r font-semibold text-gray-800',
+            )}
+          >
+            <CheckIcon size={16} className={cn('md:size-6', !(pendingSort === 'latest') && 'hidden')} />
+            최신순
+          </Link>
+          <span className='md:text-body-02-r text-small-02-r text-gray-500'>|</span>
+          <Link
+            href={sortHref('oldest')}
+            replace
+            scroll={false}
+            className={cn(
+              'md:text-body-02-r text-small-02-r flex items-center text-gray-500',
+              pendingSort === 'oldest' && 'md:text-body-02-r text-small-02-r font-semibold text-gray-800',
+            )}
+          >
+            <CheckIcon size={16} className={cn('md:size-6', !(pendingSort === 'oldest') && 'hidden')} />
+            과거순
+          </Link>
+        </div>
+      </div>
+
+      {sortedApplications.length === 0 ? (
+        <div className='flex flex-col items-center justify-center gap-2 py-12 text-center'>
+          <p className='text-body-01-m text-gray-800'>대기 중인 모임이 없습니다</p>
+          <p className='text-body-02-r text-gray-500'>모임에 참여 신청하면 이곳에 표시됩니다.</p>
+        </div>
+      ) : (
+        <>
+          <ul className='grid grid-cols-1 gap-4 md:gap-6 lg:grid-cols-2'>
+            {pagedApplications.map((application) => {
+              const qIndex = gatheringIdToQueryIndex.get(application.gathering.id);
+              const query = qIndex !== undefined ? detailQueries[qIndex] : undefined;
+
+              return (
+                <li key={application.id}>
+                  {!query || query.isPending ? (
+                    <PendingGatheringRowSkeleton />
+                  ) : query.isError ? (
+                    <PendingGatheringRowError message='모임 정보를 불러오지 못했습니다.' />
+                  ) : query.data ? (
+                    <PendingGatheringCard application={application} gathering={query.data} />
+                  ) : (
+                    <PendingGatheringRowError message='모임 정보를 불러오지 못했습니다.' />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          {totalPages > 1 && (
+            <Pagination
+              variant='numbered'
+              currentPage={effectivePage}
+              totalPages={totalPages}
+              onPageChange={setCurrentPage}
+              className='mt-12'
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/my/_components/ProfileSidebar/index.tsx
+++ b/src/app/my/_components/ProfileSidebar/index.tsx
@@ -142,7 +142,7 @@ export function ProfileSidebar({ className }: ProfileSidebarProps) {
   return (
     <aside
       className={cn(
-        'border-gray-150 bg-gray-0 w-full rounded-2xl border px-6 py-6 shadow-(--shadow-02) md:max-h-none md:px-7 md:py-8 lg:max-h-none lg:min-h-[915px] lg:max-w-[450px] lg:px-7 lg:py-12',
+        'border-gray-150 bg-gray-0 w-full rounded-2xl border px-6 py-6 shadow-(--shadow-02) md:max-h-[688px] md:px-7 md:py-8 lg:max-h-[915px] lg:max-w-[450px] lg:px-7 lg:py-12',
         className,
       )}
     >

--- a/src/app/my/_constants.ts
+++ b/src/app/my/_constants.ts
@@ -8,3 +8,13 @@ export const MY_PAGE_TAB_ITEMS = [
 
 export type MyPageTab = (typeof MY_PAGE_TAB_ITEMS)[number]['key'];
 export const DEFAULT_TAB: MyPageTab = 'my-gatherings';
+
+/** 대기중인 모임 탭 — 신청일시 정렬 (URL `pendingSort`) */
+export const PENDING_GATHERING_SORT_VALUES = ['latest', 'oldest'] as const;
+export type PendingGatheringSort = (typeof PENDING_GATHERING_SORT_VALUES)[number];
+export const DEFAULT_PENDING_GATHERING_SORT: PendingGatheringSort = 'latest';
+
+export const parsePendingGatheringSort = (value: string | undefined): PendingGatheringSort => {
+  if (value === 'latest' || value === 'oldest') return value;
+  return DEFAULT_PENDING_GATHERING_SORT;
+};

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,18 +1,19 @@
 import { MyPageContent } from './_components/MyPageContent';
 import { MyPageTabs } from './_components/MyPageTabs';
 import { ProfileSidebar, ProfileSidebarSkeleton } from './_components/ProfileSidebar';
-import { DEFAULT_TAB } from './_constants';
+import { DEFAULT_TAB, parsePendingGatheringSort } from './_constants';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 
-import type { MyPageTab } from './_constants';
+import type { MyPageTab, PendingGatheringSort } from './_constants';
 
 interface MyPageProps {
-  searchParams: Promise<{ tab?: MyPageTab }>;
+  searchParams: Promise<{ tab?: MyPageTab; pendingSort?: string }>;
 }
 
 export default async function MyPage({ searchParams }: MyPageProps) {
-  const { tab } = await searchParams;
+  const { tab, pendingSort: pendingSortRaw } = await searchParams;
   const activeTab = tab ?? DEFAULT_TAB;
+  const pendingSort: PendingGatheringSort = parsePendingGatheringSort(pendingSortRaw);
 
   return (
     <main className='min-h-screen bg-gray-50'>
@@ -27,8 +28,8 @@ export default async function MyPage({ searchParams }: MyPageProps) {
           </SuspenseBoundary>
 
           <div className='min-w-0 flex-1'>
-            <MyPageTabs activeTab={activeTab} />
-            <MyPageContent activeTab={activeTab} />
+            <MyPageTabs activeTab={activeTab} pendingSort={pendingSort} />
+            <MyPageContent activeTab={activeTab} pendingSort={pendingSort} />
           </div>
         </div>
       </div>

--- a/src/components/landing/landingConstants.ts
+++ b/src/components/landing/landingConstants.ts
@@ -27,10 +27,10 @@ export const LANDING_IMAGES = {
   bottomImagePC: encodePublicImage('bottom', 'bottom CTA-PC.png'),
   bottomImageTablet: encodePublicImage('bottom', 'bottom CTA.png'),
   bottomImageMobile: encodePublicImage('bottom', 'bottom CTA-Mobile.png'),
-  featureTeam: encodePublicImage('featrue', 'feature-team.png'),
-  featureGoal: encodePublicImage('featrue', 'feature-goal.png'),
-  featureAchievement: encodePublicImage('featrue', 'feature-achievement.png'),
-  featureManners: encodePublicImage('featrue', 'feature-manners.png'),
+  featureTeam: encodePublicImage('feature', 'feature-team.png'),
+  featureGoal: encodePublicImage('feature', 'feature-goal.png'),
+  featureAchievement: encodePublicImage('feature', 'feature-achievement.png'),
+  featureManners: encodePublicImage('feature', 'feature-manners.png'),
 } as const;
 
 export interface LandingFeatureItem {

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -17,7 +17,7 @@ export const buttonVariants = cva('cursor-pointer transition-colors disabled:cur
       'file-upload': 'rounded-lg text-body-01-sb text-gray-800 border border-gray-300',
       'participation-outline':
         'rounded-lg text-body-01-sb text-blue-400 border-gradient-primary enabled:hover:bg-gradient-primary enabled:hover:text-white disabled:bg-gray-100 disabled:text-gray-600 disabled:border disabled:border-gray-150 disabled:before:hidden ',
-      cancel: 'rounded-lg text-body-01-sb text-blue-300 bg-blue-50 aria-pressed:bg-blue-100',
+      cancel: 'rounded-lg md:text-body-01-sb text-small-01-sb text-blue-300 bg-blue-50 aria-pressed:bg-blue-100',
       'mypage-edit':
         'rounded-lg text-small-01-m lg:text-body-01-m text-gray-600 bg-gray-100 border border-gray-150 md:text-body-02-m',
       'icon-hand': 'rounded-lg flex items-center justify-center text-gray-400 bg-gray-150',
@@ -58,7 +58,7 @@ export const buttonVariants = cva('cursor-pointer transition-colors disabled:cur
       participation: 'h-18 w-[447px]',
       'file-upload': 'h-12 w-[122px]',
       'action-sm': 'h-20 w-75',
-      cancel: 'h-18 w-[527px]',
+      cancel: 'h-18',
       'mypage-edit': 'lg:h-[60px] lg:w-[394px] md:w-[200px] md:h-[50px] w-[295px] h-[48px]',
       'icon-hand': 'h-12 w-12',
       tag: 'h-12 w-12',

--- a/src/mocks/handlers/applications.ts
+++ b/src/mocks/handlers/applications.ts
@@ -17,143 +17,72 @@ const mockApplicationListResponse: ApplicationListResponse = {
     {
       id: 1,
       applicant: {
-        id: 20,
-        nickname: '이수정',
-        profileImage: 'https://avatars.githubusercontent.com/u/20?v=4',
-        reputationScore: 70,
+        id: 1,
+        nickname: '김선장',
+        profileImage: 'https://example.com/profile.jpg',
+        reputationScore: 36.5,
         reviewSummary: {
           reviewCount: 12,
-          topTags: ['불꽃 메이트', '소통이 좋아요'],
+          topTags: ['성실해요', '소통이 좋아요'],
         },
-        recentReviews: [{ id: 1, comment: '항상 열심히 참여해주셨어요!', tags: ['성실해요', '소통이 좋아요'] }],
+        recentReviews: [
+          {
+            id: 1,
+            comment: '항상 열심히 참여해주셨어요!',
+            tags: ['성실해요', '소통이 좋아요'],
+          },
+          {
+            id: 2,
+            comment: '시간 약속을 잘 지켜요',
+            tags: ['시간을 잘 지켜요'],
+          },
+        ],
       },
-      personalGoal: '비전공생으로 피그마 기초를 마스터하는 걸 목표로 합니다.',
-      selfIntroduction: '디자인 분야로 직무 전환을 준비하는 취업 준비생입니다. 열심히 활동하겠습니다.',
+      personalGoal: 'React 기초 완벽 이해',
+      selfIntroduction: '안녕하세요! React 기초를 배우고 싶어서 신청했습니다. 잘 부탁드립니다.',
+      status: 'PENDING', // 'PENDING' | 'ACCEPTED' | 'REJECTED'
+      createdAt: '2026-03-24T18:24:00Z',
+    },
+  ],
+};
+
+const mockMyApplicationListResponse: MyApplicationListResponse = {
+  applications: [
+    {
+      id: 101,
+      gathering: {
+        id: 1,
+        title: 'React 19 & Next.js 스터디',
+        type: '스터디',
+        status: 'RECRUITING',
+      },
+      personalGoal: 'React 기초 완벽 이해',
       status: 'PENDING',
       createdAt: '2026-03-24T18:24:00Z',
     },
     {
-      id: 2,
-      applicant: {
-        id: 21,
-        nickname: '김민수',
-        profileImage: 'https://avatars.githubusercontent.com/u/21?v=4',
-        reputationScore: 80,
-        reviewSummary: {
-          reviewCount: 8,
-          topTags: ['불꽃 메이트'],
-        },
-        recentReviews: [{ id: 3, comment: '시간 약속을 잘 지켜요', tags: ['시간을 잘 지켜요'] }],
+      id: 102,
+      gathering: {
+        id: 2,
+        title: 'SaaS 사이드 프로젝트 팀 모집',
+        type: '프로젝트',
+        status: 'RECRUITING',
       },
-      personalGoal: 'UI/UX 디자인 포트폴리오를 완성하고 싶습니다.',
-      selfIntroduction: '현직 프론트엔드 개발자이고, 디자인 역량을 키우고 싶어서 신청합니다.',
+      personalGoal: '풀스택 경험 쌓기',
       status: 'PENDING',
-      createdAt: '2026-03-25T10:00:00Z',
+      createdAt: '2026-03-20T12:00:00Z',
     },
     {
-      id: 3,
-      applicant: {
-        id: 22,
-        nickname: '박지영',
-        profileImage: 'https://avatars.githubusercontent.com/u/22?v=4',
-        reputationScore: 55,
-        reviewSummary: {
-          reviewCount: 5,
-          topTags: ['성실해요'],
-        },
-        recentReviews: [],
+      id: 103,
+      gathering: {
+        id: 4,
+        title: '매일 영어 회화 30분 챌린지',
+        type: '스터디',
+        status: 'RECRUITING',
       },
-      personalGoal: '피그마 기본 기능을 익혀서 실무에 바로 적용하고 싶습니다.',
+      personalGoal: '스피킹 루틴 만들기',
       status: 'PENDING',
-      createdAt: '2026-03-25T14:30:00Z',
-    },
-    {
-      id: 4,
-      applicant: {
-        id: 23,
-        nickname: '최현우',
-        profileImage: 'https://avatars.githubusercontent.com/u/23?v=4',
-        reputationScore: 92,
-        reviewSummary: {
-          reviewCount: 20,
-          topTags: ['불꽃 메이트', '잘 도와줘요'],
-        },
-        recentReviews: [{ id: 4, comment: '덕분에 많이 배웠습니다.', tags: ['잘 도와줘요', '다시 함께하고 싶어요'] }],
-      },
-      personalGoal: '디자인 시스템 구축 경험을 쌓고 싶습니다.',
-      selfIntroduction: 'IT 스타트업에서 PM으로 일하고 있습니다.',
-      status: 'PENDING',
-      createdAt: '2026-03-26T09:15:00Z',
-    },
-    {
-      id: 5,
-      applicant: {
-        id: 24,
-        nickname: '정다은',
-        profileImage: 'https://avatars.githubusercontent.com/u/24?v=4',
-        reputationScore: 45,
-        reviewSummary: {
-          reviewCount: 3,
-          topTags: ['소통이 좋아요'],
-        },
-        recentReviews: [],
-      },
-      personalGoal: '웹 디자인 기초부터 차근차근 배우고 싶어요.',
-      selfIntroduction: '디자인 전공 대학생입니다.',
-      status: 'PENDING',
-      createdAt: '2026-03-26T16:00:00Z',
-    },
-    {
-      id: 6,
-      applicant: {
-        id: 25,
-        nickname: '한승민',
-        profileImage: 'https://avatars.githubusercontent.com/u/25?v=4',
-        reputationScore: 63,
-        reviewSummary: {
-          reviewCount: 7,
-          topTags: ['시간을 잘 지켜요'],
-        },
-        recentReviews: [],
-      },
-      personalGoal: '피그마 플러그인 개발까지 도전해보고 싶습니다.',
-      status: 'PENDING',
-      createdAt: '2026-03-27T11:45:00Z',
-    },
-    {
-      id: 7,
-      applicant: {
-        id: 26,
-        nickname: '윤서아',
-        profileImage: '',
-        reputationScore: 38,
-        reviewSummary: {
-          reviewCount: 2,
-          topTags: ['성실해요'],
-        },
-        recentReviews: [],
-      },
-      personalGoal: '협업 도구로서의 피그마 활용법을 배우고 싶습니다.',
-      selfIntroduction: '백엔드 개발자인데 디자이너와 소통을 잘 하고 싶어서 신청합니다.',
-      status: 'PENDING',
-      createdAt: '2026-03-28T08:30:00Z',
-    },
-    {
-      id: 8,
-      applicant: {
-        id: 27,
-        nickname: '송태호',
-        profileImage: 'https://avatars.githubusercontent.com/u/27?v=4',
-        reputationScore: 75,
-        reviewSummary: {
-          reviewCount: 15,
-          topTags: ['불꽃 메이트', '성실해요'],
-        },
-        recentReviews: [{ id: 5, comment: '리더십이 좋아요!', tags: ['성실해요', '잘 도와줘요'] }],
-      },
-      personalGoal: '디자인 툴 숙련도를 높여서 1인 개발에 활용하고 싶습니다.',
-      status: 'PENDING',
-      createdAt: '2026-03-28T20:00:00Z',
+      createdAt: '2026-03-18T09:00:00Z',
     },
   ],
 };
@@ -205,36 +134,20 @@ export const applicationsHandlers = [
     await delay(MOCK_DELAY);
     const applicationId = Number(params.applicationId);
 
-    const targetApplication = mockApplicationListResponse.applications.find((app) => app.id === applicationId);
+    const targetApplication = mockMyApplicationListResponse.applications.find((app) => app.id === applicationId);
 
     if (targetApplication) {
-      mockApplicationListResponse.applications = mockApplicationListResponse.applications.filter(
+      mockMyApplicationListResponse.applications = mockMyApplicationListResponse.applications.filter(
         (app) => app.id !== applicationId,
       );
     }
 
-    return HttpResponse.json(createApiResponse(mockApplicationListResponse));
+    return HttpResponse.json(createApiResponse(null));
   }),
 
   /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
   http.get(`/api/v1/users/me/applications`, async () => {
     await delay(MOCK_DELAY);
-    const myApplicationListResponse: MyApplicationListResponse = {
-      applications: [
-        {
-          id: 101,
-          gathering: {
-            id: 1,
-            title: '피그마 기초 스터디',
-            type: 'STUDY',
-            status: 'RECRUITING',
-          },
-          personalGoal: 'React 기초 완벽 이해',
-          status: 'PENDING',
-          createdAt: '2026-03-24T18:24:00Z',
-        },
-      ],
-    };
-    return HttpResponse.json(createApiResponse(myApplicationListResponse));
+    return HttpResponse.json(createApiResponse(mockMyApplicationListResponse));
   }),
 ];


### PR DESCRIPTION
## ❓ 이슈

- close #192 

## ✍️ Description

- 마이페이지 대기중인 모임 탭에서 내 신청 목록 중 PENDING만 노출되도록 구현
- 카드에 필요한 정보(카테고리/기간/인원/태그 등)를 gathering.id로 상세 조회(N+1) 해서 보강
- 카드 내 “참여 취소하기” → 확인 모달 → 신청 취소 mutation 플로우 추가
- 정렬(최신순/과거순) 지원 및 URL 파라미터(pendingSort)로 유지
- numbered 페이지네이션 추가: 2열(lg) 6개/1열 5개 기준

## 📸 스크린샷 (UI 변경 시)
<img width="1821" height="711" alt="image" src="https://github.com/user-attachments/assets/0a6061bc-8ed2-4fa0-bfc5-e0b3efd8b55e" />
<img width="927" height="753" alt="image" src="https://github.com/user-attachments/assets/f6736f74-5218-4780-adde-19b2e9d0a03c" />
<img width="468" height="651" alt="image" src="https://github.com/user-attachments/assets/dd4d98eb-244c-42e4-9cda-4f0068007a6c" />


## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes

참여 취소하기 -> 확인 모달 플로우 디자인 시안은 임시로 넣었습니다.
추후에 디자인 시 변경예정
