### PR TITLE
[SM-154] fix/style: 디자인QA 모임 상세페이지 수정사항 반영

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import axios from 'axios';
 import { useCreateApplication } from '@/api/applications/queries';
 import { BottomSheet } from '@/components/ui/BottomSheet';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { useFunnel } from '@/hooks/useFunnel';
 import { GatheringApplyForm } from '../../GatheringApplyForm';
 import { GatheringApplySuccess } from '../../GatheringApplySuccess';
@@ -20,9 +22,17 @@ export function GatheringApplyBottomSheet({
   gatheringTitle,
 }: GatheringApplyBottomSheetProps) {
   const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
+  const { showToast } = useToastStore();
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => setStep('SUCCESS'),
+    onError: (error) => {
+      if (axios.isAxiosError(error) && error.response?.data?.message) {
+        showToast({ variant: 'error', title: error.response.data.message });
+        return;
+      }
+      showToast({ variant: 'error', title: '신청에 실패했습니다.' });
+    },
   });
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose}>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
@@ -100,7 +100,12 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
         </label>
       </div>
 
-      <Button type='submit' variant='action' className='w-full' disabled={!isValid || isLoading}>
+      <Button
+        type='submit'
+        variant='action'
+        className='text-body-01-sb h-13.5 w-full md:h-18 lg:h-20'
+        disabled={!isValid || isLoading}
+      >
         {isLoading ? '신청 중...' : '작성 완료'}
       </Button>
     </form>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringApplyForm/index.tsx
@@ -54,16 +54,16 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
       <div className='flex flex-col gap-2'>
         <h2 className='text-h3-b text-gray-900'>모임 신청</h2>
         <p className='text-body-02-m text-gray-600'>
-          신청 모임 <span className='mx-2 text-gray-300'>|</span>{' '}
-          <span className='text-body-02-b text-gray-900'>{gatheringTitle}</span>
+          신청 모임 <span className='mx-2 text-gray-600'>|</span>{' '}
+          <span className='text-body-02-sb text-gray-900'>{gatheringTitle}</span>
         </p>
       </div>
 
       <div className='flex flex-col gap-4'>
         <div className='relative flex flex-col gap-2'>
           <div className='flex justify-between'>
-            <label className='text-body-02-b text-gray-900'>
-              나의 목표 <span className='text-blue-300'>*</span>
+            <label className='text-body-02-m text-gray-800'>
+              나의 목표 <span className='text-blue-400'>*</span>
             </label>
           </div>
           <Textarea
@@ -76,7 +76,7 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
         </div>
 
         <div className='relative flex flex-col gap-2'>
-          <label className='text-body-02-b text-gray-900'>한 줄 소개</label>
+          <label className='text-body-02-m text-gray-800'>한 줄 소개</label>
           <Textarea
             {...register('selfIntroduction')}
             placeholder='(선택) 모임장에게 한마디를 적어주세요.'
@@ -90,15 +90,11 @@ export function GatheringApplyForm({ gatheringTitle, onSubmit, isLoading }: Gath
       </div>
 
       <div className='flex flex-col gap-2'>
-        <p className='text-body-02-b text-gray-900'>팀 구성을 위해 닉네임과 평판 점수가 모임장에게 전달됩니다.</p>
+        <p className='text-body-02-m text-gray-800'>팀 구성을 위해 닉네임과 평판 점수가 모임장에게 전달됩니다.</p>
         <label className='flex cursor-pointer items-center gap-2'>
-          <div className='relative flex h-5 w-5 items-center justify-center'>
-            <input type='checkbox' {...register('agreement')} className='peer sr-only' />
-            <div className='flex h-4 w-4 items-center justify-center rounded-md border border-gray-200 bg-white transition-colors peer-checked:border-blue-300 peer-checked:bg-blue-300'>
-              <CheckIcon size={16} className='text-white' />
-            </div>
-          </div>
-          <span className={cn('text-body-02-m transition-colors', agreement ? 'text-gray-900' : 'text-gray-400')}>
+          <input type='checkbox' {...register('agreement')} className='peer sr-only' />
+          <CheckIcon className={cn('size-5 transition-colors', agreement ? 'text-blue-300' : 'text-gray-500')} />
+          <span className={cn('text-small-01-r transition-colors', agreement ? 'text-blue-300' : 'text-gray-500')}>
             내용을 확인했으며 제공에 동의합니다.
           </span>
         </label>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -155,7 +155,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
             <Button
               variant='action'
-              className={`text-body-01-sb h-13.5 flex-1 md:h-18 ${!isJoinable || hasPendingApplication ? 'bg-gray-300' : ''}`}
+              className='text-body-01-sb h-13.5 w-full md:h-18 lg:h-20'
               disabled={!isJoinable || hasPendingApplication}
               onClick={async () => {
                 if (!isLoggedIn) {

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { useLikeToggle } from '@/api/likes/hooks';
@@ -14,6 +15,7 @@ import { AuthModal } from '@/components/AuthModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useFunnel } from '@/hooks/useFunnel';
 import { useOverlay } from '@/hooks/useOverlay';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
 
 import { DeadlineLabel } from '../DeadlineLabel';
 import { InfoAccordion } from '../InfoAccordion';
@@ -46,11 +48,19 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const { isLiked, isPending: isLikePending, toggleLike } = useLikeToggle(gatheringId);
   const overlay = useOverlay();
+  const { showToast } = useToastStore();
   const { Funnel, Step, setStep } = useFunnel<'DEFAULT' | 'APPLY' | 'SUCCESS'>('DEFAULT');
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
       setStep('SUCCESS');
+    },
+    onError: (error) => {
+      if (axios.isAxiosError(error) && error.response?.data?.message) {
+        showToast({ variant: 'error', title: error.response.data.message });
+        return;
+      }
+      showToast({ variant: 'error', title: '신청에 실패했습니다.' });
     },
   });
 

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -8,7 +8,6 @@ import { useLikeToggle } from '@/api/likes/hooks';
 import { applicationQueries, useCreateApplication } from '@/api/applications/queries';
 import { getCurrentWeek } from '@/lib/formatGatheringDate';
 import { Button } from '@/components/ui/Button';
-import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { AuthModal } from '@/components/AuthModal';
@@ -104,20 +103,20 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
       <Funnel>
         <Step name='APPLY'>
-          <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+          <div className='border-focus-100 shadow-01 w-full rounded-2xl border bg-white p-8'>
             <GatheringApplyForm gatheringTitle={data.title} onSubmit={mutate} isLoading={isPending} />
           </div>
         </Step>
 
         <Step name='SUCCESS'>
-          <div className='border-gray-150 rounded-2xl border bg-white p-8 shadow-sm'>
+          <div className='border-focus-100 shadow-01 w-full rounded-2xl border bg-white p-8'>
             <GatheringApplySuccess onClose={() => setStep('DEFAULT')} />
           </div>
         </Step>
 
         <Step name='DEFAULT'>
-          <GatheringCard className='border-focus-100 w-full border'>
-            <GatheringCard.Header className='items-center'>
+          <div className='border-focus-100 shadow-01 w-full rounded-2xl border bg-white p-7'>
+            <div className='mb-6 flex items-center justify-between'>
               <Tag
                 variant='category'
                 icon={<TypeIcon size={14} className='text-blue-200' />}
@@ -135,9 +134,9 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
               >
                 <HeartIcon size={20} variant={isLiked ? 'filled' : 'outline'} />
               </Button>
-            </GatheringCard.Header>
+            </div>
 
-            <GatheringCard.Body className='mb-10 gap-2'>
+            <div className='mb-10 flex flex-col gap-2'>
               <div className='flex flex-wrap gap-1'>
                 {data.tags.map((tag) => (
                   <span key={tag} className='text-body-02-r text-gray-700'>
@@ -145,14 +144,14 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                   </span>
                 ))}
               </div>
-              <p className='text-body-01-b text-gray-900'>{data.title}</p>
-              <p className='text-small-01-r text-gray-800'>{data.shortDescription}</p>
-            </GatheringCard.Body>
+              <h3 className='text-h3-b text-gray-900'>{data.title}</h3>
+              <p className='text-body-02-r text-gray-800'>{data.shortDescription}</p>
+            </div>
 
-            <GatheringCard.Footer className='flex-col'>
+            <div className='flex flex-col'>
               <InfoAccordion data={data} className='mb-7' />
               <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
-            </GatheringCard.Footer>
+            </div>
 
             <Button
               variant='action'
@@ -176,7 +175,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                 status: data.status,
               })}
             </Button>
-          </GatheringCard>
+          </div>
         </Step>
       </Funnel>
     </div>

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -71,7 +71,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
   const { displayLabel, tagState, isJoinable, isFull, isDeadlinePassed, isFinished } = getGatheringDisplayStatus(data);
 
   return (
-    <div className='sticky top-[-20px]'>
+    <div>
       {/* 모집 상태 바 - 항상 노출 */}
       {tagState === 'recruiting' && (
         <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -43,7 +43,11 @@ export function ParticipantsList({ members, maxMembers, className }: Participant
               className='flex cursor-pointer items-center justify-between rounded-md p-2 hover:bg-blue-100'
             >
               <div className='flex items-center gap-2'>
-                <AvatarGroup avatars={[{ id: member.userId, imageUrl: member.profileImage }]} size='md' />
+                <AvatarGroup
+                  avatars={[{ id: member.userId, imageUrl: member.profileImage }]}
+                  size='md'
+                  shape='square'
+                />
                 <span className='text-sm font-medium'>{member.nickname}</span>
               </div>
               <span className='text-small-02-r text-blue-300'>상세보기</span>

--- a/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
@@ -55,7 +55,7 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
         </section>
       )}
 
-      <section id='recruit-period' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+      <section id='recruit-period' className='mt-10 scroll-mt-10 md:mt-15 lg:mt-25 xl:scroll-mt-12'>
         <InfoCard title='모집 기간 📌'>
           <span className='text-body-02-m xl:text-body-01-m text-gray-800'>
             ~ {formatDateDot(data.recruitDeadline)} ({formatDday(data.recruitDeadline)})
@@ -63,7 +63,7 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
         </InfoCard>
       </section>
 
-      <section id='activity-period' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+      <section id='activity-period' className='mt-10 scroll-mt-10 md:mt-15 lg:mt-25 xl:scroll-mt-12'>
         <InfoCard title='활동 기간 🗓️'>
           <span className='text-body-02-m xl:text-body-01-m text-gray-800'>
             {formatDateDot(data.startDate)} ~ {formatDateDot(data.endDate)} ({data.totalWeeks}주)
@@ -71,14 +71,14 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
         </InfoCard>
       </section>
 
-      <section id='goal' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+      <section id='goal' className='mt-10 scroll-mt-10 md:mt-15 lg:mt-25 xl:scroll-mt-12'>
         <InfoCard title='모임 최종 목표 🔥'>
           <span className='text-body-02-m xl:text-body-01-m text-gray-800'>{data.goal}</span>
         </InfoCard>
       </section>
 
       {data.weeklyPlans.length > 0 && (
-        <section id='weekly-plans' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+        <section id='weekly-plans' className='mt-10 scroll-mt-10 md:mt-15 lg:mt-25 xl:scroll-mt-12'>
           <div className='flex flex-col gap-4 xl:gap-6'>
             <h2 className='text-body-01-sb xl:text-h5-sb text-gray-900'>주차별 계획 ✅</h2>
             <WeeklyPlanAccordion weeklyPlans={data.weeklyPlans} />
@@ -86,7 +86,7 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
         </section>
       )}
 
-      <section id='members' className='mt-15 scroll-mt-10 xl:scroll-mt-12'>
+      <section id='members' className='mt-10 scroll-mt-10 md:mt-15 lg:mt-25 xl:scroll-mt-12'>
         <div className='flex flex-col gap-6'>
           <h2 className='text-body-01-sb xl:text-h5-sb text-gray-900'>모집 인원 현황 👀</h2>
           <MembersStatus currentMembers={data.currentMembers} maxMembers={data.maxMembers} />

--- a/src/app/gatherings/[id]/_components/WeeklyPlanAccordion/index.tsx
+++ b/src/app/gatherings/[id]/_components/WeeklyPlanAccordion/index.tsx
@@ -46,7 +46,7 @@ export function WeeklyPlanAccordion({ weeklyPlans }: WeeklyPlanAccordionProps) {
                 size={28}
                 className={cn(
                   'text-gray-800 transition-transform duration-200 xl:h-8! xl:w-8!',
-                  isExpanded ? '-rotate-90' : 'rotate-90',
+                  isExpanded ? 'rotate-270' : 'rotate-90',
                 )}
                 viewBox='0 0 16 16'
               />

--- a/src/components/ui/AvatarGroup/index.tsx
+++ b/src/components/ui/AvatarGroup/index.tsx
@@ -2,35 +2,39 @@ import { cva } from 'class-variance-authority';
 
 import { cn } from '@/lib/cn';
 
-const avatarSizeVariants = cva(
-  'rounded-full border-2 border-gray-0 bg-gray-300 flex items-center justify-center overflow-hidden',
-  {
-    variants: {
-      size: {
-        sm: 'h-5 w-5',
-        md: 'h-8 w-8',
-      },
+const avatarSizeVariants = cva('bg-gray-300 flex items-center justify-center overflow-hidden', {
+  variants: {
+    size: {
+      sm: 'h-5 w-5',
+      md: 'h-8 w-8',
     },
-    defaultVariants: {
-      size: 'sm',
+    shape: {
+      circle: 'rounded-full border-2 border-gray-0',
+      square: 'rounded',
     },
   },
-);
+  defaultVariants: {
+    size: 'sm',
+    shape: 'circle',
+  },
+});
 
-const overflowSizeVariants = cva(
-  'rounded-full border-2 border-gray-0 bg-gray-200 flex items-center justify-center text-gray-500 font-medium',
-  {
-    variants: {
-      size: {
-        sm: 'h-5 w-5 text-[8px]',
-        md: 'h-8 w-8 text-[10px]',
-      },
+const overflowSizeVariants = cva('bg-gray-200 flex items-center justify-center text-gray-500 font-medium', {
+  variants: {
+    size: {
+      sm: 'h-5 w-5 text-[8px]',
+      md: 'h-8 w-8 text-[10px]',
     },
-    defaultVariants: {
-      size: 'sm',
+    shape: {
+      circle: 'rounded-full border-2 border-gray-0',
+      square: 'rounded',
     },
   },
-);
+  defaultVariants: {
+    size: 'sm',
+    shape: 'circle',
+  },
+});
 
 interface AvatarItem {
   id?: number;
@@ -44,12 +48,14 @@ interface AvatarGroupProps {
   max?: number;
   /** 아바타 크기 */
   size?: 'sm' | 'md';
+  /** 아바타 모양 */
+  shape?: 'circle' | 'square';
   className?: string;
 }
 
 const PLACEHOLDER_COLORS = ['bg-gray-300', 'bg-gray-400', 'bg-gray-500'] as const;
 
-export function AvatarGroup({ avatars, max, size = 'sm', className }: AvatarGroupProps) {
+export function AvatarGroup({ avatars, max, size = 'sm', shape = 'circle', className }: AvatarGroupProps) {
   const displayAvatars = max ? avatars.slice(0, max) : avatars;
   const overflowCount = max && avatars.length > max ? avatars.length - max : 0;
 
@@ -59,7 +65,7 @@ export function AvatarGroup({ avatars, max, size = 'sm', className }: AvatarGrou
         <div
           key={avatar.id ?? index}
           className={cn(
-            avatarSizeVariants({ size }),
+            avatarSizeVariants({ size, shape }),
             !avatar.imageUrl && PLACEHOLDER_COLORS[index % PLACEHOLDER_COLORS.length],
           )}
         >
@@ -68,7 +74,7 @@ export function AvatarGroup({ avatars, max, size = 'sm', className }: AvatarGrou
           )}
         </div>
       ))}
-      {overflowCount > 0 && <div className={overflowSizeVariants({ size })}>+{overflowCount}</div>}
+      {overflowCount > 0 && <div className={overflowSizeVariants({ size, shape })}>+{overflowCount}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## ❓ 이슈

- close #244 

## ✍️ Description

- 기존 모임장이나 이미 신청한 사람이 다시 신청하는 경우 에러메시지 토스트를 통해 보여주도록 수정
- GatheringInfoAside 상단에 고정 (sticky 해제)
- rotate 화살표 펼쳤을 때 위로 향하도록
- margin 수정 (기존 60 -> 100)
- 드롭다운 아이템에서 보이는 사진 원형에서 네모로
- 모임 신청 컴포넌트 디자인 수정(크기 볼드)
- 모임 신청 버튼 디자인 수정(크기)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
