### PR TITLE
[SM-163] refactor: 나의 모임 탭에 모집중 상태 모임 포함

### DIFF
--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -81,6 +81,17 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
           </div>
         </GatheringCard.Body>
         <GatheringCard.Footer>
+          {gathering.status === 'RECRUITING' && (
+            <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
+              <div className='flex flex-1 items-center justify-center gap-1.5'>
+                <span className='text-small-01-m md:text-body-01-m text-gray-600'>모집 인원</span>
+                <span className='flex items-center'>
+                  <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>{gathering.currentMembers}</span>
+                  <span className='text-small-01-sb md:text-body-01-sb text-gray-700'>/{gathering.maxMembers}</span>
+                </span>
+              </div>
+            </div>
+          )}
           {gathering.status === 'IN_PROGRESS' && (
             <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
               <div className='flex flex-1 items-center justify-center gap-1.5'>

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -81,7 +81,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
           </div>
         </GatheringCard.Body>
         <GatheringCard.Footer>
-          {gathering.status === 'RECRUITING' && (
+          {tagState === 'recruiting' && (
             <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
               <div className='flex flex-1 items-center justify-center gap-1.5'>
                 <span className='text-small-01-m md:text-body-01-m text-gray-600'>모집 인원</span>
@@ -92,7 +92,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
               </div>
             </div>
           )}
-          {gathering.status === 'IN_PROGRESS' && (
+          {tagState === 'progressing' && (
             <div className='border-gray-150 flex h-[54px] w-full items-center rounded-[8px] border bg-gray-100 md:h-[72px]'>
               <div className='flex flex-1 items-center justify-center gap-1.5'>
                 <span className='text-small-01-m md:text-body-01-m text-gray-600'>총</span>
@@ -107,7 +107,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
               </div>
             </div>
           )}
-          {gathering.status === 'COMPLETED' && !hasReviewed && (
+          {isFinished && !hasReviewed && (
             <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
               <div className='flex items-center gap-2'>
                 <ReviewIcon size={16} className='text-blue-300 md:size-6' />
@@ -115,7 +115,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
               </div>
             </div>
           )}
-          {gathering.status === 'COMPLETED' && hasReviewed && (
+          {isFinished && hasReviewed && (
             <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
               <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성완료</span>
             </div>

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -26,6 +26,8 @@ const SORT_OPTIONS: { label: string; value: SortOrder }[] = [
   { label: '과거순', value: 'oldest' },
 ];
 
+const FETCH_ALL_LIMIT = 999;
+
 const STATUS_OPTIONS: { label: string; value: MyStatusFilter }[] = [
   { label: '전체', value: 'all' },
   { label: '모집중', value: 'recruiting' },
@@ -56,7 +58,7 @@ export function MyGatheringsList() {
   const [isPending, startTransition] = useTransition();
 
   // 항상 전체 조회 후 tagState 기준으로 클라이언트 필터링 → 태그 표시와 드롭다운 필터 일치 보장
-  const { data } = useSuspenseQuery(membershipQueries.my({ status: 'all', page: 1, limit: 999 }));
+  const { data } = useSuspenseQuery(membershipQueries.my({ status: 'all', page: 1, limit: FETCH_ALL_LIMIT }));
 
   const filtered = data.gatherings.filter((g) => {
     if (status === 'all') return true;

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -18,7 +18,7 @@ import { MyGatheringsCard } from '../MyGatheringsCard';
 import type { GatheringStatusFilter } from '@/api/memberships/types';
 
 type SortOrder = 'latest' | 'oldest';
-type MyStatusFilter = Extract<GatheringStatusFilter, 'all' | 'in_progress' | 'completed'>;
+type MyStatusFilter = Extract<GatheringStatusFilter, 'all' | 'recruiting' | 'in_progress' | 'completed'>;
 
 const SORT_OPTIONS: { label: string; value: SortOrder }[] = [
   { label: '최신순', value: 'latest' },
@@ -27,6 +27,7 @@ const SORT_OPTIONS: { label: string; value: SortOrder }[] = [
 
 const STATUS_OPTIONS: { label: string; value: MyStatusFilter }[] = [
   { label: '전체', value: 'all' },
+  { label: '모집중', value: 'recruiting' },
   { label: '진행중', value: 'in_progress' },
   { label: '진행완료', value: 'completed' },
 ];
@@ -53,16 +54,14 @@ export function MyGatheringsList() {
   const [page, setPage] = useState(1);
   const [isPending, startTransition] = useTransition();
 
-  // status=all: API가 RECRUITING 포함 반환 → 서버 totalPages 신뢰 불가
-  // → 전체를 한 번에 받아(limit=999) 클라이언트에서 필터/페이지네이션
-  // status=in_progress|completed: 서버 필터 정확 → 서버 페이지네이션 그대로 사용
+  // status=all: 전체 정렬 정확도를 위해 limit=999로 전체 조회 후 클라이언트에서 정렬/페이지네이션
+  // status=recruiting|in_progress|completed: 서버 필터 정확 → 서버 페이지네이션 그대로 사용
   const isAll = status === 'all';
   const { data } = useSuspenseQuery(
     membershipQueries.my({ status, page: isAll ? 1 : page, limit: isAll ? 999 : limit }),
   );
 
-  const filtered = isAll ? data.gatherings.filter((g) => g.status !== 'RECRUITING') : data.gatherings;
-  const sorted = [...filtered].sort((a, b) => {
+  const sorted = [...data.gatherings].sort((a, b) => {
     const diff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
     return sort === 'latest' ? -diff : diff;
   });

--- a/src/app/my/_components/MyGatheringsList/index.tsx
+++ b/src/app/my/_components/MyGatheringsList/index.tsx
@@ -5,6 +5,7 @@ import { useState, useTransition } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { cn } from '@/lib/cn';
+import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 import { Dropdown } from '@/components/ui/Dropdown';
 import { useDropdown } from '@/components/ui/Dropdown/context';
 import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
@@ -54,19 +55,23 @@ export function MyGatheringsList() {
   const [page, setPage] = useState(1);
   const [isPending, startTransition] = useTransition();
 
-  // status=all: 전체 정렬 정확도를 위해 limit=999로 전체 조회 후 클라이언트에서 정렬/페이지네이션
-  // status=recruiting|in_progress|completed: 서버 필터 정확 → 서버 페이지네이션 그대로 사용
-  const isAll = status === 'all';
-  const { data } = useSuspenseQuery(
-    membershipQueries.my({ status, page: isAll ? 1 : page, limit: isAll ? 999 : limit }),
-  );
+  // 항상 전체 조회 후 tagState 기준으로 클라이언트 필터링 → 태그 표시와 드롭다운 필터 일치 보장
+  const { data } = useSuspenseQuery(membershipQueries.my({ status: 'all', page: 1, limit: 999 }));
 
-  const sorted = [...data.gatherings].sort((a, b) => {
+  const filtered = data.gatherings.filter((g) => {
+    if (status === 'all') return true;
+    const { tagState, isFinished } = getGatheringDisplayStatus(g);
+    if (status === 'recruiting') return tagState === 'recruiting';
+    if (status === 'in_progress') return tagState === 'progressing';
+    if (status === 'completed') return isFinished;
+    return true;
+  });
+  const sorted = [...filtered].sort((a, b) => {
     const diff = new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
     return sort === 'latest' ? -diff : diff;
   });
-  const totalPages = isAll ? Math.max(1, Math.ceil(sorted.length / limit)) : data.totalPages;
-  const paged = isAll ? sorted.slice((page - 1) * limit, page * limit) : sorted;
+  const totalPages = Math.max(1, Math.ceil(sorted.length / limit));
+  const paged = sorted.slice((page - 1) * limit, page * limit);
 
   const handleFilterChange = (next: Partial<{ status: MyStatusFilter; sort: SortOrder }>) => {
     if (next.sort !== undefined) {


### PR DESCRIPTION
## ❓ 이슈

- close #266 

## ✍️ Description

### 변경 내용

'나의 모임' 탭에서 `RECRUITING`(모집중) 상태 모임을 포함하도록 변경합니다.

기존에는 참여한 모임 중 `IN_PROGRESS`, `COMPLETED` 상태만 표시하고 `RECRUITING` 상태는 클라이언트에서 필터링해 제외하고 있었습니다.

**변경된 파일**

- `MyGatheringsList/index.tsx`: 필터 옵션에 '모집중' 추가, tagState 기반 클라이언트 필터링으로 변경
- `MyGatheringsCard/index.tsx`: RECRUITING 상태 카드 Footer 추가 (모집 인원 표시), Footer 조건을 `tagState` 기준으로 통일

---

### 주요 변경 상세

**`MyGatheringsList` — tagState 기반 클라이언트 필터링**

```ts
// Before: 백엔드 status 파라미터로 서버 필터링
membershipQueries.my({ status, page, limit })

// After: 항상 전체 조회 후 tagState로 클라이언트 필터링
membershipQueries.my({ status: 'all', page: 1, limit: 999 })

const filtered = data.gatherings.filter((g) => {
  if (status === 'all') return true;
  const { tagState, isFinished } = getGatheringDisplayStatus(g);
  if (status === 'recruiting') return tagState === 'recruiting';
  if (status === 'in_progress') return tagState === 'progressing';
  if (status === 'completed') return isFinished;
  return true;
});
```

**`MyGatheringsCard` Footer — tagState 기준으로 통일**

| 상태 | Footer |
|------|--------|
| `tagState === 'recruiting'` | 모집 인원 N/M |
| `tagState === 'progressing'` | 총 N주 \| N주차 진행중 |
| `isFinished` | 리뷰 쓰기 / 리뷰 작성완료 |

---

### 배경: `gathering.status` vs `getGatheringDisplayStatus`

이 프로젝트에서 모임 상태는 두 가지 방식으로 표현됩니다.

**백엔드 `status` 필드** (`RECRUITING` | `IN_PROGRESS` | `COMPLETED`)
- 백엔드가 관리하는 공식 상태값
- 현재 백엔드에서 날짜 기반 자동 전환이 이루어지지 않아, `startDate`가 지나도 `RECRUITING`으로 남아있는 경우가 있음

**`getGatheringDisplayStatus()` (프론트엔드 유틸)**
- `gathering.status` 외에 `isFull`, `isDeadlinePassed` 등을 추가로 계산해 시각적 태그 상태(`tagState`)를 반환
- 예: `status === 'RECRUITING'`이어도 `isFull === true`이면 `tagState === 'progressing'`('진행중' 태그) 표시

**드롭다운 필터와 Footer를 `tagState` 기준으로 통일**

기존에 드롭다운 필터는 백엔드 `status` 파라미터, Footer는 `gathering.status`를 직접 사용해 태그 표시와 불일치하는 문제가 있었습니다.
항상 전체(`status='all'`, `limit=999`)를 조회한 후 `tagState` 기준으로 클라이언트 필터링함으로써 태그·필터·Footer가 모두 일치합니다.

---





## 📸 스크린샷 (UI 변경 시)

<img width="1342" height="858" alt="image" src="https://github.com/user-attachments/assets/88665b27-a21b-49a9-922d-097452c0ccc7" />

zep에서 권진님이 알려주신 계정으로 로그인했을 때의 화면입니다!

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] 백엔드 `status` 자동 전환 미동작 이슈 별도 논의 필요
  - `startDate` 경과 후에도 `RECRUITING` 유지 → 백엔드에서 `IN_PROGRESS`로 자동 전환되면 `getGatheringDisplayStatus`의 날짜/인원 보정 로직 불필요해짐
