### PR TITLE
[SM-156] fix: categoryIds 수정

### DIFF
--- a/src/constants/gathering.ts
+++ b/src/constants/gathering.ts
@@ -15,9 +15,9 @@ export const GATHERING_STATUS_LABEL = {
 } as const;
 
 export const DEFAULT_CATEGORIES = [
-  { id: 1, name: '개발' },
-  { id: 2, name: '어학' },
-  { id: 3, name: '독서' },
-  { id: 4, name: '자격증' },
-  { id: 5, name: '디자인' },
+  { id: 7, name: '개발' },
+  { id: 8, name: '어학' },
+  { id: 9, name: '독서' },
+  { id: 10, name: '자격증' },
+  { id: 11, name: '디자인' },
 ] as const;


### PR DESCRIPTION
## ❓ 이슈

  - close #248

  ## ✍️  Description

  `DEFAULT_CATEGORIES`의 카테고리 ID가 1~5로 하드코딩되어 있어 백엔드 실제 ID(7~11)와 불일치하여 모임 생성/수정 시 500 에러가 발생하던 문제를 수정했습니다.

  ### 주요 변경
  - `src/constants/gathering.ts`의 `DEFAULT_CATEGORIES` ID를 백엔드 실제 값(7~11)으로 수정

  ### 영향 범위
  - 모임 생성 폼 (`/gatherings/new`)
  - 모임 수정 폼 (`/gatherings/:id/edit`)
  - 모임 탐색 카테고리 필터 (`/gatherings`)

  ## 📸 스크린샷 (UI 변경 시)

  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [x] (없음)