### PR TITLE
[SM-141] feat: 상세 페이지 찜 기능 구현 + blocking -> streaming 구조로 리팩토링 + 스켈레톤 + 디자인 수정(AuthModal, BarCharts)

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
+import { useLikeToggle } from '@/api/likes/hooks';
 import { applicationQueries, useCreateApplication } from '@/api/applications/queries';
 import { getCurrentWeek } from '@/lib/formatGatheringDate';
 import { Button } from '@/components/ui/Button';
@@ -45,7 +44,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
   const hasPendingApplication =
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
-  const [isFavorite, setIsFavorite] = useState(false);
+  const { isLiked, isPending: isLikePending, toggleLike } = useLikeToggle(gatheringId);
   const overlay = useOverlay();
   const { Funnel, Step, setStep } = useFunnel<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
 
@@ -118,20 +117,13 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
               <Button
                 variant='bookmark'
                 size='bookmark-sm'
-                data-selected={isFavorite}
+                data-selected={isLiked}
                 aria-label='찜하기'
-                aria-pressed={isFavorite}
-                onClick={async () => {
-                  if (!isLoggedIn) {
-                    const isLoginSuccessful = await overlay.open(({ isOpen, close }) => (
-                      <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />
-                    ));
-                    if (!isLoginSuccessful) return;
-                  }
-                  setIsFavorite((prev) => !prev);
-                }}
+                aria-pressed={isLiked}
+                onClick={toggleLike}
+                disabled={isLikePending}
               >
-                <HeartIcon size={20} variant={isFavorite ? 'filled' : 'outline'} />
+                <HeartIcon size={20} variant={isLiked ? 'filled' : 'outline'} />
               </Button>
             </GatheringCard.Header>
 

--- a/src/app/gatherings/[id]/_components/GatheringDetailContainer/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContainer/index.tsx
@@ -1,0 +1,45 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { getQueryClient } from '@/lib/getQueryClient';
+
+import { AnchorTabNav } from '../AnchorTabNav';
+import { FloatingActionBar } from '../ApplySection/FloatingActionBar';
+import { GatheringHero } from '../GatheringHero';
+import { GatheringDetailContent } from '../GatheringDetailContent';
+import { GatheringInfoAside } from '../ApplySection/GatheringInfoAside';
+import { GatheringInfoCard } from '../ApplySection/GatheringInfoCard';
+
+interface GatheringDetailContainerProps {
+  gatheringId: number;
+}
+
+export async function GatheringDetailContainer({ gatheringId }: GatheringDetailContainerProps) {
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery(gatheringQueries.detail(gatheringId));
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <GatheringHero gatheringId={gatheringId} />
+
+      <div className='px-4 pt-6 md:px-8 xl:hidden'>
+        <GatheringInfoCard gatheringId={gatheringId} />
+      </div>
+
+      <AnchorTabNav gatheringId={gatheringId} />
+
+      <div className='px-4 pt-10 md:px-7 xl:flex xl:gap-20 xl:px-30'>
+        <section className='min-w-0 flex-1'>
+          <GatheringDetailContent gatheringId={gatheringId} />
+        </section>
+
+        <aside className='hidden xl:block xl:w-[560px] xl:shrink-0'>
+          <GatheringInfoAside gatheringId={gatheringId} />
+        </aside>
+      </div>
+
+      <FloatingActionBar gatheringId={gatheringId} />
+    </HydrationBoundary>
+  );
+}

--- a/src/app/gatherings/[id]/_components/GatheringDetailSkeleton/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailSkeleton/index.tsx
@@ -1,0 +1,66 @@
+export function GatheringDetailSkeleton() {
+  return (
+    <div className='flex flex-col'>
+      <section className='bg-gradient-sub-200 px-4 pt-20 pb-6 md:px-7 xl:px-30'>
+        <div className='flex flex-col gap-1'>
+          <div className='h-[168.8px] md:h-[181.6px] xl:h-[194.4px]'>
+            <div className='mb-2 h-4 w-24 animate-pulse rounded bg-blue-100 opacity-50' />
+            <div className='h-10 w-2/3 animate-pulse rounded bg-blue-100 opacity-50 md:h-12 xl:h-14' />
+          </div>
+        </div>
+      </section>
+
+      <div className='px-4 pt-6 md:px-8 xl:hidden'>
+        <div className='mb-4 h-12 w-full animate-pulse rounded-[8px] bg-gray-100' />
+        <div className='mb-4 h-[268px] w-full animate-pulse rounded-2xl bg-gray-50' />
+        <div className='mb-8 h-20 w-full animate-pulse rounded-2xl bg-gray-50' />
+      </div>
+
+      <nav className='border-gray-150 bg-gray-0 sticky top-0 z-20 border-b px-4 md:px-7 xl:px-30'>
+        <div className='mx-auto flex h-[39px] max-w-[1680px] items-center gap-6 md:h-12'>
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className='h-4 w-16 animate-pulse rounded bg-gray-100' />
+          ))}
+        </div>
+      </nav>
+
+      <div className='px-4 pt-10 md:px-7 xl:flex xl:gap-20 xl:px-30'>
+        <section className='min-w-0 flex-1 space-y-15'>
+          <div className='space-y-4'>
+            <div className='h-8 w-48 animate-pulse rounded-md bg-gray-200 lg:h-10' />
+            <div className='space-y-2'>
+              <div className='h-5 w-full animate-pulse rounded-md bg-gray-100' />
+              <div className='h-5 w-full animate-pulse rounded-md bg-gray-100' />
+              <div className='h-5 w-3/4 animate-pulse rounded-md bg-gray-100' />
+            </div>
+          </div>
+          <div className='aspect-video w-full animate-pulse rounded-2xl bg-gray-50' />
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className='border-gray-150 rounded-2xl border p-6 xl:p-8'>
+              <div className='mb-4 h-6 w-32 animate-pulse rounded bg-gray-200' />
+              <div className='h-6 w-1/2 animate-pulse rounded bg-gray-100' />
+            </div>
+          ))}
+        </section>
+
+        <aside className='hidden xl:block xl:w-[560px] xl:shrink-0'>
+          <div className='sticky top-24 space-y-4'>
+            <div className='h-12 w-full animate-pulse rounded-[8px] bg-gray-100' />
+            <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+              <div className='mb-8 h-8 w-3/4 animate-pulse rounded bg-gray-200' />
+              <div className='mb-10 space-y-3'>
+                <div className='h-5 w-full animate-pulse rounded bg-gray-100' />
+                <div className='h-5 w-2/3 animate-pulse rounded bg-gray-100' />
+              </div>
+              <div className='border-gray-150 space-y-7 border-t pt-6'>
+                <div className='h-[268px] w-full animate-pulse rounded bg-gray-50' />
+                <div className='h-20 w-full animate-pulse rounded bg-gray-50' />
+              </div>
+              <div className='mt-8 h-18 w-full animate-pulse rounded-xl bg-gray-100' />
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/gatherings/[id]/_components/GatheringStreaming/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringStreaming/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { GatheringDetailSkeleton } from '../GatheringDetailSkeleton';
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+
+import type { ReactNode } from 'react';
+
+interface GatheringStreamingProps {
+  children: ReactNode;
+}
+
+export function MainGatheringStreaming({ children }: GatheringStreamingProps) {
+  return (
+    <SuspenseBoundary
+      pendingFallback={<GatheringDetailSkeleton />}
+      errorFallback={(_error, reset) => (
+        <div className='flex flex-col items-center justify-center gap-4 py-20 text-center'>
+          <p className='text-body-01-m text-gray-500'>모임 정보를 불러오는 데 실패했습니다.</p>
+          <button
+            onClick={reset}
+            className='text-body-02-sb cursor-pointer text-blue-500 underline decoration-1 underline-offset-4 transition-colors hover:text-blue-600'
+          >
+            다시 시도하기
+          </button>
+        </div>
+      )}
+    >
+      {children}
+    </SuspenseBoundary>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklyTrendChart/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklyTrendChart/index.tsx
@@ -56,7 +56,7 @@ export function WeeklyTrendChart({ gatheringId }: WeeklyTrendChartProps) {
       <div className='custom-scrollbar w-full overflow-x-auto'>
         <div className='h-[300px]' style={{ minWidth: chartMinWidth }}>
           <ResponsiveContainer width='100%' height='100%'>
-            <BarChart accessibilityLayer={false} data={chartData} margin={{ top: 40, right: 0, left: -20, bottom: 0 }}>
+            <BarChart accessibilityLayer={false} data={chartData} margin={{ top: 60, right: 0, left: -20, bottom: 0 }}>
               <defs>
                 <linearGradient id='dashboard-focus' x1='0' y1='0' x2='0' y2='1'>
                   <stop offset='0%' stopColor='#3779fe' />

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -1,15 +1,10 @@
-import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { Suspense } from 'react';
 
 import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { getQueryClient } from '@/lib/getQueryClient';
-import { gatheringQueries } from '@/api/gatherings/queries';
-
-import { AnchorTabNav } from './_components/AnchorTabNav';
-import { GatheringDetailContent } from './_components/GatheringDetailContent';
-import { FloatingActionBar } from './_components/ApplySection/FloatingActionBar';
 import { GatheringHero } from './_components/GatheringHero';
-import { GatheringInfoAside } from './_components/ApplySection/GatheringInfoAside';
-import { GatheringInfoCard } from './_components/ApplySection/GatheringInfoCard';
+import { GatheringDetailContainer } from './_components/GatheringDetailContainer';
+import { GatheringDetailSkeleton } from './_components/GatheringDetailSkeleton';
+import { MainGatheringStreaming } from './_components/GatheringStreaming';
 
 interface GatheringDetailPageProps {
   params: Promise<{ id: string }>;
@@ -19,42 +14,11 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
   const { id } = await params;
   const gatheringId = Number(id);
 
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(gatheringQueries.detail(gatheringId));
-
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <main className='mb-20 min-h-screen'>
-        <ErrorBoundary
-          fallback={<p className='py-20 text-center text-gray-500'>모임 정보를 불러오는데 실패했습니다.</p>}
-        >
-          <GatheringHero gatheringId={gatheringId} />
-
-          {/* TODO: [이슈 2] Mobile/Tablet 사이드바 정보 카드 (xl:hidden) */}
-
-          {/* Mobile/Tablet: 모임 정보 카드 (탭 위에 배치) */}
-          <div className='px-4 pt-6 md:px-8 xl:hidden'>
-            <GatheringInfoCard gatheringId={gatheringId} />
-          </div>
-
-          {/* TODO: [이슈 3] 앵커 탭 네비게이션 */}
-
-          <AnchorTabNav gatheringId={gatheringId} />
-
-          <div className='px-4 pt-10 md:px-7 xl:flex xl:gap-20 xl:px-30'>
-            <section className='min-w-0 flex-1'>
-              <GatheringDetailContent gatheringId={gatheringId} />
-            </section>
-
-            {/* Desktop: 사이드바 (sticky) */}
-            <aside className='hidden xl:block xl:w-[560px] xl:shrink-0'>
-              <GatheringInfoAside gatheringId={gatheringId} />
-            </aside>
-          </div>
-          {/* Mobile/Tablet: 하단 고정 액션 바 */}
-          <FloatingActionBar gatheringId={gatheringId} />
-        </ErrorBoundary>
-      </main>
-    </HydrationBoundary>
+    <main className='mb-20 min-h-screen'>
+      <MainGatheringStreaming>
+        <GatheringDetailContainer gatheringId={gatheringId} />
+      </MainGatheringStreaming>
+    </main>
   );
 }

--- a/src/components/AuthModal/AuthFunnel/EmailStep.tsx
+++ b/src/components/AuthModal/AuthFunnel/EmailStep.tsx
@@ -34,16 +34,12 @@ export function EmailStep({ onResolved }: { onResolved: (email: string, isAvaila
   };
 
   return (
-    <div className='flex flex-col gap-8'>
+    <div className='flex flex-col gap-5.5'>
       <div className='flex flex-col gap-2'>
         <h2 className='text-h4-b text-center text-gray-900'>로그인 / 회원가입</h2>
-        <p className='text-body-02-r text-center text-gray-600'>
-          이메일을 입력하시면 가입 여부에 따라 로그인 또는 회원가입을 진행합니다.
-        </p>
       </div>
 
       <SocialLoginButtons kakaoLabel='카카오로 시작하기' googleLabel='구글로 시작하기' />
-      <AuthDivider text='또는 이메일로 시작' />
 
       <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-6'>
         <Input
@@ -52,7 +48,7 @@ export function EmailStep({ onResolved }: { onResolved: (email: string, isAvaila
               이메일 <span className='ml-1 text-blue-400'>*</span>
             </>
           }
-          placeholder='이메일을 입력해주세요'
+          placeholder='가입 여부에 따라 로그인/회원가입이 진행됩니다.'
           type='email'
           error={errors.email?.message}
           {...register('email')}


### PR DESCRIPTION
## ❓ 이슈

- close #219 

## ✍️ Description

찜 기능 구현을 합니다
이전 이슈였던 메인페이지처럼 스트리밍 형식으로 리팩토링 합니다
스켈레톤을 만듭니다
AuthModal 구분선 없애고 UI를 비밀번호 입력 모달과 통일하였습니다
BarCharts 100%일 때 짤리는 현상을 방지하기 위해 top속성을 변경합니다

## 📸 스크린샷 (UI 변경 시)
AuthModal 디자인 수정

https://github.com/user-attachments/assets/b8e26d7e-831f-424c-aa47-3dbaf244b800


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
