### PR TITLE
[SM-158] style: Footer 반응형 레이아웃 개선

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -11,22 +11,30 @@ const NAV_LINKS = [
 
 export function Footer() {
   return (
-    <footer className='bg-gray-150 h-[100px] w-full max-lg:h-auto max-lg:py-6'>
-      <div className='grid h-full w-full grid-cols-3 items-center px-[100px] max-lg:flex max-lg:flex-col max-lg:items-center max-lg:gap-4 max-lg:px-6'>
+    <footer className='bg-gray-150 h-[100px] w-full max-xl:h-auto max-xl:py-6'>
+      <div className='flex h-full w-full flex-col items-center gap-4 px-6 md:flex-row md:justify-between xl:grid xl:grid-cols-3 xl:items-center xl:px-[100px]'>
         <Link href='/'>
-          <Image src='/images/logo.svg' alt='완성도 로고' width={97} height={20} />
+          <Image
+            src='/images/logo.svg'
+            alt='완성도 로고'
+            width={110}
+            height={22}
+            className='h-[16px] w-[82px] md:h-[22px] md:w-[110px] xl:h-[20px] xl:w-[97px]'
+          />
         </Link>
-        <nav className='text-body-02-r flex items-center justify-center gap-4 text-gray-500'>
-          {NAV_LINKS.map(({ label, href }, index) => (
-            <Fragment key={href}>
-              {index > 0 && <span>|</span>}
-              <Link href={href}>{label}</Link>
-            </Fragment>
-          ))}
-        </nav>
-        <p className='text-body-02-r justify-self-end text-gray-300 max-lg:justify-self-auto'>
-          © 2026. Codeit Sprint Team 3 All right reserved.
-        </p>
+        <div className='flex flex-col items-center gap-2 md:items-end xl:contents'>
+          <nav className='text-small-02-r md:text-small-01-r xl:text-body-02-r flex items-center justify-center gap-6 text-gray-500'>
+            {NAV_LINKS.map(({ label, href }, index) => (
+              <Fragment key={href}>
+                {index > 0 && <span>|</span>}
+                <Link href={href}>{label}</Link>
+              </Fragment>
+            ))}
+          </nav>
+          <p className='text-small-02-r md:text-small-01-r xl:text-body-02-r text-gray-300 xl:justify-self-end'>
+            © 2026. Codeit Sprint Team 3 All right reserved.
+          </p>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## ❓ 이슈

- close #254 

## ✍️ Description

**로고 크기 반응형**

- 모바일: 82×16 / 태블릿: 110×22 / PC: 97×20

**태블릿 레이아웃**

- nav + copyright를 <div>로 묶어 세로 정렬
- 로고 좌측 ↔ [nav + copyright] 우측 양쪽 배치

**nav 간격**

- | 구분자 사이 간격 gap-4 → gap-6

**브레이크포인트 상향**

- PC 레이아웃 기준 lg(1024px) → xl(1280px)으로 변경
- 768px~1279px 구간이 태블릿 레이아웃으로 표시됨

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<img width="1052" height="86" alt="image" src="https://github.com/user-attachments/assets/2080af76-9089-4350-bbc5-a706842086c0" />

<img width="1022" height="124" alt="image" src="https://github.com/user-attachments/assets/3bf3a86b-b525-48af-8591-aa0c58a9c119" />

<img width="558" height="188" alt="image" src="https://github.com/user-attachments/assets/e927d955-ee64-4b81-b959-bbc8e600b0ad" />

