### PR TITLE
[SM-153] fix: 마이페이지 프로필 이미지 수정 - URL 텍스트 입력을 파일 업로드로 변경

### DIFF
--- a/src/api/users/index.ts
+++ b/src/api/users/index.ts
@@ -24,9 +24,13 @@ export const getUsersMe = async (): Promise<User> => {
 export const updateProfile = async (body: UpdateProfileForm): Promise<UpdateProfileResponseData> => {
   const formData = new FormData();
 
+  const requestData: Record<string, string> = {};
   if (body.nickname !== undefined) {
-    formData.append('nickname', body.nickname);
+    requestData.nickname = body.nickname;
   }
+
+  const requestBlob = new Blob([JSON.stringify(requestData)], { type: 'application/json' });
+  formData.append('request', requestBlob);
 
   if (body.profileImage) {
     formData.append('profileImage', body.profileImage);

--- a/src/app/my/_components/LikedGatheringsList/index.tsx
+++ b/src/app/my/_components/LikedGatheringsList/index.tsx
@@ -140,7 +140,7 @@ export function LikedGatheringsList() {
                 <RotatingArrow />
               </div>
             </Dropdown.Trigger>
-            <Dropdown.Menu className='flex flex-col gap-3 overflow-hidden px-3 py-2 whitespace-nowrap'>
+            <Dropdown.Menu className='flex flex-col gap-3 overflow-hidden p-2 whitespace-nowrap md:p-3'>
               {STATUS_OPTIONS.map((option) => {
                 const isSelected = status === option.value;
                 return (
@@ -148,8 +148,8 @@ export function LikedGatheringsList() {
                     key={option.value}
                     onClick={() => handleFilterChange({ status: option.value })}
                     className={cn(
-                      'text-small-02-m md:text-body-02-r cursor-pointer rounded-lg px-4 py-2 text-gray-500 hover:bg-blue-100 hover:text-blue-400',
-                      isSelected && 'text-small-02-m md:text-body-02-m bg-blue-100 text-gray-900',
+                      'text-small-02-m md:text-body-02-r cursor-pointer rounded-lg pr-4 text-gray-500 hover:text-gray-900',
+                      isSelected && 'text-small-02-m md:text-body-02-m text-gray-900',
                     )}
                   >
                     {option.label}

--- a/src/app/my/_components/MyCreatedGatheringList/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringList/index.tsx
@@ -126,7 +126,7 @@ export function MyCreatedGatheringList() {
                 <RotatingArrow />
               </div>
             </Dropdown.Trigger>
-            <Dropdown.Menu className='flex min-w-[100px] flex-col gap-3 overflow-hidden px-3 py-2 whitespace-nowrap'>
+            <Dropdown.Menu className='flex min-w-[100px] flex-col gap-3 overflow-hidden p-2 whitespace-nowrap md:p-3'>
               {STATUS_OPTIONS.map((option) => {
                 const isSelected = status === option.value;
                 return (
@@ -134,8 +134,8 @@ export function MyCreatedGatheringList() {
                     key={option.value}
                     onClick={() => handleFilterChange({ status: option.value })}
                     className={cn(
-                      'text-small-02-m md:text-body-02-r cursor-pointer rounded-lg px-4 py-2 text-gray-500 hover:bg-blue-100 hover:text-blue-400',
-                      isSelected && 'text-small-02-m md:text-body-02-m bg-blue-100 text-gray-900',
+                      'text-small-02-m md:text-body-02-r cursor-pointer rounded-lg pr-4 text-gray-500 hover:text-gray-900',
+                      isSelected && 'text-small-02-m md:text-body-02-m text-gray-900',
                     )}
                   >
                     {option.label}

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -120,7 +120,7 @@ export function MyGatheringsList() {
                 <RotatingArrow />
               </div>
             </Dropdown.Trigger>
-            <Dropdown.Menu className='flex flex-col gap-3 overflow-hidden px-3 py-2 whitespace-nowrap'>
+            <Dropdown.Menu className='flex flex-col gap-3 overflow-hidden p-2 whitespace-nowrap md:p-3'>
               {STATUS_OPTIONS.map((option) => {
                 const isSelected = status === option.value;
                 return (
@@ -128,8 +128,8 @@ export function MyGatheringsList() {
                     key={option.value}
                     onClick={() => handleFilterChange({ status: option.value })}
                     className={cn(
-                      'text-small-02-m md:text-body-02-r cursor-pointer rounded-lg px-4 py-2 text-gray-500 hover:bg-blue-100 hover:text-blue-400',
-                      isSelected && 'text-small-02-m md:text-body-02-m bg-blue-100 text-gray-900',
+                      'text-small-02-m md:text-body-02-r cursor-pointer rounded-lg pr-4 text-gray-500 hover:text-gray-900',
+                      isSelected && 'text-small-02-m md:text-body-02-m text-gray-900',
                     )}
                   >
                     {option.label}

--- a/src/app/my/_components/MyPageTabs/index.tsx
+++ b/src/app/my/_components/MyPageTabs/index.tsx
@@ -20,8 +20,8 @@ const buildTabHref = (key: MyPageTab, pendingSort: PendingGatheringSort) => {
 
 export function MyPageTabs({ activeTab, pendingSort }: MyPageTabsProps) {
   return (
-    <nav>
-      <ul className='scrollbar-none flex flex-nowrap gap-2 overflow-x-auto'>
+    <nav className='after:bg-gray-150 relative after:absolute after:inset-x-0 after:bottom-0 after:h-[2px]'>
+      <ul className='scrollbar-none relative z-1 flex flex-nowrap gap-2 overflow-x-auto'>
         {MY_PAGE_TAB_ITEMS.map(({ key, label }) => {
           const isActive = activeTab === key;
 

--- a/src/app/my/_components/ProfileSidebar/ProfileEditForm/index.tsx
+++ b/src/app/my/_components/ProfileSidebar/ProfileEditForm/index.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import type { UseFormRegister, FieldErrors, UseFormHandleSubmit } from 'react-hook-form';
+import { useRef } from 'react';
+
+import { Controller } from 'react-hook-form';
+
+import type { Control, UseFormRegister, FieldErrors, UseFormHandleSubmit } from 'react-hook-form';
 
 import type { UpdateProfileForm } from '@/api/users/types';
-import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 
+const ACCEPTED_IMAGE_TYPES = 'image/jpeg,image/png,image/webp';
+
 interface ProfileEditFormProps {
+  control: Control<UpdateProfileForm>;
   register: UseFormRegister<UpdateProfileForm>;
   handleSubmit: UseFormHandleSubmit<UpdateProfileForm>;
   errors: FieldErrors<UpdateProfileForm>;
@@ -16,6 +22,7 @@ interface ProfileEditFormProps {
 }
 
 export function ProfileEditForm({
+  control,
   register,
   handleSubmit,
   errors,
@@ -23,6 +30,8 @@ export function ProfileEditForm({
   onSubmit,
   onCancel,
 }: ProfileEditFormProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   return (
     <form
       className='border-gray-150 flex w-full flex-col gap-4 rounded-xl border border-dashed p-4'
@@ -42,20 +51,59 @@ export function ProfileEditForm({
         {...register('nickname')}
         className='h-11 w-full'
       />
-      <Input
-        label='프로필 이미지 URL'
-        placeholder='비우면 기본 이미지 (jpg, png, webp URL)'
-        error={errors.profileImage?.message}
-        {...register('profileImage')}
-        className='h-11 w-full'
+      <Controller
+        name='profileImage'
+        control={control}
+        render={({ field }) => (
+          <div className='flex flex-col gap-1.5'>
+            <label className='text-sm font-bold text-gray-900'>프로필 이미지</label>
+            <input
+              ref={fileInputRef}
+              type='file'
+              accept={ACCEPTED_IMAGE_TYPES}
+              className='hidden'
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                field.onChange(file);
+              }}
+            />
+            <div className='flex items-center gap-2'>
+              <button
+                type='button'
+                className='text-small-01-r border-gray-150 h-11 shrink-0 rounded-lg border px-4 text-gray-800'
+                onClick={() => fileInputRef.current?.click()}
+              >
+                파일 선택
+              </button>
+              <span className='text-small-01-r min-w-0 truncate text-gray-600'>
+                {field.value instanceof File ? field.value.name : '선택된 파일 없음'}
+              </span>
+            </div>
+            <p className='text-small-02-r text-gray-400'>jpg, png, webp / 5MB 이하</p>
+            {errors.profileImage?.message && (
+              <p className='text-xs text-red-200' role='alert'>
+                {errors.profileImage.message}
+              </p>
+            )}
+          </div>
+        )}
       />
-      <div className='flex w-full flex-wrap justify-end gap-2'>
-        <Button type='button' variant='file-upload' size='file-upload' onClick={onCancel} disabled={isPending}>
+      <div className='flex w-full justify-end gap-2'>
+        <button
+          type='button'
+          className='text-small-01-r border-gray-150 h-11 rounded-lg border px-6 text-gray-800 disabled:opacity-50'
+          onClick={onCancel}
+          disabled={isPending}
+        >
           취소
-        </Button>
-        <Button type='submit' variant='primary' className='h-12 min-w-[100px] rounded-lg' disabled={isPending}>
+        </button>
+        <button
+          type='submit'
+          className='text-small-01-r bg-gradient-primary h-11 rounded-lg px-6 text-white disabled:opacity-50'
+          disabled={isPending}
+        >
           {isPending ? '저장 중...' : '저장'}
-        </Button>
+        </button>
       </div>
     </form>
   );

--- a/src/app/my/_components/ProfileSidebar/ProfileIdentitySection/index.tsx
+++ b/src/app/my/_components/ProfileSidebar/ProfileIdentitySection/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FieldErrors, UseFormHandleSubmit, UseFormRegister } from 'react-hook-form';
+import type { Control, FieldErrors, UseFormHandleSubmit, UseFormRegister } from 'react-hook-form';
 
 import type { UpdateProfileForm, User } from '@/api/users/types';
 import { Button } from '@/components/ui/Button';
@@ -16,6 +16,7 @@ interface ProfileIdentitySectionProps {
   user: Pick<User, 'nickname' | 'email' | 'provider' | 'profileImage'>;
   previewImageUrl: string;
   previewNickname: string;
+  control: Control<UpdateProfileForm>;
   register: UseFormRegister<UpdateProfileForm>;
   handleSubmit: UseFormHandleSubmit<UpdateProfileForm>;
   errors: FieldErrors<UpdateProfileForm>;
@@ -31,6 +32,7 @@ export function ProfileIdentitySection({
   user,
   previewImageUrl,
   previewNickname,
+  control,
   register,
   handleSubmit,
   errors,
@@ -42,6 +44,7 @@ export function ProfileIdentitySection({
   if (isEditing) {
     return (
       <ProfileEditForm
+        control={control}
         register={register}
         handleSubmit={handleSubmit}
         errors={errors}

--- a/src/app/my/_components/ProfileSidebar/index.tsx
+++ b/src/app/my/_components/ProfileSidebar/index.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/cn';
 
 import { ActivityEnergySection } from './ActivityEnergySection';
 import { ActivityStatsSection } from './ActivityStatsSection';
+import { ProfileEditForm } from './ProfileEditForm';
 import { ProfileIdentitySection } from './ProfileIdentitySection';
 import { SidebarAvatar } from './SidebarAvatar';
 
@@ -55,6 +56,7 @@ export function ProfileSidebar({ className }: ProfileSidebarProps) {
   const showToast = useToastStore((s) => s.showToast);
 
   const {
+    control,
     register,
     handleSubmit,
     reset,
@@ -130,6 +132,7 @@ export function ProfileSidebar({ className }: ProfileSidebarProps) {
     user,
     previewImageUrl,
     previewNickname,
+    control,
     register,
     handleSubmit,
     errors,
@@ -146,40 +149,54 @@ export function ProfileSidebar({ className }: ProfileSidebarProps) {
         className,
       )}
     >
-      <div className='md:hidden'>
-        <ProfileIdentitySection layout='mobile' {...identityProps} />
-      </div>
-
-      <div className='hidden p-8 md:flex md:w-full lg:hidden'>
-        <div className='md:border-gray-150 flex flex-col items-center md:shrink-0 md:border-r md:pr-8'>
-          <div className='flex flex-col items-center'>
-            <SidebarAvatar imageUrl={previewImageUrl} nickname={previewNickname} size={140} />
-          </div>
-          <ProfileIdentitySection layout='tablet' {...identityProps} />
-        </div>
-
-        <div className='flex flex-col md:w-full md:flex-1 md:pl-8'>
-          <ActivityEnergySection
-            variant='tablet'
-            reputationScore={user.reputationScore}
-            reputationLabel={user.reputationLabel}
-          />
-          <ActivityStatsSection variant='tablet' rows={statRows} />
-        </div>
-      </div>
-
-      <div className='hidden w-full flex-col items-center lg:flex'>
-        <ProfileIdentitySection layout='desktop' {...identityProps} />
-      </div>
-
-      <div className='md:hidden lg:block'>
-        <ActivityEnergySection
-          variant='wide'
-          reputationScore={user.reputationScore}
-          reputationLabel={user.reputationLabel}
+      {isEditing ? (
+        <ProfileEditForm
+          control={control}
+          register={register}
+          handleSubmit={handleSubmit}
+          errors={errors}
+          isPending={isPending}
+          onSubmit={onSubmit}
+          onCancel={handleCancelEdit}
         />
-        <ActivityStatsSection variant='wide' rows={statRows} />
-      </div>
+      ) : (
+        <>
+          <div className='md:hidden'>
+            <ProfileIdentitySection layout='mobile' {...identityProps} />
+          </div>
+
+          <div className='hidden p-8 md:flex md:w-full lg:hidden'>
+            <div className='md:border-gray-150 flex flex-col items-center md:shrink-0 md:border-r md:pr-8'>
+              <div className='flex flex-col items-center'>
+                <SidebarAvatar imageUrl={previewImageUrl} nickname={previewNickname} size={140} />
+              </div>
+              <ProfileIdentitySection layout='tablet' {...identityProps} />
+            </div>
+
+            <div className='flex flex-col md:w-full md:flex-1 md:pl-8'>
+              <ActivityEnergySection
+                variant='tablet'
+                reputationScore={user.reputationScore}
+                reputationLabel={user.reputationLabel}
+              />
+              <ActivityStatsSection variant='tablet' rows={statRows} />
+            </div>
+          </div>
+
+          <div className='hidden w-full flex-col items-center lg:flex'>
+            <ProfileIdentitySection layout='desktop' {...identityProps} />
+          </div>
+
+          <div className='md:hidden lg:block'>
+            <ActivityEnergySection
+              variant='wide'
+              reputationScore={user.reputationScore}
+              reputationLabel={user.reputationLabel}
+            />
+            <ActivityStatsSection variant='wide' rows={statRows} />
+          </div>
+        </>
+      )}
     </aside>
   );
 }

--- a/src/app/my/_components/ProfileSidebar/index.tsx
+++ b/src/app/my/_components/ProfileSidebar/index.tsx
@@ -27,7 +27,7 @@ export function ProfileSidebarSkeleton({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'border-gray-150 bg-gray-0 w-full max-w-[450px] animate-pulse rounded-2xl border px-7 py-12 shadow-(--shadow-02)',
+        'border-gray-150 bg-gray-0 w-full animate-pulse rounded-2xl border px-7 py-12 shadow-(--shadow-02) lg:w-[35%] lg:min-w-[300px] lg:shrink-0',
         className,
       )}
     >
@@ -145,7 +145,7 @@ export function ProfileSidebar({ className }: ProfileSidebarProps) {
   return (
     <aside
       className={cn(
-        'border-gray-150 bg-gray-0 w-full rounded-2xl border px-6 py-6 shadow-(--shadow-02) md:max-h-[688px] md:px-7 md:py-8 lg:max-h-[915px] lg:max-w-[450px] lg:px-7 lg:py-12',
+        'border-gray-150 bg-gray-0 w-full rounded-2xl border px-6 py-6 shadow-(--shadow-02) md:max-h-[688px] md:px-7 md:py-8 lg:max-h-[915px] lg:w-[35%] lg:min-w-[300px] lg:shrink-0 lg:px-7 lg:py-12',
         className,
       )}
     >

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -17,8 +17,8 @@ export default async function MyPage({ searchParams }: MyPageProps) {
 
   return (
     <main className='min-h-screen bg-gray-50'>
-      <div className='px-4 py-6 md:px-7 lg:px-15'>
-        <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mt-12'>마이페이지</h1>
+      <div className='px-4 py-6 md:px-7 xl:px-30 xl:pt-20 xl:pb-40'>
+        <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b'>마이페이지</h1>
         <div className='mt-11 flex flex-col gap-8 lg:flex-row lg:items-start'>
           <SuspenseBoundary
             pendingFallback={<ProfileSidebarSkeleton />}


### PR DESCRIPTION
 - close #242

  ## ✍️  Description

  마이페이지 프로필 이미지 수정 시 URL 텍스트 입력이었던 것을 파일 업로드 방식으로 변경하고, API FormData 구조를 백엔드 규격(request JSON Blob + profileImage File)에 맞게 수정했습니다.

  ### 주요 변경
  - 프로필 이미지 입력: URL 텍스트 → `<input type="file">` + Controller 패턴
  - `updateProfile` API: nickname을 `request` JSON Blob으로 전송하도록 수정
  - 편집 폼 렌더링 버그 수정 및 control props 전달
  - 마이페이지 드롭다운 메뉴, 탭 하단선 스타일 수정
  - 프로필 사이드바 PC 너비를 고정(450px) → 비율 기반(35%, min 300px)으로 변경

  ## 📸 스크린샷 (UI 변경 시)



  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [ ] 프로필 수정 API는 현재 백엔드 이슈로 동작하지 않아 백엔드 수정 후 재확인 필요