### PR TITLE
[SM-159] style: 모바일 사이드바 디자인 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { CloseIcon, ArrowIcon } from '@/components/ui/Icon';
 
 const NAVIGATION_ITEMS = [
-  { href: '/', label: '홈' },
+  { href: '/main', label: '홈' },
   { href: '/gatherings', label: '모임 탐색' },
   { href: '/gatherings/new', label: '모임 만들기' },
   { href: '/my', label: '내 모임' },
@@ -113,24 +113,34 @@ export function Header() {
             onClick={() => setIsSidebarOpen(false)}
             className='inline-flex h-8 w-8 items-center justify-center text-gray-600'
           >
-            <CloseIcon size={24} />
+            <CloseIcon size={32} />
           </button>
         </div>
 
         <nav aria-label='모바일 네비게이션' className='mt-5'>
           <ul className='flex flex-col'>
-            {NAVIGATION_ITEMS.map((item) => (
-              <li key={item.href}>
-                <button
-                  type='button'
-                  onClick={() => handleNavigate(item.href)}
-                  className='text-body-02-m flex w-full items-center justify-between py-5 text-left text-gray-700'
-                >
-                  {item.label}
-                  <ArrowIcon size={24} direction='right' className='text-gray-300' aria-hidden />
-                </button>
-              </li>
-            ))}
+            {NAVIGATION_ITEMS.map((item) => {
+              const isActive = pathname === item.href;
+              return (
+                <li key={item.href}>
+                  <button
+                    type='button'
+                    onClick={() => handleNavigate(item.href)}
+                    className={`text-body-02-m flex w-full items-center justify-between py-5 text-left ${
+                      isActive ? 'text-blue-300' : 'text-gray-700'
+                    }`}
+                  >
+                    {item.label}
+                    <ArrowIcon
+                      size={24}
+                      direction='right'
+                      className={isActive ? 'text-blue-300' : 'text-gray-300'}
+                      aria-hidden
+                    />
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         </nav>
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { CloseIcon, ArrowIcon } from '@/components/ui/Icon';
 
 const NAVIGATION_ITEMS = [
-  { href: '/main', label: '홈' },
+  { href: '/', label: '홈' },
   { href: '/gatherings', label: '모임 탐색' },
   { href: '/gatherings/new', label: '모임 만들기' },
   { href: '/my', label: '내 모임' },
@@ -120,7 +120,8 @@ export function Header() {
         <nav aria-label='모바일 네비게이션' className='mt-5'>
           <ul className='flex flex-col'>
             {NAVIGATION_ITEMS.map((item) => {
-              const isActive = pathname === item.href;
+              const isHomeItem = item.href === '/';
+              const isActive = isHomeItem ? pathname === '/' || pathname === '/main' : pathname === item.href;
               return (
                 <li key={item.href}>
                   <button

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -20,6 +20,7 @@ export function Header() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
+  const isNavActive = (href: string) => pathname === href || (href === '/' && pathname === '/main');
   const { isLoggedIn, isLoading } = useAuth();
 
   useEffect(() => {
@@ -57,7 +58,7 @@ export function Header() {
             <nav aria-label='주요 네비게이션' className='max-md:hidden'>
               <ul className='flex h-[88px] items-center gap-7 lg:gap-11'>
                 {NAVIGATION_ITEMS.map((item) => {
-                  const isActive = item.href === pathname || (item.href === '/' && pathname === '/main');
+                  const isActive = isNavActive(item.href);
                   return (
                     <li key={item.href}>
                       <Link
@@ -120,8 +121,8 @@ export function Header() {
         <nav aria-label='모바일 네비게이션' className='mt-5'>
           <ul className='flex flex-col'>
             {NAVIGATION_ITEMS.map((item) => {
-              const isHomeItem = item.href === '/';
-              const isActive = isHomeItem ? pathname === '/' || pathname === '/main' : pathname === item.href;
+              const isActive = isNavActive(item.href);
+              const label = isLoggedIn && item.href === '/my' ? '마이페이지' : item.label;
               return (
                 <li key={item.href}>
                   <button
@@ -131,7 +132,7 @@ export function Header() {
                       isActive ? 'text-blue-300' : 'text-gray-700'
                     }`}
                   >
-                    {item.label}
+                    {label}
                     <ArrowIcon
                       size={24}
                       direction='right'
@@ -145,25 +146,17 @@ export function Header() {
           </ul>
         </nav>
 
-        <div className='text-body-02-m absolute right-7 bottom-7 flex items-center gap-3 text-gray-400'>
-          {isLoading || !isLoggedIn ? (
-            <>
-              <button type='button' onClick={() => handleNavigate('/login')}>
-                로그인
-              </button>
-              <span>|</span>
-              <button type='button' onClick={() => handleNavigate('/register')}>
-                회원가입
-              </button>
-            </>
-          ) : (
-            <>
-              <button type='button' onClick={() => handleNavigate('/my')}>
-                마이페이지
-              </button>
-            </>
-          )}
-        </div>
+        {(isLoading || !isLoggedIn) && (
+          <div className='text-body-02-m absolute right-7 bottom-7 flex items-center gap-3 text-gray-400'>
+            <button type='button' onClick={() => handleNavigate('/login')}>
+              로그인
+            </button>
+            <span>|</span>
+            <button type='button' onClick={() => handleNavigate('/register')}>
+              회원가입
+            </button>
+          </div>
+        )}
       </aside>
     </>
   );


### PR DESCRIPTION
## ❓ 이슈

- close #258

## ✍️ Description
- 모바일 사이드바 현재 페이지 활성 스타일 추가 (텍스트/아이콘 파란색 강조)
- 홈 항목 /와 /main 양쪽에서 활성화 처리
- isNavActive 헬퍼 함수로 PC/모바일 활성 판단 로직 통일
- 로그인 상태에서 "내 모임" → "마이페이지" 라벨 변경
- 로그인 상태에서 하단 마이페이지 버튼 제거 (nav 항목으로 대체)
- 닫기 버튼 아이콘 크기 24 → 32 수정

## 📸 스크린샷 (UI 변경 시)

<img width="426" height="780" alt="image" src="https://github.com/user-attachments/assets/bf9ac4e3-7cd6-4e0c-90c0-baf3e9e6c66a" />

<img width="454" height="762" alt="image" src="https://github.com/user-attachments/assets/2876cf77-f691-4564-bbc4-a1d9ca371240" />



## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


