### PR TITLE
[SM-142] fix: 모임 생성 폼 다중 버그 수정

### DIFF
--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -44,7 +44,7 @@ export const gatheringFormSchema = z.object({
   recruitDeadline: dateStringSchema('모집 마감일을 선택해주세요.'),
   startDate: dateStringSchema('모임 시작일을 선택해주세요.'),
   endDate: dateStringSchema('모임 종료일을 선택해주세요.'),
-  weeklyGuides: z.array(weeklyGuideSchema).min(1, '최소 1주차 계획은 입력해 주세요.'),
+  weeklyGuides: z.array(weeklyGuideSchema).optional(),
   images: z
     .array(z.instanceof(File, { message: '유효한 파일이 아닙니다.' }))
     .max(6, '이미지는 최대 6장까지 업로드 가능합니다.')

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -15,7 +15,7 @@ export const weeklyGuideSchema = z.object({
 });
 
 /** 모임 생성/수정 폼 공통 필드 (cross-field 검증 전 base) */
-const gatheringFormBaseSchema = z.object({
+export const gatheringFormBaseSchema = z.object({
   type: z.enum(['스터디', '프로젝트'], {
     message: '모임 유형을 지정해 주세요.',
   }),

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -51,30 +51,39 @@ export const gatheringFormBaseSchema = z.object({
     .optional(),
 });
 
-/** POST `/gatherings` — 모임 생성 폼 */
-export const gatheringFormSchema = gatheringFormBaseSchema.superRefine((data, ctx) => {
-  const today = new Date().toISOString().slice(0, 10);
+/** 날짜 크로스필드 검증 스키마 */
+const dateRefinementSchema = z
+  .object({
+    recruitDeadline: dateStringSchema('모집 마감일을 선택해주세요.').optional(),
+    startDate: dateStringSchema('모임 시작일을 선택해주세요.').optional(),
+    endDate: dateStringSchema('모임 종료일을 선택해주세요.').optional(),
+  })
+  .superRefine((data, ctx) => {
+    const today = new Date().toISOString().slice(0, 10);
 
-  if (data.recruitDeadline && data.recruitDeadline < today) {
-    ctx.addIssue({ code: 'custom', message: '모집 마감일은 오늘 이후여야 합니다.', path: ['recruitDeadline'] });
-  }
-  if (data.startDate && data.startDate < today) {
-    ctx.addIssue({ code: 'custom', message: '모임 시작일은 오늘 이후여야 합니다.', path: ['startDate'] });
-  }
-  if (data.endDate && data.endDate < today) {
-    ctx.addIssue({ code: 'custom', message: '모임 종료일은 오늘 이후여야 합니다.', path: ['endDate'] });
-  }
-  if (data.recruitDeadline && data.startDate && data.recruitDeadline >= data.startDate) {
-    ctx.addIssue({
-      code: 'custom',
-      message: '모집 마감일은 모임 시작일보다 빨라야 합니다.',
-      path: ['recruitDeadline'],
-    });
-  }
-  if (data.startDate && data.endDate && data.endDate <= data.startDate) {
-    ctx.addIssue({ code: 'custom', message: '종료일은 시작일 이후여야 합니다.', path: ['endDate'] });
-  }
-});
+    if (data.recruitDeadline && data.recruitDeadline < today) {
+      ctx.addIssue({ code: 'custom', message: '모집 마감일은 오늘 이후여야 합니다.', path: ['recruitDeadline'] });
+    }
+    if (data.startDate && data.startDate < today) {
+      ctx.addIssue({ code: 'custom', message: '모임 시작일은 오늘 이후여야 합니다.', path: ['startDate'] });
+    }
+    if (data.endDate && data.endDate < today) {
+      ctx.addIssue({ code: 'custom', message: '모임 종료일은 오늘 이후여야 합니다.', path: ['endDate'] });
+    }
+    if (data.recruitDeadline && data.startDate && data.recruitDeadline >= data.startDate) {
+      ctx.addIssue({
+        code: 'custom',
+        message: '모집 마감일은 모임 시작일보다 빨라야 합니다.',
+        path: ['recruitDeadline'],
+      });
+    }
+    if (data.startDate && data.endDate && data.endDate <= data.startDate) {
+      ctx.addIssue({ code: 'custom', message: '종료일은 시작일 이후여야 합니다.', path: ['endDate'] });
+    }
+  });
+
+/** POST `/gatherings` — 모임 생성 폼 */
+export const gatheringFormSchema = gatheringFormBaseSchema.and(dateRefinementSchema);
 
 /** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (모든 필드 optional) */
 export const gatheringUpdateFormSchema = gatheringFormBaseSchema.partial();

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -51,12 +51,12 @@ export const gatheringFormBaseSchema = z.object({
     .optional(),
 });
 
-/** 날짜 크로스필드 검증 스키마 */
+/** 날짜 크로스필드 검증 스키마 — 필드 검증은 base schema에 위임, 여기서는 cross-field 검증만 담당 */
 const dateRefinementSchema = z
   .object({
-    recruitDeadline: dateStringSchema('모집 마감일을 선택해주세요.').optional(),
-    startDate: dateStringSchema('모임 시작일을 선택해주세요.').optional(),
-    endDate: dateStringSchema('모임 종료일을 선택해주세요.').optional(),
+    recruitDeadline: z.string().optional(),
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     const today = new Date().toISOString().slice(0, 10);

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -14,8 +14,8 @@ export const weeklyGuideSchema = z.object({
     .optional(),
 });
 
-/** POST `/gatherings` — 모임 생성 폼 */
-export const gatheringFormSchema = z.object({
+/** 모임 생성/수정 폼 공통 필드 (cross-field 검증 전 base) */
+const gatheringFormBaseSchema = z.object({
   type: z.enum(['스터디', '프로젝트'], {
     message: '모임 유형을 지정해 주세요.',
   }),
@@ -51,8 +51,30 @@ export const gatheringFormSchema = z.object({
     .optional(),
 });
 
-/** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (모든 필드 optional) */
-export const gatheringUpdateFormSchema = gatheringFormSchema.partial();
+/** POST `/gatherings` — 모임 생성 폼 */
+export const gatheringFormSchema = gatheringFormBaseSchema.superRefine((data, ctx) => {
+  const today = new Date().toISOString().slice(0, 10);
 
-/** POST `/gatherings` — 모임 생성 폼 (호환용 별칭) */
-export const gatheringFormPartialSchema = gatheringFormSchema;
+  if (data.recruitDeadline && data.recruitDeadline < today) {
+    ctx.addIssue({ code: 'custom', message: '모집 마감일은 오늘 이후여야 합니다.', path: ['recruitDeadline'] });
+  }
+  if (data.startDate && data.startDate < today) {
+    ctx.addIssue({ code: 'custom', message: '모임 시작일은 오늘 이후여야 합니다.', path: ['startDate'] });
+  }
+  if (data.endDate && data.endDate < today) {
+    ctx.addIssue({ code: 'custom', message: '모임 종료일은 오늘 이후여야 합니다.', path: ['endDate'] });
+  }
+  if (data.recruitDeadline && data.startDate && data.recruitDeadline >= data.startDate) {
+    ctx.addIssue({
+      code: 'custom',
+      message: '모집 마감일은 모임 시작일보다 빨라야 합니다.',
+      path: ['recruitDeadline'],
+    });
+  }
+  if (data.startDate && data.endDate && data.endDate <= data.startDate) {
+    ctx.addIssue({ code: 'custom', message: '종료일은 시작일 이후여야 합니다.', path: ['endDate'] });
+  }
+});
+
+/** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (모든 필드 optional) */
+export const gatheringUpdateFormSchema = gatheringFormBaseSchema.partial();

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -7,7 +7,7 @@ const dateStringSchema = (requiredMessage: string) =>
 /** 주차별 가이드 스키마 (모임 생성 폼용) */
 export const weeklyGuideSchema = z.object({
   week: z.number().min(1, '주차는 1 이상이어야 합니다.'),
-  title: z.string().max(100, '제목은 최대 100자까지 가능합니다.').optional().or(z.literal('')),
+  title: z.string().min(1, '제목을 입력해주세요.').max(100, '제목은 최대 100자까지 가능합니다.'),
   details: z
     .array(z.string().max(200, '세부 계획은 200자 이하여야 합니다.'))
     .max(2, '세부 계획은 최대 2개까지 입력할 수 있습니다.')
@@ -44,7 +44,7 @@ const gatheringFormBaseSchema = z.object({
   recruitDeadline: dateStringSchema('모집 마감일을 선택해주세요.'),
   startDate: dateStringSchema('모임 시작일을 선택해주세요.'),
   endDate: dateStringSchema('모임 종료일을 선택해주세요.'),
-  weeklyGuides: z.array(weeklyGuideSchema).optional(),
+  weeklyGuides: z.array(weeklyGuideSchema).min(1, '최소 1주차 계획은 입력해 주세요.'),
   images: z
     .array(z.instanceof(File, { message: '유효한 파일이 아닙니다.' }))
     .max(6, '이미지는 최대 6장까지 업로드 가능합니다.')

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { z } from 'zod';
 
 /** 날짜 문자열 스키마 (YYYY-MM-DD) */
@@ -59,7 +60,7 @@ const dateRefinementSchema = z
     endDate: z.string().optional(),
   })
   .superRefine((data, ctx) => {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = format(new Date(), 'yyyy-MM-dd');
 
     if (data.recruitDeadline && data.recruitDeadline < today) {
       ctx.addIssue({ code: 'custom', message: '모집 마감일은 오늘 이후여야 합니다.', path: ['recruitDeadline'] });

--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 
 /** 날짜 문자열 스키마 (YYYY-MM-DD) */
-const dateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, '날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)');
+const dateStringSchema = (requiredMessage: string) =>
+  z.string({ error: requiredMessage }).regex(/^\d{4}-\d{2}-\d{2}$/, '날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)');
 
 /** 주차별 가이드 스키마 (모임 생성 폼용) */
 export const weeklyGuideSchema = z.object({
@@ -36,10 +37,13 @@ export const gatheringFormSchema = z.object({
     .max(10, '태그는 최대 10개까지 가능합니다.')
     .optional(),
   goal: z.string().min(1, '모임 목표를 입력해 주세요.').max(200, '모임 목표는 최대 200자까지 가능합니다.'),
-  maxMembers: z.number().min(2, '최소 2명 이상이어야 합니다.').max(20, '최대 20명 이하이어야 합니다.'),
-  recruitDeadline: dateStringSchema,
-  startDate: dateStringSchema,
-  endDate: dateStringSchema,
+  maxMembers: z
+    .number({ error: '모집 인원을 입력해주세요.' })
+    .min(2, '최소 2명 이상이어야 합니다.')
+    .max(10, '최대 10명 이하이어야 합니다.'),
+  recruitDeadline: dateStringSchema('모집 마감일을 선택해주세요.'),
+  startDate: dateStringSchema('모임 시작일을 선택해주세요.'),
+  endDate: dateStringSchema('모임 종료일을 선택해주세요.'),
   weeklyGuides: z.array(weeklyGuideSchema).min(1, '최소 1주차 계획은 입력해 주세요.'),
   images: z
     .array(z.instanceof(File, { message: '유효한 파일이 아닙니다.' }))

--- a/src/app/gatherings/[id]/_components/WeeklyPlanAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/WeeklyPlanAccordion/index.tsx
@@ -46,7 +46,7 @@ export function WeeklyPlanAccordion({ weeklyPlans }: WeeklyPlanAccordionProps) {
                 size={28}
                 className={cn(
                   'text-gray-800 transition-transform duration-200 xl:h-8! xl:w-8!',
-                  isExpanded ? 'rotate-90' : '-rotate-90',
+                  isExpanded ? '-rotate-90' : 'rotate-90',
                 )}
                 viewBox='0 0 16 16'
               />

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -128,7 +128,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         /* ── 1장 이상: 썸네일 + 빈 슬롯 ── */
         <div
           className={cn(
-            'flex flex-row gap-2 overflow-x-auto rounded-lg border border-dashed border-gray-300 bg-gray-100 p-3 md:flex-wrap md:overflow-x-visible',
+            'flex flex-row gap-2 overflow-x-auto rounded-lg border border-dashed border-gray-300 bg-gray-100 px-1 py-3 md:flex-wrap md:overflow-x-visible',
             isDragging && 'border-blue-300',
           )}
           onDragOver={handleDragOver}

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -87,7 +87,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
   const openFilePicker = () => fileInputRef.current?.click();
 
   const hasImages = value.length > 0;
-  const emptySlotCount = MAX_IMAGES - value.length;
+  const emptySlotCount = value.length < MAX_IMAGES ? 1 : 0;
 
   return (
     <div className='flex flex-col gap-1.5'>
@@ -128,8 +128,8 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         /* ── 1장 이상: 썸네일 + 빈 슬롯 ── */
         <div
           className={cn(
-            'flex flex-row gap-2 overflow-x-auto rounded-lg md:flex-wrap md:overflow-x-visible',
-            isDragging && 'outline-2 outline-blue-300 outline-dashed',
+            'flex flex-row gap-2 overflow-x-auto rounded-lg border border-dashed border-gray-300 bg-gray-100 p-3 md:flex-wrap md:overflow-x-visible',
+            isDragging && 'border-blue-300',
           )}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -20,7 +20,7 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
   const hasError = !!error;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key !== 'Enter') return;
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
     e.preventDefault();
 
     const trimmed = inputValue.trim();

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.test.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.test.tsx
@@ -20,10 +20,8 @@ function TestHarness({ totalWeeks }: TestHarnessProps) {
 }
 
 describe('WeeklyPlanForm', () => {
-  it('아코디언을 열면 주차 입력 폼이 렌더링된다', () => {
+  it('totalWeeks > 0이면 아코디언이 자동으로 열리고 주차 입력 폼이 렌더링된다', () => {
     render(<TestHarness totalWeeks={2} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /주차별 계획/i }));
 
     expect(screen.getByText('1주차')).toBeInTheDocument();
 
@@ -34,7 +32,6 @@ describe('WeeklyPlanForm', () => {
   it('totalWeeks가 줄어들면 주차 입력 필드가 자동으로 줄어든다', () => {
     const { rerender } = render(<TestHarness totalWeeks={3} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /주차별 계획/i }));
     fireEvent.click(screen.getByRole('button', { name: /\+ 다음 주차 추가/i }));
     fireEvent.click(screen.getByRole('button', { name: /\+ 다음 주차 추가/i }));
     expect(screen.getByText('3주차')).toBeInTheDocument();

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { type Control, type FieldErrors, type UseFormRegister, useController, useFieldArray } from 'react-hook-form';
+import { AnimatePresence, motion } from 'motion/react';
 
 import { Input } from '@/components/ui/Input';
-import { ArrowIcon } from '@/components/ui/Icon';
+import { ArrowIcon, CalendarIcon, CloseIcon } from '@/components/ui/Icon';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/cn';
 
@@ -48,6 +49,10 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
     field.onChange([...details, '']);
   };
 
+  const handleRemoveDetail = (detailIndex: number) => {
+    field.onChange(details.filter((_, i) => i !== detailIndex));
+  };
+
   const canAddDetail = details.length < MAX_DETAILS;
 
   return (
@@ -68,14 +73,23 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
         <>
           <div className='flex flex-col gap-3 lg:flex-row'>
             <div className='flex w-full flex-col gap-1.5 lg:w-1/2'>
-              <Input
-                placeholder='세부 계획을 적어주세요'
-                value={details[0] ?? ''}
-                onBlur={field.onBlur}
-                onChange={(event) => updateDetail(0, event.target.value)}
-                error={error}
-                className='text-small-02-r md:text-body-02-r h-11 md:h-14.5'
-              />
+              <div className='flex items-center gap-2'>
+                <Input
+                  placeholder='세부 계획을 적어주세요'
+                  value={details[0] ?? ''}
+                  onBlur={field.onBlur}
+                  onChange={(event) => updateDetail(0, event.target.value)}
+                  error={error}
+                  className='text-small-02-r md:text-body-02-r h-11 md:h-14.5'
+                />
+                <button
+                  type='button'
+                  onClick={() => handleRemoveDetail(0)}
+                  className='shrink-0 text-gray-400 hover:text-gray-600'
+                >
+                  <CloseIcon className='size-4' />
+                </button>
+              </div>
             </div>
             {canAddDetail && (
               <Button
@@ -92,13 +106,22 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
 
           {details.length > 1 && (
             <div className='flex w-full flex-col gap-1.5 lg:w-1/2'>
-              <Input
-                placeholder='세부 계획을 적어주세요'
-                value={details[1] ?? ''}
-                onBlur={field.onBlur}
-                onChange={(event) => updateDetail(1, event.target.value)}
-                className='text-small-02-r md:text-body-02-r h-11 md:h-14.5'
-              />
+              <div className='flex items-center gap-2'>
+                <Input
+                  placeholder='세부 계획을 적어주세요'
+                  value={details[1] ?? ''}
+                  onBlur={field.onBlur}
+                  onChange={(event) => updateDetail(1, event.target.value)}
+                  className='text-small-02-r md:text-body-02-r h-11 md:h-14.5'
+                />
+                <button
+                  type='button'
+                  onClick={() => handleRemoveDetail(1)}
+                  className='shrink-0 text-gray-400 hover:text-gray-600'
+                >
+                  <CloseIcon className='size-4' />
+                </button>
+              </div>
             </div>
           )}
 
@@ -120,7 +143,8 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
 }
 
 export function WeeklyPlanForm({ control, register, errors, totalWeeks }: WeeklyPlanFormProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpenOverride, setIsOpenOverride] = useState<boolean | null>(null);
+  const isOpen = isOpenOverride ?? totalWeeks > 0;
   const { fields, append, remove, replace } = useFieldArray({
     control,
     name: 'weeklyGuides',
@@ -172,43 +196,65 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
     <section className='mt-8 flex flex-col'>
       <button
         type='button'
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => setIsOpenOverride((prev) => !(prev ?? totalWeeks > 0))}
         className='bg-gray-150 flex h-12 items-center justify-between rounded-lg border border-gray-200 px-7 py-5'
       >
         <span className='text-small-01-sb md:text-body-02-sb text-gray-800'>
-          주차별 계획 <span className='md:text-small-02-r lg:text-small-01-r text-gray-400'>(선택)</span>
+          주차별 계획 <span className='text-blue-400'>*</span>
         </span>
         <ArrowIcon className={cn('size-4 rotate-90 text-gray-800 transition-transform', isOpen && '-rotate-90')} />
       </button>
 
-      {isOpen && fields.length > 0 && (
-        <div className='bg-gray-0 flex flex-col gap-5 rounded-b-lg border border-t-0 border-gray-200 px-7 py-7'>
-          {fields.map((field, index) => (
-            <div key={field.id} className='border-gray-150 flex flex-col gap-3 border-b pb-5 last:border-b-0 last:pb-0'>
-              <p className='text-small-01-sb md:text-body-01-sb text-gray-800'>{index + 1}주차</p>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            key='weekly-plan-panel'
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
+            className='overflow-hidden'
+          >
+            <div className='bg-gray-0 flex flex-col gap-5 rounded-b-lg border border-t-0 border-gray-200 px-7 py-7'>
+              {fields.length === 0 && (
+                <div className='flex flex-col items-center gap-2 py-6 text-gray-400'>
+                  <CalendarIcon className='size-8' />
+                  <p className='text-small-01-r md:text-body-02-r text-center'>
+                    모임 시작일과 종료일을 입력하면 주차별 계획을 작성할 수 있어요
+                  </p>
+                </div>
+              )}
+              {fields.map((field, index) => (
+                <div
+                  key={field.id}
+                  className='border-gray-150 flex flex-col gap-3 border-b pb-5 last:border-b-0 last:pb-0'
+                >
+                  <p className='text-small-01-sb md:text-body-01-sb text-gray-800'>{index + 1}주차</p>
 
-              <Input
-                label={<span className='text-small-02-m md:text-body-02-m text-gray-800'>제목</span>}
-                placeholder={`${index + 1}주차 계획의 제목을 적어주세요`}
-                error={guideErrors?.[index]?.title?.message as string | undefined}
-                {...register(`weeklyGuides.${index}.title`)}
-              />
+                  <Input
+                    label={<span className='text-small-02-m md:text-body-02-m text-gray-800'>제목</span>}
+                    placeholder={`${index + 1}주차 계획의 제목을 적어주세요`}
+                    error={guideErrors?.[index]?.title?.message as string | undefined}
+                    {...register(`weeklyGuides.${index}.title`)}
+                  />
 
-              <WeekDetailInputs
-                control={control}
-                index={index}
-                error={guideErrors?.[index]?.details?.message as string | undefined}
-              />
+                  <WeekDetailInputs
+                    control={control}
+                    index={index}
+                    error={guideErrors?.[index]?.details?.message as string | undefined}
+                  />
+                </div>
+              ))}
+
+              {canAddNextWeek && (
+                <Button type='button' variant='add-task' size='add-task' className='mb-2.5' onClick={handleAddNextWeek}>
+                  + 다음 주차 추가
+                </Button>
+              )}
             </div>
-          ))}
-
-          {canAddNextWeek && (
-            <Button type='button' variant='add-task' size='add-task' className='mb-2.5' onClick={handleAddNextWeek}>
-              + 다음 주차 추가
-            </Button>
-          )}
-        </div>
-      )}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   );
 }

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -169,7 +169,7 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
 
     // 최초 1주차는 자동 생성, 이후 주차는 "다음 주차 추가" 버튼으로만 생성
     if (currentLength === 0) {
-      append(createEmptyGuide(1));
+      append(createEmptyGuide(1), { shouldFocus: false });
       return;
     }
 

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -107,6 +107,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   const recruitDeadlineValue = watch('recruitDeadline');
   const startDateValue = watch('startDate');
   const endDateValue = watch('endDate');
+  const weeklyGuidesValue = watch('weeklyGuides') ?? [];
   const totalWeeks = useMemo(() => {
     if (!startDateValue || !endDateValue) return 0;
 
@@ -117,6 +118,9 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
 
     return Math.max(1, differenceInWeeks(endDate, startDate));
   }, [endDateValue, startDateValue]);
+
+  const isWeeklyGuidesComplete =
+    weeklyGuidesValue.length > 0 && weeklyGuidesValue.every((guide) => Boolean(guide?.title?.trim()));
 
   const isFormComplete =
     !!typeValue &&
@@ -131,7 +135,8 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     maxMembersValue <= 10 &&
     !!recruitDeadlineValue &&
     !!startDateValue &&
-    !!endDateValue;
+    !!endDateValue &&
+    isWeeklyGuidesComplete;
 
   const onSubmit = (data: GatheringForm) => {
     mutate(data, {
@@ -384,7 +389,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
             <Input
               type='number'
               min={2}
-              max={20}
+              max={10}
               label={
                 <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모집 인원</span>
               }

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -107,8 +107,6 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   const recruitDeadlineValue = watch('recruitDeadline');
   const startDateValue = watch('startDate');
   const endDateValue = watch('endDate');
-  const weeklyGuidesValue = watch('weeklyGuides') ?? [];
-
   const totalWeeks = useMemo(() => {
     if (!startDateValue || !endDateValue) return 0;
 
@@ -120,9 +118,6 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     return Math.max(1, differenceInWeeks(endDate, startDate));
   }, [endDateValue, startDateValue]);
 
-  const isWeeklyGuidesComplete =
-    weeklyGuidesValue.length > 0 && weeklyGuidesValue.every((guide) => Boolean(guide?.title?.trim()));
-
   const isFormComplete =
     !!typeValue &&
     categoryIdsValue.length > 0 &&
@@ -133,11 +128,10 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     tagsValue.length > 0 &&
     typeof maxMembersValue === 'number' &&
     maxMembersValue >= 2 &&
-    maxMembersValue <= 20 &&
+    maxMembersValue <= 10 &&
     !!recruitDeadlineValue &&
     !!startDateValue &&
-    !!endDateValue &&
-    isWeeklyGuidesComplete;
+    !!endDateValue;
 
   const onSubmit = (data: GatheringForm) => {
     mutate(data, {

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { differenceInWeeks, isValid, parseISO } from 'date-fns';
+import { differenceInDays, isValid, parseISO } from 'date-fns';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -54,6 +54,8 @@ const CategoryTriggerBorder = ({ children }: { children: ReactNode }) => {
   );
 };
 
+const DATE_FIELDS = ['recruitDeadline', 'startDate', 'endDate'] as const;
+
 const TYPE_META = {
   스터디: { label: '스터디', subtitle: '함께 학습하고 성장해요', Icon: StudyIcon },
   프로젝트: { label: '프로젝트', subtitle: '함께 만들고 완성해요', Icon: ProjectIcon },
@@ -80,7 +82,8 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     handleSubmit,
     control,
     watch,
-    formState: { errors },
+    trigger,
+    formState: { errors, touchedFields },
   } = useForm<GatheringForm>({
     resolver: zodResolver(gatheringFormSchema),
     mode: 'onBlur',
@@ -116,7 +119,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     const isDateRangeInvalid = !isValid(startDate) || !isValid(endDate);
     if (isDateRangeInvalid) return 0;
 
-    return Math.max(1, differenceInWeeks(endDate, startDate));
+    return Math.max(1, Math.ceil(differenceInDays(endDate, startDate) / 7));
   }, [endDateValue, startDateValue]);
 
   const isWeeklyGuidesComplete =
@@ -408,7 +411,11 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                 <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모집 마감 일정</p>
                 <DatePicker
                   value={field.value}
-                  onChange={field.onChange}
+                  onChange={(value) => {
+                    field.onChange(value);
+                    const fieldsToTrigger = DATE_FIELDS.filter((f) => f === field.name || touchedFields[f]);
+                    trigger(fieldsToTrigger);
+                  }}
                   onBlur={field.onBlur}
                   placeholder='모집 마감 일정을 선택해주세요'
                   error={errors.recruitDeadline?.message}
@@ -434,7 +441,11 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                 <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 시작일</p>
                 <DatePicker
                   value={field.value}
-                  onChange={field.onChange}
+                  onChange={(value) => {
+                    field.onChange(value);
+                    const fieldsToTrigger = DATE_FIELDS.filter((f) => f === field.name || touchedFields[f]);
+                    trigger(fieldsToTrigger);
+                  }}
                   onBlur={field.onBlur}
                   placeholder='모임 시작일을 선택해주세요'
                   error={errors.startDate?.message}
@@ -451,7 +462,11 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                 <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 종료일</p>
                 <DatePicker
                   value={field.value}
-                  onChange={field.onChange}
+                  onChange={(value) => {
+                    field.onChange(value);
+                    const fieldsToTrigger = DATE_FIELDS.filter((f) => f === field.name || touchedFields[f]);
+                    trigger(fieldsToTrigger);
+                  }}
                   onBlur={field.onBlur}
                   placeholder='모임 종료일을 선택해주세요'
                   error={errors.endDate?.message}

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse, delay } from 'msw';
 
 import { gatheringFormSchema, gatheringUpdateFormSchema } from '@/api/gatherings/schemas';
+import { getTotalWeeks } from '@/lib/formatGatheringDate';
 import { createApiResponse } from '../utils';
 
 import type {
@@ -545,7 +546,7 @@ export const gatheringsHandlers = [
       ...newGathering,
       description: body.description,
       goal: body.goal,
-      totalWeeks: body.weeklyGuides.length,
+      totalWeeks: getTotalWeeks(body.startDate, body.endDate),
       images: [],
       weeklyPlans: [],
       members: [{ userId: 1, nickname: '김코딩', profileImage: null, role: 'LEADER' }],

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse, delay } from 'msw';
 
-import { gatheringFormSchema, gatheringUpdateFormSchema } from '@/api/gatherings/schemas';
+import { gatheringFormBaseSchema, gatheringUpdateFormSchema } from '@/api/gatherings/schemas';
 import { getTotalWeeks } from '@/lib/formatGatheringDate';
 import { createApiResponse } from '../utils';
 
@@ -37,7 +37,7 @@ import type { GatheringType } from '@/api/gatherings/types';
 
 // API 함수에서 type이 한글 → 영어(STUDY/PROJECT)로 변환된 후 전송되므로
 // MSW 스키마에서도 영어 enum을 허용
-const createBodySchema = gatheringFormSchema
+const createBodySchema = gatheringFormBaseSchema
   .omit({ images: true })
   .extend({ type: z.enum(['STUDY', 'PROJECT', '스터디', '프로젝트']) });
 const updateBodySchema = gatheringUpdateFormSchema


### PR DESCRIPTION
## ❓ 이슈

- close #221 

## ✍️ Description

## 개요

모임 생성 폼에서 발견된 버그들을 수정합니다.

---

## 버그 수정 내역

### 1. 태그 입력 시 한글 마지막 글자가 중복 등록되는 문제

**원인**: 한글 입력 시 IME 조합 완료 이벤트(`keydown`)와 `compositionend` 이벤트가 동시에 발생하여 태그가 이중 등록됨

**수정**: `isComposing` 상태 체크 추가 — IME 조합 중일 때는 keydown 이벤트 무시

예: '웹개발' 입력 → '웹개발', '발' 두 개 생성되던 문제 해결

---

### 2. 이미지 1개 추가 시 업로드 슬롯이 5개로 늘어나는 문제

**원인**: Figma 디자인 시안을 확인했으나 디테일을 충분히 검토하지 않아 업로드 슬롯 5개를 한꺼번에 노출하도록 잘못 구현

**수정**: 이미지 업로드 후에도 외곽 border 유지, 빈 슬롯 표시 개수 계산 로직 수정, 가로 패딩 축소로 6장 1줄 표시

---

### 3. 모집 정보 미입력 시 에러 메시지가 부적절하게 표시되는 문제

**원인**: 필드에 커스텀 에러 메시지 미설정으로 기본 메시지 노출

**수정**: 모집 인원, 날짜 필드 에러 메시지 명시

---

### 4. 주차별 계획 UX 문제

**수정 내역**:
- `weeklyGuides`는 필수 항목으로 유지, 주차 제목 필수 입력으로 변경
- 시작일/종료일 선택 시 아코디언 자동 열림
- 자동 append 시 `shouldFocus: false` 적용 — 자동 포커스로 인한 즉시 onBlur 에러 표시 방지
  - (사용자가 직접 "다음 주차 추가" 버튼으로 append하는 경우는 자연스러운 흐름이므로 `shouldFocus: true` 유지)

---

### 5. 날짜 크로스필드 유효성 검사 문제

#### 5-1. `superRefine`이 실행되지 않는 문제

**원인**: Zod에서 `superRefine`은 타입 에러가 있는 필드가 존재하면 실행되지 않음. 다른 필드(type, categoryIds 등)가 미입력 상태일 때 날짜 검증이 동작하지 않았음

**수정**: 날짜 필드만 포함한 `dateRefinementSchema`를 분리하고 `.and()`로 결합. 두 스키마가 독립 실행되므로 다른 필드 오류와 무관하게 날짜 검증이 동작함

#### 5-2. 연관 날짜 필드의 에러가 stale하게 남는 문제

**원인**: `mode: 'onBlur'`에서 blur된 필드만 재검증되므로, 연관 필드를 수정해도 기존 에러가 지워지지 않음

예: `모집 마감일 4/14`, `시작일 4/13` → 마감일 에러 발생 → 시작일을 4/15로 변경해도 마감일 에러가 그대로 남음

**수정**: 날짜 필드 `onChange` 시 `trigger()` + `touchedFields` 필터링으로 touched된 연관 날짜 필드만 재검증

#### 5-3. 모임 기간 주차 계산이 floor로 되어 마지막 부분 주가 누락되는 문제

**원인**: `differenceInWeeks()`는 완전한 주 수만 반환(floor). 예: 4/14\~4/30 = 16일 → 2주로 계산되어 4/28\~4/30에 대한 계획을 세울 수 없음

**수정**: `Math.ceil(differenceInDays() / 7)`로 변경하여 부분 주도 포함

> 기존 `MyGatheringsCard`, `MyGatheringCard`도 동일하게 ceiling 방식을 사용 중 — 일관성 확보

---

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes



<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->
- [x] ~cross-field 날짜 검증 문제 수정 필요~ 수정완료
- [x] 모임 상세 페이지 주차별 계획 아코디언 화살표 방향 수정

