### PR TITLE
[SM-164] fix: 비로그인 시 보호 라우트 Link prefetch로 인한 리다이렉트 캐싱 버그 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,10 +10,10 @@ import { useAuth } from '@/hooks/useAuth';
 import { CloseIcon, ArrowIcon } from '@/components/ui/Icon';
 
 const NAVIGATION_ITEMS = [
-  { href: '/', label: '홈' },
-  { href: '/gatherings', label: '모임 탐색' },
-  { href: '/gatherings/new', label: '모임 만들기' },
-  { href: '/my', label: '내 모임' },
+  { href: '/', label: '홈', protected: false },
+  { href: '/gatherings', label: '모임 탐색', protected: false },
+  { href: '/gatherings/new', label: '모임 만들기', protected: true },
+  { href: '/my', label: '내 모임', protected: true },
 ] as const;
 
 export function Header() {
@@ -22,6 +22,7 @@ export function Header() {
   const pathname = usePathname();
   const isNavActive = (href: string) => pathname === href || (href === '/' && pathname === '/main');
   const { isLoggedIn, isLoading } = useAuth();
+  const hasSession = typeof document !== 'undefined' && document.cookie.includes('has-session=');
 
   useEffect(() => {
     if (!isSidebarOpen) {
@@ -64,6 +65,7 @@ export function Header() {
                       <Link
                         href={item.href}
                         className={`transition-colors hover:text-blue-400 ${isActive ? 'text-body-02-b lg:text-body-01-b text-gray-900' : 'text-body-02-m lg:text-body-01-m text-gray-700'}`}
+                        prefetch={item.protected && !hasSession ? false : undefined}
                       >
                         {item.label}
                       </Link>


### PR DESCRIPTION
## ❓ 이슈

  - close #268

  ## ✍️ Description

  프로덕션 환경에서 비로그인 유저가 사이트 진입 후 로그인하면, 헤더의 "모임 만들기"(`/gatherings/new`), "내 모임"(`/my`) 클릭 시 로그인 페이지로 리다이렉트되는 버그를 수정합니다.

  ### 원인

  Next.js `<Link>`의 자동 prefetch는 프로덕션에서만 뷰포트 진입 시 동작합니다. 비로그인 상태에서 보호 라우트의 prefetch가 발생하면 proxy가 `/login`으로 307 리다이렉트를 반환하고, 이 응답이 Router Cache에 저장됩니다. 로그인 후에도 캐시된
  리다이렉트가 재생되어 로그인 페이지로 이동됩니다.

  ### 해결

  `NAVIGATION_ITEMS`에 `protected` 플래그를 추가하고, `has-session` 쿠키를 동기적으로 읽어 비로그인 시 보호 라우트에만 `prefetch={false}`를 적용합니다. 로그인 후에는 `has-session` 쿠키가 존재하므로 prefetch가 정상 동작합니다.

 
  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [x] 비로그인 시 `my?_rsc`, `new?_rsc` prefetch 요청 없음 확인
  - [x] 로그인 후 정상 prefetch 및 페이지 이동 확인
