### PR TITLE
[SM-106] feat: 찜 기능 구현 및 메인페이지 데이터 blocking -> 스트리밍으로 리팩토링 + 스켈레톤

### DIFF
--- a/src/api/likes/hooks.tsx
+++ b/src/api/likes/hooks.tsx
@@ -9,7 +9,7 @@ import { useToastStore } from '@/components/ui/Toast/useToastStore';
 
 import { likeQueries, useAddLike, useRemoveLike } from './queries';
 
-export function useLikeToggle(gatheringId: number) {
+export const useLikeToggle = (gatheringId: number) => {
   const { isLoggedIn } = useAuth();
   const overlay = useOverlay();
   const { showToast } = useToastStore();
@@ -51,4 +51,4 @@ export function useLikeToggle(gatheringId: number) {
     toggleLike,
     isPending: isAdding || isRemoving,
   };
-}
+};

--- a/src/api/likes/hooks.tsx
+++ b/src/api/likes/hooks.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { AuthModal } from '@/components/AuthModal';
+import { useAuth } from '@/hooks/useAuth';
+import { useOverlay } from '@/hooks/useOverlay';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
+
+import { likeQueries, useAddLike, useRemoveLike } from './queries';
+
+export function useLikeToggle(gatheringId: number) {
+  const { isLoggedIn } = useAuth();
+  const overlay = useOverlay();
+  const { showToast } = useToastStore();
+
+  const { data: likedIds = [] } = useQuery({
+    ...likeQueries.myIds(),
+    enabled: isLoggedIn,
+  });
+
+  const isLiked = likedIds.includes(gatheringId);
+
+  const { mutate: addLike, isPending: isAdding } = useAddLike();
+  const { mutate: removeLike, isPending: isRemoving } = useRemoveLike();
+
+  const toggleLike = async () => {
+    if (!isLoggedIn) {
+      const isLoginSuccessful = await overlay.open(({ isOpen, close }) => (
+        <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />
+      ));
+
+      if (!isLoginSuccessful) return;
+
+      addLike(gatheringId);
+      showToast({ variant: 'success', title: '관심 모임에 추가되었습니다.' });
+      return;
+    }
+
+    if (isLiked) {
+      removeLike(gatheringId);
+      showToast({ variant: 'success', title: '관심 모임에서 제외되었습니다.' });
+    } else {
+      addLike(gatheringId);
+      showToast({ variant: 'success', title: '관심 모임에 추가되었습니다.' });
+    }
+  };
+
+  return {
+    isLiked,
+    toggleLike,
+    isPending: isAdding || isRemoving,
+  };
+}

--- a/src/api/likes/queries.ts
+++ b/src/api/likes/queries.ts
@@ -28,28 +28,69 @@ export const likeQueries = {
 };
 
 /** POST /gatherings/:gatheringId/likes — 찜 추가 */
-export const useAddLike = (options?: UseMutationOptions<void, Error, number, unknown>) => {
+export const useAddLike = (options?: UseMutationOptions<void, Error, number, { previousIds?: number[] }>) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (gatheringId: number) => addLike(gatheringId),
     ...options,
-    onSuccess: (data, variables, onMutateResult, context) => {
+    onMutate: async (gatheringId) => {
+      await queryClient.cancelQueries({ queryKey: likeKeys.all });
+
+      const previousIds = queryClient.getQueryData<number[]>(likeKeys.myIds());
+
+      if (previousIds) {
+        queryClient.setQueryData<number[]>(likeKeys.myIds(), Array.from(new Set([...previousIds, gatheringId])));
+      }
+
+      return { previousIds };
+    },
+    onError: (err, variables, onMutateResult, context) => {
+      if (onMutateResult?.previousIds) {
+        queryClient.setQueryData(likeKeys.myIds(), onMutateResult.previousIds);
+      }
+      options?.onError?.(err, variables, onMutateResult, context);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: likeKeys.all });
+    },
+    onSuccess: (data, variables, onMutateResult, context) => {
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });
 };
 
 /** DELETE /gatherings/:gatheringId/likes — 찜 취소 */
-export const useRemoveLike = (options?: UseMutationOptions<void, Error, number, unknown>) => {
+export const useRemoveLike = (options?: UseMutationOptions<void, Error, number, { previousIds?: number[] }>) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (gatheringId: number) => removeLike(gatheringId),
     ...options,
-    onSuccess: (data, variables, onMutateResult, context) => {
+    onMutate: async (gatheringId) => {
+      await queryClient.cancelQueries({ queryKey: likeKeys.all });
+
+      const previousIds = queryClient.getQueryData<number[]>(likeKeys.myIds());
+
+      if (previousIds) {
+        queryClient.setQueryData<number[]>(
+          likeKeys.myIds(),
+          previousIds.filter((id) => id !== gatheringId),
+        );
+      }
+
+      return { previousIds };
+    },
+    onError: (err, variables, onMutateResult, context) => {
+      if (onMutateResult?.previousIds) {
+        queryClient.setQueryData(likeKeys.myIds(), onMutateResult.previousIds);
+      }
+      options?.onError?.(err, variables, onMutateResult, context);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: likeKeys.all });
+    },
+    onSuccess: (data, variables, onMutateResult, context) => {
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/app/main/components/GatheringSectionSkeleton/index.tsx
+++ b/src/app/main/components/GatheringSectionSkeleton/index.tsx
@@ -1,0 +1,38 @@
+export function GatheringSectionSkeleton() {
+  return (
+    <div className='flex flex-col gap-6'>
+      <div className='h-8 w-48 animate-pulse rounded-md bg-gray-200' />
+
+      <div className='grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className='border-gray-150 bg-gray-0 shadow-01 flex h-full flex-col rounded-2xl border p-7'>
+            <div className='mb-6 flex items-center justify-between'>
+              <div className='h-8 w-24 animate-pulse rounded-lg bg-gray-100' />
+              <div className='h-5 w-12 animate-pulse rounded bg-gray-100' />
+            </div>
+
+            <div className='mb-6 flex flex-1 flex-col gap-3'>
+              <div className='flex gap-2'>
+                <div className='h-4 w-12 animate-pulse rounded bg-gray-100' />
+                <div className='h-4 w-12 animate-pulse rounded bg-gray-100' />
+              </div>
+              <div className='space-y-2'>
+                <div className='h-6 w-3/4 animate-pulse rounded bg-gray-200' />
+                <div className='h-4 w-full animate-pulse rounded bg-gray-100' />
+              </div>
+              <div className='flex gap-2 pt-2'>
+                <div className='h-6 w-16 animate-pulse rounded-full bg-gray-100' />
+                <div className='h-6 w-20 animate-pulse rounded-full bg-gray-100' />
+              </div>
+            </div>
+
+            <div className='border-gray-150 mt-auto flex items-center gap-2 border-t pt-4'>
+              <div className='h-11 w-11 animate-pulse rounded-full bg-gray-100' />
+              <div className='h-11 flex-1 animate-pulse rounded-lg bg-gray-100' />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/main/components/MainGatheringContainer.tsx
+++ b/src/app/main/components/MainGatheringContainer.tsx
@@ -1,0 +1,25 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { getQueryClient } from '@/lib/getQueryClient';
+
+import { DeadlineGatheringSection } from './DeadlineGatheringSection';
+import { LatestGatheringSection } from './LatestGatheringSection';
+import { PopularGatheringSection } from './PopularGatheringSection';
+import { MAX_GATHERING_LIMIT } from '../constant/constant';
+
+export async function MainGatheringContainer() {
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery(gatheringQueries.main({ limit: MAX_GATHERING_LIMIT }));
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className='flex flex-col gap-15 md:gap-26 lg:gap-30'>
+        <PopularGatheringSection />
+        <DeadlineGatheringSection />
+        <LatestGatheringSection />
+      </div>
+    </HydrationBoundary>
+  );
+}

--- a/src/app/main/components/MainGatheringContainer/index.tsx
+++ b/src/app/main/components/MainGatheringContainer/index.tsx
@@ -3,10 +3,10 @@ import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { getQueryClient } from '@/lib/getQueryClient';
 
-import { DeadlineGatheringSection } from './DeadlineGatheringSection';
-import { LatestGatheringSection } from './LatestGatheringSection';
-import { PopularGatheringSection } from './PopularGatheringSection';
-import { MAX_GATHERING_LIMIT } from '../constant/constant';
+import { DeadlineGatheringSection } from '../DeadlineGatheringSection';
+import { LatestGatheringSection } from '../LatestGatheringSection';
+import { PopularGatheringSection } from '../PopularGatheringSection';
+import { MAX_GATHERING_LIMIT } from '../../constant/constant';
 
 export async function MainGatheringContainer() {
   const queryClient = getQueryClient();

--- a/src/app/main/components/MainGatheringStreaming/index.tsx
+++ b/src/app/main/components/MainGatheringStreaming/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+import { GatheringSectionSkeleton } from '@/app/main/components/GatheringSectionSkeleton';
+
+interface MainGatheringStreamingProps {
+  children: ReactNode;
+}
+
+export function MainGatheringStreaming({ children }: MainGatheringStreamingProps) {
+  return (
+    <SuspenseBoundary
+      pendingFallback={<GatheringSectionSkeleton />}
+      errorFallback={(_error, reset) => (
+        <div className='flex flex-col items-center justify-center gap-4 py-20 text-center'>
+          <p className='text-body-01-m text-gray-500'>모임 목록을 불러오지 못했습니다.</p>
+          <button
+            onClick={reset}
+            className='text-body-02-sb cursor-pointer text-blue-500 underline decoration-1 underline-offset-4 transition-colors hover:text-blue-600'
+          >
+            다시 시도하기
+          </button>
+        </div>
+      )}
+    >
+      {children}
+    </SuspenseBoundary>
+  );
+}

--- a/src/app/main/components/MyGatheringSection/MyGatheringCard/index.tsx
+++ b/src/app/main/components/MyGatheringSection/MyGatheringCard/index.tsx
@@ -34,7 +34,7 @@ export function MyGatheringCard({ gathering, members = [], onClick, className }:
   const dDayText = dDay > 0 ? `D-${dDay}` : dDay === 0 ? 'D-Day' : `D+${Math.abs(dDay)}`;
 
   return (
-    <GatheringCard onClick={onClick} className={cn('w-full cursor-pointer', className)}>
+    <GatheringCard onClick={onClick} className={cn('flex h-full cursor-pointer flex-col', className)}>
       <GatheringCard.Header className='items-center'>
         <Tag
           variant='category'
@@ -47,7 +47,7 @@ export function MyGatheringCard({ gathering, members = [], onClick, className }:
         />
         <AvatarGroup max={4} avatars={members.map((m) => ({ id: m.userId, imageUrl: m.profileImage }))} size='sm' />
       </GatheringCard.Header>
-      <GatheringCard.Body>
+      <GatheringCard.Body className='flex-1'>
         <div className='flex flex-col gap-0.5'>
           <div>
             <div className='flex gap-1'>
@@ -57,7 +57,7 @@ export function MyGatheringCard({ gathering, members = [], onClick, className }:
                 </div>
               ))}
             </div>
-            <div className='text-body-01-b text-gray-900'>{gathering.title}</div>
+            <div className='text-body-01-b line-clamp-2 text-gray-900'>{gathering.title}</div>
           </div>
         </div>
         <div className='mb-1.5 flex gap-1'>
@@ -66,9 +66,9 @@ export function MyGatheringCard({ gathering, members = [], onClick, className }:
             목표 {dDayText}
           </Tag>
         </div>
-        <div className='border-gray-150 mb-4.5 border'></div>
       </GatheringCard.Body>
-      <GatheringCard.Footer className='flex-col gap-1'>
+      <GatheringCard.Footer className='mt-auto flex-col gap-1'>
+        <div className='border-gray-150 my-4 border'></div>
         <ProgressBar value={progressRate} label='달성률' />
       </GatheringCard.Footer>
     </GatheringCard>

--- a/src/app/main/components/MyGatheringSection/index.tsx
+++ b/src/app/main/components/MyGatheringSection/index.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useAuth } from '@/hooks/useAuth';
+import { GatheringSectionSkeleton } from '@/components/GatheringSectionSkeleton';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+import { useAuth } from '@/hooks/useAuth';
+
 import { MyGatheringList } from './MyGatheringList';
 
 export function MyGatheringSection() {
@@ -13,7 +15,8 @@ export function MyGatheringSection() {
 
   return (
     <SuspenseBoundary
-      pendingFallback={<div className='p-4 text-center text-gray-500'>모임을 불러오는 중입니다...</div>}
+      // 🟢 단순 텍스트 대신 새로 만든 고퀄리티 스켈레톤을 적용합니다.
+      pendingFallback={<GatheringSectionSkeleton />}
       errorFallback={(error, reset) => (
         <div className='p-4 text-center text-red-500'>
           <p>모임을 불러올 수 없습니다.</p>

--- a/src/app/main/components/MyGatheringSection/index.tsx
+++ b/src/app/main/components/MyGatheringSection/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { GatheringSectionSkeleton } from '@/components/GatheringSectionSkeleton';
+import { GatheringSectionSkeleton } from '@/app/main/components/GatheringSectionSkeleton';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -15,7 +15,6 @@ export function MyGatheringSection() {
 
   return (
     <SuspenseBoundary
-      // 🟢 단순 텍스트 대신 새로 만든 고퀄리티 스켈레톤을 적용합니다.
       pendingFallback={<GatheringSectionSkeleton />}
       errorFallback={(error, reset) => (
         <div className='p-4 text-center text-red-500'>

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,10 +1,7 @@
-import { Suspense } from 'react';
-
-import { GatheringSectionSkeleton } from '@/app/main/components/GatheringSectionSkeleton';
-
 import { HeroSection } from './components/HeroSection';
-import { MainGatheringContainer } from './components/MainGatheringContainer';
 import { MyGatheringSection } from './components/MyGatheringSection';
+import { MainGatheringContainer } from './components/MainGatheringContainer';
+import { MainGatheringStreaming } from './components/MainGatheringStreaming';
 
 export const revalidate = 3600;
 
@@ -14,9 +11,9 @@ export default async function MainPage() {
       <HeroSection />
       <div className='mx-auto flex w-full max-w-[1920px] flex-col gap-15 px-4 py-10 md:gap-26 md:px-7 md:py-20 lg:gap-30 lg:px-12 lg:py-24 xl:px-20 2xl:px-30'>
         <MyGatheringSection />
-        <Suspense fallback={<GatheringSectionSkeleton />}>
+        <MainGatheringStreaming>
           <MainGatheringContainer />
-        </Suspense>
+        </MainGatheringStreaming>
       </div>
     </>
   );

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 
-import { GatheringSectionSkeleton } from '@/components/GatheringSectionSkeleton';
+import { GatheringSectionSkeleton } from '@/app/main/components/GatheringSectionSkeleton';
 
 import { HeroSection } from './components/HeroSection';
 import { MainGatheringContainer } from './components/MainGatheringContainer';

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,32 +1,22 @@
-import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { Suspense } from 'react';
 
-import { getQueryClient } from '@/lib/getQueryClient';
-import { gatheringQueries } from '@/api/gatherings/queries';
+import { GatheringSectionSkeleton } from '@/components/GatheringSectionSkeleton';
 
 import { HeroSection } from './components/HeroSection';
+import { MainGatheringContainer } from './components/MainGatheringContainer';
 import { MyGatheringSection } from './components/MyGatheringSection';
-import { PopularGatheringSection } from './components/PopularGatheringSection';
-import { DeadlineGatheringSection } from './components/DeadlineGatheringSection';
-import { LatestGatheringSection } from './components/LatestGatheringSection';
-import { MAX_GATHERING_LIMIT } from './constant/constant';
 
 export const revalidate = 3600;
 
 export default async function MainPage() {
-  const queryClient = getQueryClient();
-
-  await queryClient.prefetchQuery(gatheringQueries.main({ limit: MAX_GATHERING_LIMIT }));
-
   return (
     <>
       <HeroSection />
       <div className='mx-auto flex w-full max-w-[1920px] flex-col gap-15 px-4 py-10 md:gap-26 md:px-7 md:py-20 lg:gap-30 lg:px-12 lg:py-24 xl:px-20 2xl:px-30'>
         <MyGatheringSection />
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <PopularGatheringSection />
-          <DeadlineGatheringSection />
-          <LatestGatheringSection />
-        </HydrationBoundary>
+        <Suspense fallback={<GatheringSectionSkeleton />}>
+          <MainGatheringContainer />
+        </Suspense>
       </div>
     </>
   );

--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -66,7 +66,7 @@ export function MainGatheringCard({
   const deadlineLabel = `${toDeadlineDdayLabel(gathering.recruitDeadline)}`;
 
   return (
-    <GatheringCard className={cn('w-full', className)}>
+    <GatheringCard className={cn('flex h-full flex-col', className)}>
       <GatheringCard.Header className='items-center'>
         <Tag
           variant='category'
@@ -84,7 +84,7 @@ export function MainGatheringCard({
           <span className='text-gray-600'>{gathering.maxMembers}</span>
         </div>
       </GatheringCard.Header>
-      <GatheringCard.Body className='mb-6 gap-3'>
+      <GatheringCard.Body className='mb-6 flex-1 gap-3'>
         <div className='flex flex-col gap-0.5'>
           <div className='flex flex-wrap gap-1'>
             {gathering.tags.map((tag) => (
@@ -93,8 +93,8 @@ export function MainGatheringCard({
               </span>
             ))}
           </div>
-          <p className='text-body-01-b text-gray-900'>{gathering.title}</p>
-          <p className='text-small-01-r text-gray-800'>{gathering.shortDescription}</p>
+          <p className='text-body-01-b line-clamp-2 text-gray-900'>{gathering.title}</p>
+          <p className='text-small-01-r line-clamp-1 text-gray-800'>{gathering.shortDescription}</p>
         </div>
         <div className='flex items-center gap-1'>
           <Tag variant='duration'>{totalWeeksLabel}</Tag>
@@ -103,14 +103,18 @@ export function MainGatheringCard({
           </Tag>
         </div>
       </GatheringCard.Body>
-      <GatheringCard.Footer className='border-gray-150 items-center gap-2 border-t pt-4'>
+      <GatheringCard.Footer className='border-gray-150 mt-auto items-center gap-2 border-t pt-4'>
         <Button
           variant='bookmark'
           size='bookmark-sm'
           data-selected={isFavorite}
           aria-label='찜하기'
           aria-pressed={isFavorite}
-          onClick={() => setIsFavorite((prev) => !prev)}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsFavorite((prev) => !prev);
+          }}
         >
           <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
         </Button>

--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { useState } from 'react';
-
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, PersonIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
+import { useLikeToggle } from '@/api/likes/hooks';
 
 import type { GatheringListItem } from '@/api/gatherings/types';
 
@@ -56,11 +55,10 @@ export function MainGatheringCard({
   joinButtonLabel = '참여하기',
   joinButtonClassName,
   isJoinDisabled = false,
-  initialFavorite = false,
   onJoin,
   className,
 }: MainGatheringCardProps) {
-  const [isFavorite, setIsFavorite] = useState(initialFavorite);
+  const { isLiked, toggleLike, isPending } = useLikeToggle(gathering.id);
 
   const totalWeeksLabel = toWeeksLabel(gathering.startDate, gathering.endDate);
   const deadlineLabel = `${toDeadlineDdayLabel(gathering.recruitDeadline)}`;
@@ -107,16 +105,17 @@ export function MainGatheringCard({
         <Button
           variant='bookmark'
           size='bookmark-sm'
-          data-selected={isFavorite}
+          data-selected={isLiked}
           aria-label='찜하기'
-          aria-pressed={isFavorite}
+          aria-pressed={isLiked}
+          disabled={isPending}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            setIsFavorite((prev) => !prev);
+            toggleLike();
           }}
         >
-          <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+          <HeartIcon size={20} variant={isLiked ? 'filled' : 'outline'} />
         </Button>
         <Button
           variant='participation-outline-sm'


### PR DESCRIPTION
## ❓ 이슈

- close #149 

## ✍️ Description

찜 기능을 구현했습니다. 낙관적 업데이트 적용
메인페이지 상단에서 await으로 인한 데이터 blocking을 완화하기 위해 스트리밍 형식으로 리팩토링 했습니다.
스켈레톤 ui를 구성하여 배치하였습니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

로그인 상황에서 찜

https://github.com/user-attachments/assets/d59c403a-d44d-4cc5-a5b0-fb73b86e98e3

비로그인 상황에서 찜

https://github.com/user-attachments/assets/948a6c9a-d13f-4a01-a039-89514d8b7f2d

### 성능 비교 

개선 전
<img width="546" height="691" alt="스크린샷 2026-04-09 오후 2 16 52" src="https://github.com/user-attachments/assets/98730f49-7d10-4f8c-bf14-cfd9832326f8" />

개선 후
<img width="546" height="703" alt="스크린샷 2026-04-09 오후 2 17 02" src="https://github.com/user-attachments/assets/9edd191b-f320-4068-9fd7-1f47a5006f36" />

게시글이 3개밖에 없어서 그런지 드라마틱한 차이는 아니네요 ㅜ

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- @claude 페이지 상단에서 await 방식에서 현재 방식대로 리팩토링을 했는데 성능 측정하기가 애매합니다. 좋은 방법이 있나요? 또한 이런 방식으로 스트리밍을 구현하는 게 next16 best pratice인지 궁금합니다. 
