### PR TITLE
[SM-152] style: 모임 만들기 페이지 디자인 수정

### DIFF
--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -95,9 +95,9 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         /* ── 0장: 큰 드롭존 ── */
         <div
           className={cn(
-            'flex w-full cursor-pointer flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-gray-300 bg-gray-100',
-            'h-[343px] md:h-[688px] lg:h-[448px]',
-            isDragging && 'border-gradient-primary',
+            'flex w-full cursor-pointer flex-col items-center justify-center gap-4 bg-gray-100',
+            'h-[343px] md:h-[688px] lg:h-[408px]',
+            isDragging ? 'rounded-lg border border-blue-300' : 'dashed-border-gray',
           )}
           onClick={openFilePicker}
           onDragOver={handleDragOver}
@@ -128,8 +128,9 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         /* ── 1장 이상: 썸네일 + 빈 슬롯 ── */
         <div
           className={cn(
-            'flex flex-row gap-2 overflow-x-auto rounded-lg border border-dashed border-gray-300 bg-gray-100 px-1 py-3 md:flex-wrap md:overflow-x-visible',
-            isDragging && 'border-blue-300',
+            'flex flex-row gap-2 overflow-x-auto bg-gray-100 px-1 py-3 md:flex-wrap md:overflow-x-visible md:overflow-y-auto',
+            'h-[343px] md:h-[688px] lg:h-[408px]',
+            isDragging ? 'rounded-lg border border-blue-300' : 'dashed-border-gray',
           )}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -44,7 +44,7 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
         <div
           className={cn(
             'flex min-h-[43px] flex-wrap items-center gap-2 px-3 py-2 md:min-h-[58px] lg:min-h-[72px] lg:px-7',
-            !hasError && 'rounded-[calc(0.375rem-1px)] bg-gray-50',
+            !hasError && 'bg-gray-0 rounded-[calc(0.375rem-1px)]',
           )}
         >
           {value.map((tag) => (

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -43,7 +43,7 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
       <div className={hasError ? 'bg-gray-0 rounded-md border border-red-200' : fieldGradientFocusWrapperClass}>
         <div
           className={cn(
-            'flex flex-wrap items-center gap-2 px-3 py-2',
+            'flex min-h-[43px] flex-wrap items-center gap-2 px-3 py-2 md:min-h-[58px] lg:min-h-[72px] lg:px-7',
             !hasError && 'rounded-[calc(0.375rem-1px)] bg-gray-50',
           )}
         >

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -57,7 +57,10 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
 
   return (
     <div className='flex flex-col gap-3'>
-      <p className='text-small-02-sb md:text-small-01-m lg:text-body-02-m text-gray-800'>세부 계획</p>
+      <p className='text-small-02-sb md:text-small-01-m lg:text-body-02-m flex items-center gap-1 text-gray-800'>
+        세부 계획
+        <span className='md:text-small-02-r lg:text-small-01-r text-[8px] font-normal text-gray-400'>(선택)</span>
+      </p>
 
       {details.length === 0 ? (
         <Button

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -72,24 +72,22 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
       ) : (
         <>
           <div className='flex flex-col gap-3 lg:flex-row'>
-            <div className='flex w-full flex-col gap-1.5 lg:w-1/2'>
-              <div className='flex items-center gap-2'>
-                <Input
-                  placeholder='세부 계획을 적어주세요'
-                  value={details[0] ?? ''}
-                  onBlur={field.onBlur}
-                  onChange={(event) => updateDetail(0, event.target.value)}
-                  error={error}
-                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
-                />
-                <button
-                  type='button'
-                  onClick={() => handleRemoveDetail(0)}
-                  className='shrink-0 text-gray-400 hover:text-gray-600'
-                >
-                  <CloseIcon className='size-4' />
-                </button>
-              </div>
+            <div className='relative w-full lg:w-1/2'>
+              <Input
+                placeholder='세부 계획을 적어주세요'
+                value={details[0] ?? ''}
+                onBlur={field.onBlur}
+                onChange={(event) => updateDetail(0, event.target.value)}
+                error={error}
+                className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-10 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-10'
+              />
+              <button
+                type='button'
+                onClick={() => handleRemoveDetail(0)}
+                className='absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600'
+              >
+                <CloseIcon className='size-4 md:size-5 lg:size-5' />
+              </button>
             </div>
             {canAddDetail && (
               <Button
@@ -105,23 +103,21 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
           </div>
 
           {details.length > 1 && (
-            <div className='flex w-full flex-col gap-1.5 lg:w-1/2'>
-              <div className='flex items-center gap-2'>
-                <Input
-                  placeholder='세부 계획을 적어주세요'
-                  value={details[1] ?? ''}
-                  onBlur={field.onBlur}
-                  onChange={(event) => updateDetail(1, event.target.value)}
-                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
-                />
-                <button
-                  type='button'
-                  onClick={() => handleRemoveDetail(1)}
-                  className='shrink-0 text-gray-400 hover:text-gray-600'
-                >
-                  <CloseIcon className='size-4' />
-                </button>
-              </div>
+            <div className='relative w-full lg:w-1/2'>
+              <Input
+                placeholder='세부 계획을 적어주세요'
+                value={details[1] ?? ''}
+                onBlur={field.onBlur}
+                onChange={(event) => updateDetail(1, event.target.value)}
+                className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-10 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-10'
+              />
+              <button
+                type='button'
+                onClick={() => handleRemoveDetail(1)}
+                className='absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600'
+              >
+                <CloseIcon className='size-4 md:size-5 lg:size-5' />
+              </button>
             </div>
           )}
 

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -80,7 +80,7 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
                   onBlur={field.onBlur}
                   onChange={(event) => updateDetail(0, event.target.value)}
                   error={error}
-                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
                 <button
                   type='button'
@@ -112,7 +112,7 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
                   value={details[1] ?? ''}
                   onBlur={field.onBlur}
                   onChange={(event) => updateDetail(1, event.target.value)}
-                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
                 <button
                   type='button'
@@ -197,7 +197,10 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
       <button
         type='button'
         onClick={() => setIsOpenOverride((prev) => !(prev ?? totalWeeks > 0))}
-        className='bg-gray-150 flex h-[43px] items-center justify-between rounded-lg border border-gray-200 px-7 py-5 md:h-[58px] lg:h-[72px]'
+        className={cn(
+          'bg-gray-150 flex h-[43px] items-center justify-between border border-gray-200 px-7 py-5 md:h-[58px] lg:h-[72px]',
+          isOpen ? 'rounded-t-lg rounded-b-none' : 'rounded-lg',
+        )}
       >
         <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
           주차별 계획 <span className='text-blue-400'>*</span>
@@ -240,7 +243,7 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
                     placeholder={`${index + 1}주차 계획의 제목을 적어주세요`}
                     error={guideErrors?.[index]?.title?.message as string | undefined}
                     {...register(`weeklyGuides.${index}.title`)}
-                    className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+                    className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                   />
 
                   <WeekDetailInputs

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -57,14 +57,14 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
 
   return (
     <div className='flex flex-col gap-3'>
-      <p className='text-small-02-m md:text-body-02-m text-gray-800'>세부 계획</p>
+      <p className='text-small-02-sb md:text-small-01-m lg:text-body-02-m text-gray-800'>세부 계획</p>
 
       {details.length === 0 ? (
         <Button
           type='button'
           variant='add-detail'
           size='add-detail'
-          className='h-[calc(2.75rem+2px)] w-full md:h-[calc(3.625rem+2px)]'
+          className='text-small-02-m md:text-body-02-m lg:text-body-01-m h-[43px] w-full md:h-[58px] lg:h-[72px]'
           onClick={handleAddDetail}
         >
           + 세부 계획 추가
@@ -80,7 +80,7 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
                   onBlur={field.onBlur}
                   onChange={(event) => updateDetail(0, event.target.value)}
                   error={error}
-                  className='text-small-02-r md:text-body-02-r h-11 md:h-14.5'
+                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
                 <button
                   type='button'
@@ -96,7 +96,7 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
                 type='button'
                 variant='add-detail'
                 size='add-detail'
-                className='hidden h-[calc(2.75rem+5px)] w-full md:h-[calc(3.625rem+5px)] lg:block lg:w-1/2'
+                className='text-small-02-m md:text-body-02-m lg:text-body-01-m hidden h-[43px] w-full md:h-[58px] lg:block lg:h-[72px] lg:w-1/2'
                 onClick={handleAddDetail}
               >
                 + 세부 계획 추가
@@ -112,7 +112,7 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
                   value={details[1] ?? ''}
                   onBlur={field.onBlur}
                   onChange={(event) => updateDetail(1, event.target.value)}
-                  className='text-small-02-r md:text-body-02-r h-11 md:h-14.5'
+                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
                 <button
                   type='button'
@@ -130,7 +130,7 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
               type='button'
               variant='add-detail'
               size='add-detail'
-              className='h-[calc(2.75rem+2px)] w-full md:h-[calc(3.625rem+2px)] lg:hidden'
+              className='text-small-02-m md:text-body-02-m lg:text-body-01-m h-[43px] w-full md:h-[58px] lg:hidden lg:h-[72px]'
               onClick={handleAddDetail}
             >
               + 세부 계획 추가
@@ -197,9 +197,9 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
       <button
         type='button'
         onClick={() => setIsOpenOverride((prev) => !(prev ?? totalWeeks > 0))}
-        className='bg-gray-150 flex h-12 items-center justify-between rounded-lg border border-gray-200 px-7 py-5'
+        className='bg-gray-150 flex h-[43px] items-center justify-between rounded-lg border border-gray-200 px-7 py-5 md:h-[58px] lg:h-[72px]'
       >
-        <span className='text-small-01-sb md:text-body-02-sb text-gray-800'>
+        <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
           주차별 계획 <span className='text-blue-400'>*</span>
         </span>
         <ArrowIcon className={cn('size-4 rotate-90 text-gray-800 transition-transform', isOpen && '-rotate-90')} />
@@ -229,13 +229,18 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
                   key={field.id}
                   className='border-gray-150 flex flex-col gap-3 border-b pb-5 last:border-b-0 last:pb-0'
                 >
-                  <p className='text-small-01-sb md:text-body-01-sb text-gray-800'>{index + 1}주차</p>
+                  <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
+                    {index + 1}주차
+                  </p>
 
                   <Input
-                    label={<span className='text-small-02-m md:text-body-02-m text-gray-800'>제목</span>}
+                    label={
+                      <span className='md:text-small-01-m lg:text-body-02-m hidden text-gray-800 md:inline'>제목</span>
+                    }
                     placeholder={`${index + 1}주차 계획의 제목을 적어주세요`}
                     error={guideErrors?.[index]?.title?.message as string | undefined}
                     {...register(`weeklyGuides.${index}.title`)}
+                    className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                   />
 
                   <WeekDetailInputs
@@ -247,7 +252,13 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
               ))}
 
               {canAddNextWeek && (
-                <Button type='button' variant='add-task' size='add-task' className='mb-2.5' onClick={handleAddNextWeek}>
+                <Button
+                  type='button'
+                  variant='add-task'
+                  size='add-task'
+                  className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb mb-2.5 h-[43px] md:h-[58px] lg:h-[72px]'
+                  onClick={handleAddNextWeek}
+                >
                   + 다음 주차 추가
                 </Button>
               )}

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -45,7 +45,7 @@ const CategoryTriggerBorder = ({ children }: { children: ReactNode }) => {
   return (
     <div
       className={cn(
-        'flex w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3 transition-colors duration-200',
+        'flex h-[43px] w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3 transition-colors duration-200 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5',
         isOpen ? 'border-gradient-primary' : 'border border-gray-200',
       )}
     >
@@ -156,7 +156,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
+    <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-10 md:gap-14 lg:gap-20'>
       {/* 모임 유형 */}
       <section className='flex flex-col gap-3'>
         <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
@@ -231,7 +231,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
               placeholder='제목을 입력하세요'
               error={errors.title?.message}
               {...register('title')}
-              className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
             />
             <p className='text-small-02-r self-end text-gray-400'>{titleValue.length}/30</p>
           </div>
@@ -302,10 +302,8 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
             }}
           />
         </div>
-      </section>
 
-      {/* 한 줄 소개 */}
-      <div className='flex flex-col gap-1'>
+        {/* 한 줄 소개 */}
         <div className='flex flex-1 flex-col gap-1'>
           <Input
             label={
@@ -315,54 +313,54 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
             placeholder='소개를 적어주세요'
             error={errors.shortDescription?.message}
             {...register('shortDescription')}
-            className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
           />
           <p className='text-small-02-r self-end text-gray-400'>{shortDescValue.length}/50</p>
         </div>
-      </div>
 
-      {/* 상세 설명 */}
-      <div className='flex flex-col gap-1'>
-        <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>상세 설명</p>
-        <Textarea
-          maxLength={1000}
-          rows={8}
-          placeholder='모임을 설명을 상세히 적어주세요'
-          error={errors.description?.message}
-          {...register('description')}
-          className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-4 py-3'
-        />
-        <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
-      </div>
+        {/* 상세 설명 */}
+        <div className='flex flex-col gap-1'>
+          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>상세 설명</p>
+          <Textarea
+            maxLength={1000}
+            rows={8}
+            placeholder='모임을 설명을 상세히 적어주세요'
+            error={errors.description?.message}
+            {...register('description')}
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-4 py-3 lg:px-7 lg:py-5'
+          />
+          <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
+        </div>
 
-      {/* 태그 */}
-      <div className='flex flex-col gap-1'>
-        <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>태그</p>
-        <Controller
-          name='tags'
-          control={control}
-          render={({ field }) => (
-            <TagInput
-              value={field.value ?? []}
-              onChange={field.onChange}
-              onBlur={field.onBlur}
-              error={errors.tags?.root?.message ?? errors.tags?.message}
-            />
-          )}
-        />
-      </div>
+        {/* 태그 */}
+        <div className='flex flex-col gap-1'>
+          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>태그</p>
+          <Controller
+            name='tags'
+            control={control}
+            render={({ field }) => (
+              <TagInput
+                value={field.value ?? []}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                error={errors.tags?.root?.message ?? errors.tags?.message}
+              />
+            )}
+          />
+        </div>
 
-      {/* 이미지 */}
-      <div className='flex flex-col gap-1'>
-        <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>이미지</p>
-        <Controller
-          name='images'
-          control={control}
-          render={({ field }) => (
-            <ImageUpload value={field.value ?? []} onChange={field.onChange} error={errors.images?.message} />
-          )}
-        />
-      </div>
+        {/* 이미지 */}
+        <div className='flex flex-col gap-1'>
+          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>이미지</p>
+          <Controller
+            name='images'
+            control={control}
+            render={({ field }) => (
+              <ImageUpload value={field.value ?? []} onChange={field.onChange} error={errors.images?.message} />
+            )}
+          />
+        </div>
+      </section>
 
       {/* 모임 최종 목표 */}
       <div className='flex flex-col gap-1'>
@@ -376,7 +374,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
           placeholder='모임의 최종 목표를 적어주세요'
           error={errors.goal?.message}
           {...register('goal')}
-          className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
+          className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
         />
         <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
       </div>
@@ -399,7 +397,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
               placeholder='모집 인원을 적어주세요'
               error={errors.maxMembers?.message}
               {...register('maxMembers', { valueAsNumber: true })}
-              className='text-small-02-r md:text-body-02-r lg:text-body-01-r'
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
             />
           </div>
 
@@ -419,6 +417,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모집 마감 일정을 선택해주세요'
                   error={errors.recruitDeadline?.message}
+                  className='h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
             )}
@@ -449,6 +448,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모임 시작일을 선택해주세요'
                   error={errors.startDate?.message}
+                  className='h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
             )}
@@ -470,15 +470,16 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모임 종료일을 선택해주세요'
                   error={errors.endDate?.message}
+                  className='h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
             )}
           />
         </div>
 
-        <div className='mt-8 flex h-12 items-center justify-between rounded-lg bg-gray-100 px-7 py-5'>
-          <p className='text-small-01-sb md:text-body-02-sb text-gray-800'>모임 기간</p>
-          <p className='text-small-01-sb md:text-body-02-sb text-gray-800'>
+        <div className='mt-8 flex h-[43px] items-center justify-between rounded-lg bg-gray-100 px-7 py-5 md:h-[58px] lg:h-[72px]'>
+          <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>모임 기간</p>
+          <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
             <span className='text-blue-400'>{totalWeeks}</span> 주
           </p>
         </div>

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -297,6 +297,8 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                       {DEFAULT_CATEGORIES.map((cat) => (
                         <Dropdown.Item
                           key={cat.id}
+                          closeOnSelect={false}
+                          disabled={selected.length >= 3 && !selected.includes(cat.id)}
                           onClick={() => toggleCategory(cat.id)}
                           className={cn(
                             'text-small-02-m md:text-body-02-m lg:text-body-01-m flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-gray-700 hover:bg-blue-100 hover:text-blue-400',

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -231,7 +231,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
               placeholder='제목을 입력하세요'
               error={errors.title?.message}
               {...register('title')}
-              className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
             />
             <p className='text-small-02-r self-end text-gray-400'>{titleValue.length}/30</p>
           </div>
@@ -320,7 +320,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
             placeholder='소개를 적어주세요'
             error={errors.shortDescription?.message}
             {...register('shortDescription')}
-            className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
           />
           <p className='text-small-02-r self-end text-gray-400'>{shortDescValue.length}/50</p>
         </div>
@@ -334,7 +334,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
             placeholder='모임을 설명을 상세히 적어주세요'
             error={errors.description?.message}
             {...register('description')}
-            className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-4 py-3 lg:px-7 lg:py-5'
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 px-4 py-3 lg:px-7 lg:py-5'
           />
           <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
         </div>
@@ -381,7 +381,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
           placeholder='모임의 최종 목표를 적어주세요'
           error={errors.goal?.message}
           {...register('goal')}
-          className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+          className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
         />
         <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
       </div>
@@ -404,7 +404,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
               placeholder='모집 인원을 적어주세요'
               error={errors.maxMembers?.message}
               {...register('maxMembers', { valueAsNumber: true })}
-              className='text-small-02-r md:text-body-02-r lg:text-body-01-r h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
             />
           </div>
 
@@ -424,7 +424,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모집 마감 일정을 선택해주세요'
                   error={errors.recruitDeadline?.message}
-                  className='h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+                  className='bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
             )}
@@ -455,7 +455,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모임 시작일을 선택해주세요'
                   error={errors.startDate?.message}
-                  className='h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+                  className='bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
             )}
@@ -477,7 +477,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모임 종료일을 선택해주세요'
                   error={errors.endDate?.message}
-                  className='h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
+                  className='bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
             )}

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -221,19 +221,29 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
         <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
           기본 정보 <span className='text-blue-400'>*</span>
         </p>
-        <div className='flex flex-col gap-6 pb-6 lg:flex-row lg:gap-4'>
+        <div className='flex flex-col gap-6 lg:flex-row lg:gap-4'>
           <div className='flex w-full flex-col gap-1 lg:flex-1'>
-            <Input
-              label={
-                <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 제목</span>
-              }
-              maxLength={30}
-              placeholder='제목을 입력하세요'
-              error={errors.title?.message}
-              {...register('title')}
-              className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
-            />
-            <p className='text-small-02-r self-end text-gray-400'>{titleValue.length}/30</p>
+            <div className='relative'>
+              <Input
+                label={
+                  <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 제목</span>
+                }
+                maxLength={30}
+                placeholder='제목을 입력하세요'
+                error={errors.title?.message}
+                hideErrorMessage
+                {...register('title')}
+                className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-12 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-20'
+              />
+              <span className='md:text-small-02-r pointer-events-none absolute right-3 bottom-1 text-[8px] text-gray-400 lg:right-5 lg:bottom-4'>
+                {titleValue.length}/30
+              </span>
+            </div>
+            {errors.title?.message && (
+              <p className='text-xs text-red-200' role='alert'>
+                {errors.title.message}
+              </p>
+            )}
           </div>
           <Controller
             name='categoryIds'
@@ -312,35 +322,55 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
 
         {/* 한 줄 소개 */}
         <div className='flex flex-1 flex-col gap-1'>
-          <Input
-            label={
-              <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>한 줄 소개</span>
-            }
-            maxLength={50}
-            placeholder='소개를 적어주세요'
-            error={errors.shortDescription?.message}
-            {...register('shortDescription')}
-            className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
-          />
-          <p className='text-small-02-r self-end text-gray-400'>{shortDescValue.length}/50</p>
+          <div className='relative'>
+            <Input
+              label={
+                <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>한 줄 소개</span>
+              }
+              maxLength={50}
+              placeholder='소개를 적어주세요'
+              error={errors.shortDescription?.message}
+              hideErrorMessage
+              {...register('shortDescription')}
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-12 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-20'
+            />
+            <span className='md:text-small-02-r pointer-events-none absolute right-3 bottom-1 text-[8px] text-gray-400 lg:right-5 lg:bottom-4'>
+              {shortDescValue.length}/50
+            </span>
+          </div>
+          {errors.shortDescription?.message && (
+            <p className='text-xs text-red-200' role='alert'>
+              {errors.shortDescription.message}
+            </p>
+          )}
         </div>
 
         {/* 상세 설명 */}
         <div className='flex flex-col gap-1'>
           <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>상세 설명</p>
-          <Textarea
-            maxLength={1000}
-            rows={8}
-            placeholder='모임을 설명을 상세히 적어주세요'
-            error={errors.description?.message}
-            {...register('description')}
-            className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 px-4 py-3 lg:px-7 lg:py-5'
-          />
-          <p className='text-small-02-r self-end text-gray-400'>{descValue.length}/1000</p>
+          <div className='relative'>
+            <Textarea
+              maxLength={1000}
+              rows={8}
+              placeholder='모임을 설명을 상세히 적어주세요'
+              error={errors.description?.message}
+              hideErrorMessage
+              {...register('description')}
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 px-4 py-3 pb-7 lg:px-7 lg:py-5 lg:pb-8'
+            />
+            <span className='md:text-small-02-r pointer-events-none absolute right-3 bottom-3 text-[8px] text-gray-400 lg:right-5 lg:bottom-4'>
+              {descValue.length}/1000
+            </span>
+          </div>
+          {errors.description?.message && (
+            <p className='text-xs text-red-200' role='alert'>
+              {errors.description.message}
+            </p>
+          )}
         </div>
 
         {/* 태그 */}
-        <div className='flex flex-col gap-1 pb-6'>
+        <div className='flex flex-col gap-1'>
           <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>태그</p>
           <Controller
             name='tags'
@@ -371,19 +401,29 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
 
       {/* 모임 최종 목표 */}
       <div className='flex flex-col gap-1'>
-        <Input
-          label={
-            <span className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
-              모임 최종 목표 <span className='text-blue-400'>*</span>
-            </span>
-          }
-          maxLength={200}
-          placeholder='모임의 최종 목표를 적어주세요'
-          error={errors.goal?.message}
-          {...register('goal')}
-          className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
-        />
-        <p className='text-small-02-r self-end text-gray-400'>{goalValue.length}/200</p>
+        <div className='relative'>
+          <Input
+            label={
+              <span className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
+                모임 최종 목표 <span className='text-blue-400'>*</span>
+              </span>
+            }
+            maxLength={200}
+            placeholder='모임의 최종 목표를 적어주세요'
+            error={errors.goal?.message}
+            hideErrorMessage
+            {...register('goal')}
+            className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-14 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-24'
+          />
+          <span className='md:text-small-02-r pointer-events-none absolute right-3 bottom-1 text-[8px] text-gray-400 lg:right-7 lg:bottom-4'>
+            {goalValue.length}/200
+          </span>
+        </div>
+        {errors.goal?.message && (
+          <p className='text-xs text-red-200' role='alert'>
+            {errors.goal.message}
+          </p>
+        )}
       </div>
 
       {/* 모집 정보 */}

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -373,7 +373,10 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
 
         {/* 태그 */}
         <div className='flex flex-col gap-1'>
-          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>태그</p>
+          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m flex items-center gap-1 text-gray-800'>
+            태그
+            <span className='md:text-small-02-r lg:text-small-01-r text-[8px] font-normal text-gray-400'>(선택)</span>
+          </p>
           <Controller
             name='tags'
             control={control}
@@ -390,7 +393,10 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
 
         {/* 이미지 */}
         <div className='flex flex-col gap-1'>
-          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>이미지</p>
+          <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m flex items-center gap-1 text-gray-800'>
+            이미지
+            <span className='md:text-small-02-r lg:text-small-01-r text-[8px] font-normal text-gray-400'>(선택)</span>
+          </p>
           <Controller
             name='images'
             control={control}

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -147,6 +147,8 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
         showToast({ variant: 'success', title: isEditMode ? '모임이 수정되었습니다.' : '모임이 생성되었습니다.' });
         if (isEditMode && gatheringId) {
           router.push(`/gatherings/${gatheringId}`);
+        } else {
+          router.push('/main');
         }
       },
       onError: () => {

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -11,7 +11,7 @@ import { Card } from '@/components/ui/Card';
 import { DatePicker } from '@/components/ui/DatePicker';
 import { Dropdown } from '@/components/ui/Dropdown';
 import { CheckIcon } from '@/components/ui/Icon/CheckIcon';
-import { StudyIcon, ProjectIcon, CategoryIcon, ArrowIcon } from '@/components/ui/Icon';
+import { StudyIcon, ProjectIcon, CategoryIcon, ArrowIcon, CloseIcon } from '@/components/ui/Icon';
 import { useDropdown } from '@/components/ui/Dropdown/context';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
@@ -217,11 +217,11 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
       </section>
 
       {/* 기본 정보 */}
-      <section className='flex flex-col gap-4'>
+      <section className='flex flex-col gap-6'>
         <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
           기본 정보 <span className='text-blue-400'>*</span>
         </p>
-        <div className='flex flex-col gap-4 lg:flex-row'>
+        <div className='flex flex-col gap-6 pb-6 lg:flex-row lg:gap-4'>
           <div className='flex w-full flex-col gap-1 lg:flex-1'>
             <Input
               label={
@@ -255,21 +255,27 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
               };
 
               return (
-                <div className='flex w-full flex-col gap-1.5 lg:flex-1'>
+                <div className='flex w-full flex-col gap-1 lg:flex-1'>
                   <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>카테고리</p>
                   <Dropdown className='flex w-full flex-col'>
                     <Dropdown.Trigger>
                       <CategoryTriggerBorder>
                         <div className='flex items-center gap-2'>
                           <CategoryIcon className='size-4 md:size-6 lg:size-7' />
-                          <span
-                            className={cn(
-                              'text-small-02-r md:text-body-02-r lg:text-body-01-r',
-                              selectedLabel ? 'text-gray-900' : 'text-gray-400',
-                            )}
-                          >
-                            {selectedLabel ?? '카테고리를 선택해주세요'}
-                          </span>
+                          {selected.length > 0 ? (
+                            <div className='flex items-center gap-1'>
+                              <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-900'>
+                                카테고리({selected.length})
+                              </span>
+                              <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-900'>
+                                {selected.map((id) => CATEGORY_META[id]?.label).join(', ')}
+                              </span>
+                            </div>
+                          ) : (
+                            <span className='text-small-02-r md:text-body-02-r lg:text-body-01-r text-gray-400'>
+                              카테고리를 선택해주세요
+                            </span>
+                          )}
                         </div>
                         <RotatingArrow />
                       </CategoryTriggerBorder>
@@ -283,11 +289,12 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                           key={cat.id}
                           onClick={() => toggleCategory(cat.id)}
                           className={cn(
-                            'cursor-pointer rounded-lg px-4 py-3 hover:bg-blue-100 hover:text-blue-400',
+                            'text-small-02-m md:text-body-02-m lg:text-body-01-m flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-gray-700 hover:bg-blue-100 hover:text-blue-400',
                             selected.includes(cat.id) && 'bg-blue-100 text-blue-400',
                           )}
                         >
                           {cat.name}
+                          {selected.includes(cat.id) && <CloseIcon className='size-4 text-blue-400 md:size-5' />}
                         </Dropdown.Item>
                       ))}
                     </Dropdown.Menu>
@@ -333,7 +340,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
         </div>
 
         {/* 태그 */}
-        <div className='flex flex-col gap-1'>
+        <div className='flex flex-col gap-1 pb-6'>
           <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>태그</p>
           <Controller
             name='tags'

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -2,7 +2,7 @@ import { CreateGatheringForm } from './CreateGatheringForm';
 
 export default function CreateGatheringPage() {
   return (
-    <main className='mx-auto max-w-[1680px] px-5 py-20'>
+    <main className='mx-auto max-w-[1680px] px-5 pt-20 pb-40'>
       <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
       <CreateGatheringForm />
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -309,6 +309,11 @@
   }
 }
 
+@utility dashed-border-gray {
+  border-radius: 0.5rem;
+  background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='8' ry='8' stroke='%23cccccc' stroke-width='1.3' stroke-dasharray='6%2c 10' stroke-linecap='square'/%3e%3c%2fsvg%3e");
+}
+
 @keyframes toast-slide-in-right {
   from {
     opacity: 0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -305,7 +305,7 @@
   &::-webkit-scrollbar-thumb {
     background-color: var(--color-blue-100);
     border-radius: 9999px;
-    max-height: 40px;
+    min-height: 40px;
   }
 }
 

--- a/src/components/ui/DatePicker/index.tsx
+++ b/src/components/ui/DatePicker/index.tsx
@@ -16,6 +16,7 @@ interface DatePickerProps {
   placeholder?: string;
   error?: string;
   disabled?: boolean;
+  className?: string;
 }
 
 const WEEKDAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
@@ -37,6 +38,7 @@ export function DatePicker({
   placeholder = '날짜를 선택해주세요',
   error,
   disabled,
+  className,
 }: DatePickerProps) {
   // input + popover를 포함하는 커스텀 date picker 상태
   const [isOpen, setIsOpen] = useState(false);
@@ -91,6 +93,7 @@ export function DatePicker({
             fieldControlVariants({ state: 'error' }),
             'flex cursor-pointer items-center justify-between text-left',
             disabled && 'cursor-not-allowed opacity-60',
+            className,
           )}
           disabled={disabled}
         >
@@ -113,6 +116,7 @@ export function DatePicker({
               fieldControlVariants({ state: 'default' }),
               'flex cursor-pointer items-center justify-between text-left',
               disabled && 'cursor-not-allowed opacity-60',
+              className,
             )}
             disabled={disabled}
           >

--- a/src/components/ui/DatePicker/index.tsx
+++ b/src/components/ui/DatePicker/index.tsx
@@ -105,7 +105,7 @@ export function DatePicker({
           >
             {displayValue || placeholder}
           </span>
-          <CalendarIcon className='text-gray-800 sm:size-4 lg:size-6' />
+          <CalendarIcon className='size-4 text-gray-800 md:size-5' />
         </button>
       ) : (
         <div className={fieldGradientFocusWrapperClass}>

--- a/src/components/ui/DatePicker/index.tsx
+++ b/src/components/ui/DatePicker/index.tsx
@@ -161,15 +161,15 @@ export function DatePicker({
             </button>
           </div>
 
-          <div className='mb-2 grid grid-cols-7 gap-y-2'>
+          <div className='mb-2 grid grid-cols-7 gap-y-1'>
             {WEEKDAY_LABELS.map((label, index) => (
-              <span key={`${label}-${index}`} className='text-center text-xs text-gray-500'>
+              <span key={`${label}-${index}`} className='text-body-02-r text-center text-gray-500'>
                 {label}
               </span>
             ))}
           </div>
 
-          <div className='grid grid-cols-7 gap-y-2'>
+          <div className='grid grid-cols-7 gap-y-1'>
             {days.map((day) => {
               const isSelected = value === format(day.date, ISO_DATE_FORMAT);
               return (
@@ -178,7 +178,7 @@ export function DatePicker({
                   key={day.date.toISOString()}
                   onClick={() => handleSelectDate(day.date)}
                   className={cn(
-                    'mx-auto flex size-7 items-center justify-center rounded-full text-xs',
+                    'text-body-02-r mx-auto flex size-[34px] items-center justify-center rounded-full',
                     day.isCurrentMonth ? 'text-gray-800' : 'text-gray-300',
                     day.isToday && !isSelected && 'font-bold text-blue-400',
                     isSelected && 'bg-blue-300 text-white',

--- a/src/components/ui/Dropdown/Item.tsx
+++ b/src/components/ui/Dropdown/Item.tsx
@@ -11,11 +11,13 @@ interface ItemProps {
   onClick?: () => void;
   className?: string;
   closeOnSelect?: boolean;
+  disabled?: boolean;
 }
-export function Item({ children, onClick, className, closeOnSelect = true }: ItemProps) {
+export function Item({ children, onClick, className, closeOnSelect = true, disabled = false }: ItemProps) {
   const { close } = useDropdown();
 
   const handleClick = () => {
+    if (disabled) return;
     onClick?.();
     if (closeOnSelect) close();
   };
@@ -23,6 +25,7 @@ export function Item({ children, onClick, className, closeOnSelect = true }: Ite
     <li
       role='option'
       tabIndex={-1}
+      aria-disabled={disabled}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -31,7 +34,7 @@ export function Item({ children, onClick, className, closeOnSelect = true }: Ite
         if (e.key === 'Escape') close();
       }}
       onClick={handleClick}
-      className={cn('transition-colors', className)}
+      className={cn('transition-colors', disabled && 'cursor-not-allowed opacity-40', className)}
     >
       {children}
     </li>

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -7,10 +7,11 @@ import { cn } from '@/lib/cn';
 type InputProps = ComponentPropsWithoutRef<'input'> & {
   label?: React.ReactNode;
   error?: string;
+  hideErrorMessage?: boolean;
 };
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { label, error, className, type, id: idProp, ...props },
+  { label, error, hideErrorMessage, className, type, id: idProp, ...props },
   ref,
 ) {
   const uid = useId();
@@ -36,7 +37,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         </label>
       )}
       <div className={cn(hasError ? 'w-full' : fieldGradientFocusWrapperClass)}>{control}</div>
-      {error && (
+      {error && !hideErrorMessage && (
         <p className='text-xs text-red-200' role='alert'>
           {error}
         </p>

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -11,11 +11,12 @@ const sizeClassName = {
 type TextareaProps = ComponentPropsWithoutRef<'textarea'> & {
   label?: string;
   error?: string;
+  hideErrorMessage?: boolean;
   size?: keyof typeof sizeClassName;
 };
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { label, error, className, id: idProp, size = 'lg', rows, ...props },
+  { label, error, hideErrorMessage, className, id: idProp, size = 'lg', rows, ...props },
   ref,
 ) {
   const uid = useId();
@@ -46,7 +47,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
         </label>
       )}
       <div className={cn(hasError ? 'w-full' : fieldGradientFocusWrapperClass)}>{control}</div>
-      {error && (
+      {error && !hideErrorMessage && (
         <p className='text-xs text-red-200' role='alert'>
           {error}
         </p>


### PR DESCRIPTION
## ❓ 이슈

- close #241 

## ✍️ Description

모임 만들기 페이지 전반의 디자인 시안 반영 및 UX 개선 작업입니다.

**시안 반영**
- 페이지 하단 여백, 섹션 간 여백, Input 높이/패딩 반응형 수치 적용
- 카테고리 드롭다운: 선택 시 트리거 텍스트를 `카테고리(N) 개발, 자격증` 형식으로 변경, 선택 항목 우측 X 아이콘 추가
- 이미지 업로드: 점선 border를 SVG data URL로 교체, 높이 수정, 업로드 후 높이 고정
- DatePicker: 날짜/요일 폰트·여백 수정, 에러 상태 아이콘 크기 통일
- WeeklyPlanForm: 타이포그래피·높이 반응형 적용, 세부 계획 X 버튼 Input 내부 배치
- 폼 필드 배경색·border 수정

**UI 개선**
- 글자 수 카운트를 Input/Textarea 내부 우측 하단에 배치 (모임 제목, 한 줄 소개, 상세 설명, 최종 목표)
- Input/Textarea에 `hideErrorMessage` prop 추가 (에러 border 유지, 에러 텍스트는 외부 렌더)

**UX 개선**
- WeeklyPlanForm: 세부 계획 X 버튼 Input 내부 배치
- 카테고리 항목 선택 시 드롭다운 유지 (`closeOnSelect={false}`)
- 카테고리 3개 선택 시 미선택 항목 비활성화 (`Dropdown.Item`에 `disabled` prop 추가)
- 태그·이미지·세부 계획 라벨에 `(선택)` 텍스트 표시


## 📸 스크린샷 (UI 변경 시)
<img width="752" height="1274" alt="image" src="https://github.com/user-attachments/assets/ac83a9de-d08b-4aeb-ae1f-0da60fb3d11f" />

<img width="1684" height="590" alt="image" src="https://github.com/user-attachments/assets/4565db32-4fa4-4b1a-88a2-5f1e0ce665fc" />

<img width="840" height="394" alt="image" src="https://github.com/user-attachments/assets/d7851e11-1eca-44eb-8080-9ffc3fea238d" />





## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes
- 카테고리 드롭다운 스크롤바 높이를 max-height: 40px 대신 min-height: 40px으로 적용한 이유
webkit 수직 스크롤바에서는 max-height 속성이 동작하지 않아 시안대로 적용 시 아무 효과가 없었습니다.
정확한 40px을 구현하려면 스크롤바를 직접 커스텀 컴포넌트로 만들어야 하는데, 
카테고리 드롭다운에서만 사용되는 요소라 구현 비용 대비 효과가 낮다고 판단했습니다. 
현재는 min-height: 40px으로 최소 높이만 보장한 상태로, 디자인 시안과 다소 차이가 있을 수 있습니다.


