### PR TITLE
[SM-151] style: 모임 탐색 페이지 디자인 수정

### DIFF
--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -105,6 +105,7 @@ export function MainGatheringCard({
         <Button
           variant='bookmark'
           size='bookmark-sm'
+          className='shrink-0'
           data-selected={isLiked}
           aria-label='찜하기'
           aria-pressed={isLiked}
@@ -115,7 +116,7 @@ export function MainGatheringCard({
             toggleLike();
           }}
         >
-          <HeartIcon size={20} variant={isLiked ? 'filled' : 'outline'} />
+          <HeartIcon size={24} variant={isLiked ? 'filled' : 'outline'} />
         </Button>
         <Button
           variant='participation-outline-sm'

--- a/src/components/Search/GatheringFilterBar/StatusFilter.tsx
+++ b/src/components/Search/GatheringFilterBar/StatusFilter.tsx
@@ -49,8 +49,8 @@ export function StatusFilter({ value, onChange }: StatusFilterProps) {
               key={option.value}
               onClick={() => onChange(option.value)}
               className={cn(
-                'cursor-pointer rounded-lg px-4 py-2 hover:bg-blue-100 hover:text-blue-400',
-                isSelected && 'bg-blue-100 text-blue-400',
+                'cursor-pointer rounded-lg px-4 py-2 text-gray-500 hover:text-gray-900',
+                isSelected && 'text-gray-900',
               )}
             >
               {option.label}

--- a/src/components/Search/GatheringFilterBar/StatusFilter.tsx
+++ b/src/components/Search/GatheringFilterBar/StatusFilter.tsx
@@ -49,8 +49,8 @@ export function StatusFilter({ value, onChange }: StatusFilterProps) {
               key={option.value}
               onClick={() => onChange(option.value)}
               className={cn(
-                'cursor-pointer rounded-lg px-4 py-2 text-gray-500 hover:text-gray-900',
-                isSelected && 'text-gray-900',
+                'text-body-02-r cursor-pointer rounded-lg px-4 py-2 text-gray-500 hover:text-gray-900',
+                isSelected && 'text-body-02-m text-gray-900',
               )}
             >
               {option.label}

--- a/src/components/Search/SearchForm/CategoryMultiSelect.tsx
+++ b/src/components/Search/SearchForm/CategoryMultiSelect.tsx
@@ -77,11 +77,11 @@ export function CategoryMultiSelect({ icon, placeholder, selectedValues, items, 
           <RotatingArrow />
         </div>
       </Dropdown.Trigger>
-      <Dropdown.Menu className='w-full min-w-[160px] overflow-hidden p-2'>
+      <Dropdown.Menu className='flex w-full min-w-[160px] flex-col gap-1 overflow-hidden p-2'>
         <Dropdown.Item
           onClick={handleReset}
           className={cn(
-            'cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+            'lg:text-body-02-r cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
             selectedValues.length === 0 && 'bg-blue-100 text-blue-400',
           )}
         >
@@ -100,7 +100,7 @@ export function CategoryMultiSelect({ icon, placeholder, selectedValues, items, 
                 if (!isDisabled) handleSelect(item.value);
               }}
               className={cn(
-                'flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+                'lg:text-body-02-r flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
                 isSelected && 'bg-blue-100 text-blue-400',
                 isDisabled && 'cursor-not-allowed opacity-40 hover:bg-transparent hover:text-inherit',
               )}

--- a/src/components/Search/SearchForm/FilterDropdown.tsx
+++ b/src/components/Search/SearchForm/FilterDropdown.tsx
@@ -51,7 +51,7 @@ export function FilterDropdown({ icon, placeholder, selectedValue, items, onSele
           <RotatingArrow />
         </div>
       </Dropdown.Trigger>
-      <Dropdown.Menu className='w-full min-w-[160px] overflow-hidden p-2'>
+      <Dropdown.Menu className='flex w-full min-w-[160px] flex-col gap-1 overflow-hidden p-2'>
         {items.map((item) => {
           const isSelected = selectedValue === item.value;
           return (
@@ -59,7 +59,7 @@ export function FilterDropdown({ icon, placeholder, selectedValue, items, onSele
               key={item.label}
               onClick={() => onSelect(item.value)}
               className={cn(
-                'cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+                'lg:text-body-02-r cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
                 isSelected && 'bg-blue-100 text-blue-400',
               )}
             >

--- a/src/components/Search/SearchForm/index.tsx
+++ b/src/components/Search/SearchForm/index.tsx
@@ -17,8 +17,10 @@ const TYPE_ITEMS = [{ label: '전체', value: null }, ...GATHERING_TYPES.map((t)
 const CATEGORY_ITEMS = DEFAULT_CATEGORIES.map((c) => ({ label: c.name, value: c.id }));
 
 export function SearchForm() {
-  const { type, categoryIds, setParams } = useGatheringSearchParams();
+  const { type, categoryIds, query, setParams } = useGatheringSearchParams();
   const [inputValue, setInputValue] = useState('');
+  const hasActiveFilter = !!type || categoryIds.length > 0 || !!query;
+  const searchVariant = hasActiveFilter ? 'search-gradient' : 'search';
 
   const handleSearch = () => {
     const trimmed = inputValue.trim();
@@ -75,7 +77,7 @@ export function SearchForm() {
           />
         </div>
 
-        <Button variant='search-gradient' size='search' onClick={handleSearch} className='hidden xl:block'>
+        <Button variant={searchVariant} size='search' onClick={handleSearch} className='relative z-1 hidden xl:block'>
           검색
         </Button>
       </div>
@@ -83,7 +85,7 @@ export function SearchForm() {
       <ActiveFilters />
 
       <Button
-        variant='search-gradient'
+        variant={searchVariant}
         onClick={handleSearch}
         className='text-body-02-sb md:text-body-01-sb h-[58px] w-full rounded-lg md:h-18 xl:hidden'
       >

--- a/src/components/ui/Icon/SearchIcon/index.tsx
+++ b/src/components/ui/Icon/SearchIcon/index.tsx
@@ -2,8 +2,8 @@ import { IconBase } from '../IconBase';
 import type { IconProps } from '../types';
 
 const VIEW_BOX = '0 0 24 24';
-const PATH =
-  'M17.6 16.55L14.8 13.75C15.1 13.33 15.33 12.86 15.49 12.34C15.66 11.82 15.74 11.27 15.74 10.7C15.74 9.14 15.18 7.81 14.07 6.7C12.96 5.59 11.63 5.03 10.07 5.03C8.51 5.03 7.18 5.59 6.07 6.7C4.96 7.81 4.4 9.14 4.4 10.7C4.4 12.26 4.96 13.59 6.07 14.7C7.18 15.81 8.51 16.37 10.07 16.37C10.67 16.37 11.24 16.29 11.76 16.12C12.29 15.94 12.77 15.7 13.2 15.39L16 18.2L17.6 16.55ZM10.07 14.37C9.07 14.37 8.21 14.01 7.49 13.29C6.77 12.57 6.4 11.71 6.4 10.7C6.4 9.7 6.76 8.84 7.49 8.12C8.21 7.4 9.07 7.03 10.07 7.03C11.07 7.03 11.93 7.39 12.65 8.12C13.37 8.84 13.74 9.7 13.74 10.7C13.74 11.7 13.38 12.56 12.65 13.28C11.93 14 11.07 14.37 10.07 14.37Z';
+const CIRCLE = { cx: 10.5, cy: 10.5, r: 5.5 };
+const LINE = { x1: 14.5, y1: 14.5, x2: 20, y2: 20 };
 
 // SVG fill은 CSS currentColor로 그라디언트를 적용할 수 없어,
 // gradient prop이 true일 때 <defs>에 linearGradient를 정의하고 fill='url(#id)'로 참조한다.
@@ -24,7 +24,23 @@ export function SearchIcon({ gradient = false, ...props }: SearchIconProps) {
           </linearGradient>
         </defs>
       )}
-      <path d={PATH} fill={gradient ? `url(#${GRADIENT_ID})` : 'currentColor'} />
+      <circle
+        cx={CIRCLE.cx}
+        cy={CIRCLE.cy}
+        r={CIRCLE.r}
+        fill='none'
+        stroke={gradient ? `url(#${GRADIENT_ID})` : 'currentColor'}
+        strokeWidth={1.8}
+      />
+      <line
+        x1={LINE.x1}
+        y1={LINE.y1}
+        x2={LINE.x2}
+        y2={LINE.y2}
+        stroke={gradient ? `url(#${GRADIENT_ID})` : 'currentColor'}
+        strokeWidth={1.8}
+        strokeLinecap='round'
+      />
     </IconBase>
   );
 }


### PR DESCRIPTION
 ## ❓ 이슈

  - close #238

  ## ✍️  Description

  디자인 QA에서 받은 피드백을 반영했습니다.

  - **SearchIcon**: filled → stroke 스타일로 변경 (시안 대비 얇고 긴 돋보기 형태)
  - **드롭다운 메뉴**: 항목 간 gap 추가로 호버 배경 겹침 해결 + PC에서 텍스트 크기 `text-body-02-r`(16px) 적용
  - **검색 버튼**: 기본 `bg-blue-300` 단색 → 필터 활성화 시 `bg-gradient-primary` 그라디언트로 전환 + gradient border 겹침 수정
  - **찜 버튼**: 44x44px 크기 고정 (`shrink-0`) + 하트 아이콘 20px → 24px

  ## 📸 스크린샷 (UI 변경 시)



  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [x] (없음)
