### PR TITLE
[SM-149] style: 로그인/회원가입 Input 라벨 반응형 타이포그래피 적용 및 border 버그 수정

### DIFF
--- a/src/app/(auth)/login/EmailLoginForm/index.tsx
+++ b/src/app/(auth)/login/EmailLoginForm/index.tsx
@@ -42,9 +42,9 @@ export function EmailLoginForm() {
       {/* 이메일 입력 필드 */}
       <Input
         label={
-          <>
+          <span className='text-small-01-m md:text-body-02-m'>
             이메일 <span className='ml-1 text-blue-400'>*</span>
-          </>
+          </span>
         }
         placeholder='이메일을 입력해주세요'
         type='email'
@@ -56,9 +56,9 @@ export function EmailLoginForm() {
       <div className='relative'>
         <Input
           label={
-            <>
+            <span className='text-small-01-m md:text-body-02-m'>
               비밀번호 <span className='ml-1 text-blue-400'>*</span>
-            </>
+            </span>
           }
           placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요'
           type={showPassword ? 'text' : 'password'}
@@ -68,7 +68,7 @@ export function EmailLoginForm() {
         />
         <button
           type='button'
-          className='absolute top-9 right-3 cursor-pointer text-gray-400'
+          className='absolute top-9 right-3 cursor-pointer text-gray-400 md:top-10'
           onClick={() => setShowPassword((prev) => !prev)}
           aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
         >

--- a/src/app/(auth)/login/EmailLoginForm/index.tsx
+++ b/src/app/(auth)/login/EmailLoginForm/index.tsx
@@ -50,7 +50,7 @@ export function EmailLoginForm() {
         type='email'
         error={showEmailError ? errors.email?.message : undefined}
         {...register('email')}
-        className='h-11'
+        className='h-11 placeholder:text-gray-300'
       />
       {/* 비밀번호 입력 필드 + 보기/숨기기 토글 버튼 */}
       <div className='relative'>
@@ -64,7 +64,7 @@ export function EmailLoginForm() {
           type={showPassword ? 'text' : 'password'}
           error={showPasswordError ? errors.password?.message : undefined}
           {...register('password')}
-          className='h-11'
+          className='h-11 placeholder:text-gray-300'
         />
         <button
           type='button'

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -40,9 +40,9 @@ export function EmailRegisterForm() {
           <div className='flex-1'>
             <Input
               label={
-                <>
+                <span className='text-small-01-m md:text-body-02-m'>
                   이메일 <span className='ml-1 text-blue-400'>*</span>
-                </>
+                </span>
               }
               placeholder='이메일을 입력해주세요.'
               type='email'
@@ -71,9 +71,9 @@ export function EmailRegisterForm() {
           <div className='flex-1'>
             <Input
               label={
-                <>
+                <span className='text-small-01-m md:text-body-02-m'>
                   닉네임 <span className='ml-1 text-blue-400'>*</span>
-                </>
+                </span>
               }
               placeholder='닉네임을 입력해주세요.'
               error={form.errors.nickname?.message}
@@ -99,9 +99,9 @@ export function EmailRegisterForm() {
       <div className='relative'>
         <Input
           label={
-            <>
+            <span className='text-small-01-m md:text-body-02-m'>
               비밀번호 <span className='ml-1 text-blue-400'>*</span>
-            </>
+            </span>
           }
           placeholder='영문, 숫자, 특수문자 포함 8자 이상 입력해주세요.'
           type={state.showPassword ? 'text' : 'password'}
@@ -113,7 +113,7 @@ export function EmailRegisterForm() {
         />
         <button
           type='button'
-          className='absolute top-9 right-3 cursor-pointer text-gray-400'
+          className='absolute top-9 right-3 cursor-pointer text-gray-400 md:top-10'
           onClick={() => state.setShowPassword((prev) => !prev)}
           aria-label={state.showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
         >
@@ -124,9 +124,9 @@ export function EmailRegisterForm() {
       <div className='relative'>
         <Input
           label={
-            <>
+            <span className='text-small-01-m md:text-body-02-m'>
               비밀번호 확인 <span className='ml-1 text-blue-400'>*</span>
-            </>
+            </span>
           }
           placeholder='비밀번호를 한번 더 입력해주세요.'
           type={state.showPasswordConfirm ? 'text' : 'password'}
@@ -136,7 +136,7 @@ export function EmailRegisterForm() {
         />
         <button
           type='button'
-          className='absolute top-9 right-3 cursor-pointer text-gray-400'
+          className='absolute top-9 right-3 cursor-pointer text-gray-400 md:top-10'
           onClick={() => state.setShowPasswordConfirm((prev) => !prev)}
           aria-label={state.showPasswordConfirm ? '비밀번호 숨기기' : '비밀번호 보기'}
         >

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -48,7 +48,7 @@ export function EmailRegisterForm() {
               type='email'
               error={form.errors.email?.message}
               {...form.register('email')}
-              className='h-11'
+              className='h-11 placeholder:text-gray-300'
             />
           </div>
           <Button
@@ -78,7 +78,7 @@ export function EmailRegisterForm() {
               placeholder='닉네임을 입력해주세요.'
               error={form.errors.nickname?.message}
               {...form.register('nickname')}
-              className='h-11'
+              className='h-11 placeholder:text-gray-300'
             />
           </div>
           <Button
@@ -109,7 +109,7 @@ export function EmailRegisterForm() {
           {...form.register('password', {
             onBlur: () => form.trigger('passwordConfirmation'),
           })}
-          className='h-11'
+          className='h-11 placeholder:text-gray-300'
         />
         <button
           type='button'
@@ -132,7 +132,7 @@ export function EmailRegisterForm() {
           type={state.showPasswordConfirm ? 'text' : 'password'}
           error={form.errors.passwordConfirmation?.message}
           {...form.register('passwordConfirmation')}
-          className='h-11'
+          className='h-11 placeholder:text-gray-300'
         />
         <button
           type='button'

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -3,9 +3,12 @@ import { extendTailwindMerge } from 'tailwind-merge';
 
 // tailwind-merge는 커스텀 텍스트 유틸리티(text-h5-b 등)를 텍스트 색상 클래스(text-blue-400 등)와
 // 동일 그룹으로 잘못 인식해 충돌 시 제거한다. font-size 그룹으로 명시 등록해 이를 방지한다.
-const twMerge = extendTailwindMerge({
+const twMerge = extendTailwindMerge<'border-gradient'>({
   extend: {
     classGroups: {
+      // border-gradient-primary를 border-color 그룹으로 잘못 인식해
+      // border-gray-200 등 border-color 클래스를 제거하는 문제 방지
+      'border-gradient': ['border-gradient-primary'],
       'font-size': [
         'text-h1-b',
         'text-h2-b',


### PR DESCRIPTION
## ❓ 이슈

- close #236 

## ✍️ Description

- 로그인/회원가입 폼 Input 라벨 반응형 타이포그래피 적용 (모바일: `small/01-m`, 태블릿+: `body/02-m`)
- 라벨 크기 변경으로 인한 비밀번호 VisibilityIcon 위치 틀어짐 수정 (`md:top-10`)
- 로그인/회원가입 폼 Input 플레이스홀더 색상 변경 (`gray-400` → `gray-300`)
- `tailwind-merge`가 `border-gradient-primary`를 `border-color` 그룹으로 오인해 `border-gray-200`을 제거하는 버그 수정 (`cn.ts`에 `border-gradient` 그룹 등록)

## 📸 스크린샷 (UI 변경 시)

<img width="488" height="344" alt="image" src="https://github.com/user-attachments/assets/e18f1e08-22a4-4cee-a0ef-a08d50f61487" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


