### PR TITLE
[SM-161] style: 헤더 디자인 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -41,7 +41,7 @@ export function Header() {
 
   return (
     <>
-      <header className='border-gray-150 bg-gray-0 h-[88px] border-b max-lg:h-[56px] max-lg:px-4 md:px-7 xl:px-30'>
+      <header className='border-gray-150 bg-gray-0 h-[88px] border-b max-md:h-[48px] max-md:px-4 md:px-7 xl:px-30'>
         <div className='flex h-full w-full items-center justify-between'>
           <div className='flex items-center gap-20'>
             <Link href='/'>
@@ -50,11 +50,11 @@ export function Header() {
                 alt='logo'
                 width={136}
                 height={28}
-                className='max-lg:h-[24px] max-lg:w-auto'
+                className='h-[16px] w-[82px] md:h-[22px] md:w-[110px] lg:h-[28px] lg:w-[136px]'
               />
             </Link>
 
-            <nav aria-label='주요 네비게이션' className='max-lg:hidden'>
+            <nav aria-label='주요 네비게이션' className='max-md:hidden'>
               <ul className='flex h-[88px] items-center gap-11'>
                 {NAVIGATION_ITEMS.map((item) => {
                   const isActive = item.href === pathname || (item.href === '/' && pathname === '/main');
@@ -62,7 +62,7 @@ export function Header() {
                     <li key={item.href}>
                       <Link
                         href={item.href}
-                        className={`transition-colors hover:text-blue-400 ${isActive ? 'text-body-01-b text-gray-900' : 'text-body-01-m text-gray-700'}`}
+                        className={`transition-colors hover:text-blue-400 ${isActive ? 'text-body-02-b lg:text-body-01-b text-gray-900' : 'text-body-02-m lg:text-body-01-m text-gray-700'}`}
                       >
                         {item.label}
                       </Link>
@@ -73,7 +73,7 @@ export function Header() {
             </nav>
           </div>
 
-          <div className='max-lg:hidden'>
+          <div className='max-md:hidden'>
             <AuthSection />
           </div>
 
@@ -81,7 +81,7 @@ export function Header() {
             type='button'
             aria-label='메뉴 열기'
             onClick={() => setIsSidebarOpen(true)}
-            className='hidden h-8 w-8 items-center justify-center text-blue-500 max-lg:inline-flex'
+            className='hidden h-8 w-8 items-center justify-center text-blue-500 max-md:inline-flex'
           >
             <span className='relative block h-[14px] w-[18px]'>
               <span className='absolute top-0 block h-[2px] w-full rounded-full bg-gray-700' />
@@ -93,7 +93,7 @@ export function Header() {
       </header>
 
       <div
-        className={`fixed inset-0 z-50 bg-black/35 transition-opacity duration-200 lg:hidden ${
+        className={`fixed inset-0 z-50 bg-black/35 transition-opacity duration-200 md:hidden ${
           isSidebarOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         }`}
         onClick={() => setIsSidebarOpen(false)}
@@ -101,7 +101,7 @@ export function Header() {
       />
 
       <aside
-        className={`bg-gray-0 fixed top-0 right-0 z-60 h-dvh w-[74%] max-w-[320px] rounded-l-2xl px-6 py-5 transition-transform duration-300 ease-out lg:hidden ${
+        className={`bg-gray-0 fixed top-0 right-0 z-60 h-dvh w-[74%] max-w-[320px] rounded-l-2xl px-6 py-5 transition-transform duration-300 ease-out md:hidden ${
           isSidebarOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
         aria-hidden={!isSidebarOpen}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -43,7 +43,7 @@ export function Header() {
     <>
       <header className='border-gray-150 bg-gray-0 h-[88px] border-b max-md:h-[48px] max-md:px-4 md:px-7 xl:px-30'>
         <div className='flex h-full w-full items-center justify-between'>
-          <div className='flex items-center gap-20'>
+          <div className='flex items-center gap-11 lg:gap-20'>
             <Link href='/'>
               <Image
                 src='/images/logo.svg'
@@ -55,7 +55,7 @@ export function Header() {
             </Link>
 
             <nav aria-label='주요 네비게이션' className='max-md:hidden'>
-              <ul className='flex h-[88px] items-center gap-11'>
+              <ul className='flex h-[88px] items-center gap-7 lg:gap-11'>
                 {NAVIGATION_ITEMS.map((item) => {
                   const isActive = item.href === pathname || (item.href === '/' && pathname === '/main');
                   return (

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 import { AuthSection } from './AuthSection';
 import { useAuth } from '@/hooks/useAuth';
@@ -19,6 +19,7 @@ const NAVIGATION_ITEMS = [
 export function Header() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const router = useRouter();
+  const pathname = usePathname();
   const { isLoggedIn, isLoading } = useAuth();
 
   useEffect(() => {
@@ -55,16 +56,19 @@ export function Header() {
 
             <nav aria-label='주요 네비게이션' className='max-lg:hidden'>
               <ul className='flex h-[88px] items-center gap-11'>
-                {NAVIGATION_ITEMS.map((item) => (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      className='text-body-01-m text-gray-700 transition-colors hover:text-blue-400'
-                    >
-                      {item.label}
-                    </Link>
-                  </li>
-                ))}
+                {NAVIGATION_ITEMS.map((item) => {
+                  const isActive = item.href === pathname || (item.href === '/' && pathname === '/main');
+                  return (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        className={`transition-colors hover:text-blue-400 ${isActive ? 'text-body-01-b text-gray-900' : 'text-body-01-m text-gray-700'}`}
+                      >
+                        {item.label}
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             </nav>
           </div>


### PR DESCRIPTION
## ❓ 이슈

- close #262 

## ✍️ Description

헤더 컴포넌트의 반응형 레이아웃 개선 및 현재 페이지 활성 표시 스타일을 적용합니다.

**활성 네비게이션 스타일**
- `usePathname`으로 현재 경로를 감지해 활성 링크에 굵은 텍스트(bold) 및 `grayscale/900` 색상 적용
- 태블릿: `body-02-b`, PC: `body-01-b`
- 홈(`/`)은 로그인 후 프록시 리다이렉트되는 `/main`에서도 활성 처리

**반응형 레이아웃 (브레이크포인트 lg → md)**
- 태블릿(768px+)에서 PC 버전 헤더(네비게이션 + AuthSection) 노출
- 사이드바 햄버거 메뉴는 모바일(768px 미만)에서만 표시

**반응형 로고 및 헤더 높이**
- 로고: 모바일 82×16 / 태블릿 110×22 / PC 136×28
- 헤더 높이: 모바일 48px, 태블릿·PC 88px

**태블릿 네비게이션 간격 조정**
- 로고↔nav 간격: 태블릿 `gap-11`, PC `gap-20`
- nav 항목 간격: 태블릿 `gap-7`, PC `gap-11`

## 📸 스크린샷 (UI 변경 시)
<img width="1008" height="50" alt="image" src="https://github.com/user-attachments/assets/99b66ab5-9448-44d6-af49-ecca31132773" />

<img width="862" height="98" alt="image" src="https://github.com/user-attachments/assets/503009d0-99b0-4042-88c3-889cb0c5c9a0" />

<img width="556" height="64" alt="image" src="https://github.com/user-attachments/assets/6b857091-ff7f-4871-942b-76f031857ef7" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


