### PR TITLE
[SM-146] fix:로그인 버튼이 입력값 있음에도 비활성화 상태 수정

### DIFF
--- a/src/app/(auth)/login/EmailLoginForm/index.tsx
+++ b/src/app/(auth)/login/EmailLoginForm/index.tsx
@@ -22,10 +22,10 @@ export function EmailLoginForm() {
     register,
     handleSubmit,
     setError,
-    formState: { errors, isValid },
+    formState: { errors, isValid, submitCount, touchedFields },
   } = useForm<LoginForm>({
     resolver: zodResolver(loginFormSchema),
-    mode: 'onBlur',
+    mode: 'onChange',
   });
 
   const { mutate: loginMutate, isPending } = useLogin({
@@ -34,6 +34,8 @@ export function EmailLoginForm() {
   });
 
   const onSubmit = (data: LoginForm) => loginMutate(data);
+  const showEmailError = !!touchedFields.email || submitCount > 0;
+  const showPasswordError = !!touchedFields.password || submitCount > 0;
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
@@ -46,7 +48,7 @@ export function EmailLoginForm() {
         }
         placeholder='이메일을 입력해주세요'
         type='email'
-        error={errors.email?.message}
+        error={showEmailError ? errors.email?.message : undefined}
         {...register('email')}
         className='h-11'
       />
@@ -60,7 +62,7 @@ export function EmailLoginForm() {
           }
           placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요'
           type={showPassword ? 'text' : 'password'}
-          error={errors.password?.message}
+          error={showPasswordError ? errors.password?.message : undefined}
           {...register('password')}
           className='h-11'
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -331,3 +331,9 @@
   outline: none;
   box-shadow: none;
 }
+
+/* Edge/IE: password reveal(눈) 아이콘 숨김 */
+input[type='password']::-ms-reveal,
+input[type='password']::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #229  

## ✍️ Description

- 로그인 폼의 react-hook-form 검증 모드를 onBlur → onChange로 변경해 이메일/비밀번호가 유효해지는 즉시 로그인 버튼이 활성화되도록 개선했습니다.
- 인라인 에러는 blur 이후 또는 submit 시도 이후(submitCount)에만 노출되도록 조정해, 입력 중 과도한 에러 노출을 줄이면서도 제출 시 즉시 피드백을 제공합니다.
- Windows/Edge에서 input[type="password"]에 브라우저가 기본으로 붙여주는 비밀번호 보기(눈) 아이콘과 겹치는 문제가 발생해서 global.css 속성 추가

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes

동영상이 너무 커서 안올라가네요...