### PR TITLE
[SM-157] fix: 백엔드 이미지 상대 경로 프록시 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,14 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   transpilePackages: ['until-async'],
   serverExternalPackages: ['msw'],
+  async rewrites() {
+    return [
+      {
+        source: '/images/:path*',
+        destination: `${process.env.BACKEND_BASE_URL}/images/:path*`,
+      },
+    ];
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
   transpilePackages: ['until-async'],
   serverExternalPackages: ['msw'],
   async rewrites() {
-    const backendBaseUrl = process.env.BACKEND_BASE_URL;
+    const backendBaseUrl = process.env.BACKEND_BASE_URL?.replace(/\/+$/, '');
     if (!backendBaseUrl) return [];
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,10 +5,12 @@ const nextConfig: NextConfig = {
   transpilePackages: ['until-async'],
   serverExternalPackages: ['msw'],
   async rewrites() {
+    const backendBaseUrl = process.env.BACKEND_BASE_URL;
+    if (!backendBaseUrl) return [];
     return [
       {
         source: '/images/:path*',
-        destination: `${process.env.BACKEND_BASE_URL}/images/:path*`,
+        destination: `${backendBaseUrl}/images/:path*`,
       },
     ];
   },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -90,5 +90,5 @@ export const proxy = async (request: NextRequest) => {
 };
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|images|favicon.ico|sitemap.xml|robots.txt).*)'],
 };


### PR DESCRIPTION
## ❓ 이슈

  - close #250

  ## ✍️  Description

  백엔드가 이미지 URL을 `/images/profiles/xxx.jpg` 상대 경로로 반환하지만, 프론트 서버에 해당 파일이 없어 이미지가 표시되지 않는 문제를 수정했습니다.

  ### 주요 변경
  - `next.config.ts`에 rewrite 추가: `/images/**` 요청을 백엔드 서버로 프록시
  - `src/proxy.ts` matcher에서 `/images` 제외하여 미들웨어가 이미지 요청을 가로채지 않도록 수정

  ### 영향 범위
  - 프로필 이미지 (마이페이지, 멤버 아바타)
  - 모임 이미지
  - `/images/**` 경로를 사용하는 모든 곳

  ## 📸 스크린샷 (UI 변경 시)

  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [ ] 로컬(http)에서는 백엔드 nginx가 403을 반환하여 테스트 불가, 프로덕션(https) 배포 후 검증 필요