### PR TITLE
[SM-160] refactor: 모임 상세 페이지 Image 태그 변경

### DIFF
--- a/src/app/gatherings/[id]/_components/ImageCarousel/index.tsx
+++ b/src/app/gatherings/[id]/_components/ImageCarousel/index.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import Image from 'next/image';
 
 import { Pagination } from '@/components/ui/Pagination';
+import { normalizeImageUrl } from '@/constants/image';
 
 import type { GatheringImage } from '@/api/gatherings/types';
 
@@ -38,12 +40,18 @@ export function ImageCarousel({ images }: ImageCarouselProps) {
           {Array.from({ length: totalPages }).map((_, pageIdx) => (
             <div key={pageIdx} className='grid w-full shrink-0 grid-cols-3' style={{ gap: 'var(--gap)' }}>
               {sortedImages.slice(pageIdx * VISIBLE_COUNT, (pageIdx + 1) * VISIBLE_COUNT).map((image) => (
-                <img
+                <div
                   key={image.displayOrder}
-                  src={image.url}
-                  alt={`모임 이미지 ${image.displayOrder + 1}`}
-                  className='aspect-4/5 w-full rounded-lg object-cover xl:rounded-2xl'
-                />
+                  className='relative aspect-4/5 w-full overflow-hidden rounded-lg xl:rounded-2xl'
+                >
+                  <Image
+                    src={normalizeImageUrl(image.url)}
+                    alt={`모임 이미지 ${image.displayOrder + 1}`}
+                    fill
+                    className='object-cover'
+                    sizes='(max-width: 1280px) 30vw, 400px'
+                  />
+                </div>
               ))}
             </div>
           ))}


### PR DESCRIPTION
## ❓ 이슈

  - close #261 
  
  ## ✍️ Description

  모임 상세 페이지 ImageCarousel 컴포넌트의 `<img>` 태그를 Next.js `<Image>`로 교체

  - `<img>` → `<Image fill>` + `relative` 래퍼 `div` 구조로 변경
  - `normalizeImageUrl`로 상대 경로(`/images/...`)를 절대 URL로 변환하여 Next.js 이미지 최적화 서버 호환
  - 기존 코드베이스(`Profile`, `SidebarAvatar`, `RankingItem` 등)의 `<Image fill>` + `overflow-hidden` 패턴과 통일

  ## 📸 스크린샷 (UI 변경 시)

  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [x] (없음)