### PR TITLE
[SM-162] refactor: 대시보드 todo create 리팩토링 (추가 버튼 도입 및 에러메시지 보여주기) 및 캐시 무효화 누락된 것 수정

### DIFF
--- a/src/api/todos/queries.ts
+++ b/src/api/todos/queries.ts
@@ -4,6 +4,8 @@ import { getTodoList, getMyTodoList, createTodo, updateTodo, deleteTodo } from '
 
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { CreateTodoForm, CreateTodoResponse, UpdateTodoForm, UpdateTodoResponse, TodoListParams } from './types';
+import { membershipQueries } from '../memberships/queries';
+import { achievementKeys, achievementQueries } from '../achievements/queries';
 
 export const todoKeys = {
   all: (gatheringId: number) => ['todos', gatheringId] as const,
@@ -38,6 +40,8 @@ export const useCreateTodo = (
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: todoKeys.all(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: membershipQueries.members(gatheringId).queryKey });
+      queryClient.invalidateQueries({ queryKey: achievementKeys.all(gatheringId) });
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });
@@ -55,6 +59,8 @@ export const useUpdateTodo = (
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: todoKeys.all(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: membershipQueries.members(gatheringId).queryKey });
+      queryClient.invalidateQueries({ queryKey: achievementKeys.all(gatheringId) });
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });
@@ -69,6 +75,8 @@ export const useDeleteTodo = (gatheringId: number, options?: UseMutationOptions<
     ...options,
     onSuccess: (data, variables, onMutateResult, context) => {
       queryClient.invalidateQueries({ queryKey: todoKeys.all(gatheringId) });
+      queryClient.invalidateQueries({ queryKey: membershipQueries.members(gatheringId).queryKey });
+      queryClient.invalidateQueries({ queryKey: achievementKeys.all(gatheringId) });
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
   });

--- a/src/api/todos/queries.ts
+++ b/src/api/todos/queries.ts
@@ -5,7 +5,7 @@ import { getTodoList, getMyTodoList, createTodo, updateTodo, deleteTodo } from '
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { CreateTodoForm, CreateTodoResponse, UpdateTodoForm, UpdateTodoResponse, TodoListParams } from './types';
 import { membershipQueries } from '../memberships/queries';
-import { achievementKeys, achievementQueries } from '../achievements/queries';
+import { achievementKeys } from '../achievements/queries';
 
 export const todoKeys = {
   all: (gatheringId: number) => ['todos', gatheringId] as const,

--- a/src/api/todos/queries.ts
+++ b/src/api/todos/queries.ts
@@ -2,10 +2,11 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 
 import { getTodoList, getMyTodoList, createTodo, updateTodo, deleteTodo } from './index';
 
-import type { UseMutationOptions } from '@tanstack/react-query';
-import type { CreateTodoForm, CreateTodoResponse, UpdateTodoForm, UpdateTodoResponse, TodoListParams } from './types';
 import { membershipQueries } from '../memberships/queries';
 import { achievementKeys } from '../achievements/queries';
+
+import type { UseMutationOptions } from '@tanstack/react-query';
+import type { CreateTodoForm, CreateTodoResponse, UpdateTodoForm, UpdateTodoResponse, TodoListParams } from './types';
 
 export const todoKeys = {
   all: (gatheringId: number) => ['todos', gatheringId] as const,

--- a/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/TodoAddForm/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/TodoAddForm/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { useCreateTodo } from '@/api/todos/queries';
 import { Button } from '@/components/ui/Button';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { cn } from '@/lib/cn';
 
 interface TodoAddFormProps {
@@ -16,29 +17,48 @@ export function TodoAddForm({ gatheringId, week, className }: TodoAddFormProps) 
   const [isAdding, setIsAdding] = useState(false);
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const showToast = useToastStore((state) => state.showToast);
+
+  const closeForm = () => {
+    setValue('');
+    setIsAdding(false);
+  };
 
   const { mutate, isPending } = useCreateTodo(gatheringId, {
     onSuccess: () => {
-      setValue('');
-      setIsAdding(false);
+      closeForm();
+    },
+    onError: (error: Error) => {
+      showToast({
+        variant: 'error',
+        title: '할 일 추가 실패',
+        description: error.message,
+      });
     },
   });
 
   useEffect(() => {
-    if (!isAdding) return;
-    inputRef.current?.focus();
+    if (isAdding) inputRef.current?.focus();
   }, [isAdding]);
 
   const submit = () => {
     const content = value.trim();
-    if (!content) {
-      // 빈 값이면 조용히 종료(입력 UI 닫기) — 피그마/요구사항의 인라인 UX 유지
-      setValue('');
-      setIsAdding(false);
-      return;
-    }
+    if (!content) return closeForm();
     if (isPending) return;
     mutate({ week, content });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    submit();
+  };
+
+  const handleBlur = () => {
+    if (!value.trim()) closeForm();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') closeForm();
   };
 
   if (!isAdding) {
@@ -54,26 +74,27 @@ export function TodoAddForm({ gatheringId, week, className }: TodoAddFormProps) 
   }
 
   return (
-    <div className={cn('w-full', className)}>
+    <form onSubmit={handleSubmit} className={cn('flex w-full gap-2', className)}>
       <input
         ref={inputRef}
         value={value}
         onChange={(e) => setValue(e.target.value)}
-        onBlur={submit}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.preventDefault();
-            submit();
-          }
-          if (e.key === 'Escape') {
-            setValue('');
-            setIsAdding(false);
-          }
-        }}
-        placeholder='할 일을 입력해 주세요'
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
         disabled={isPending}
-        className='border-gray-150 bg-gray-0 text-body-02-r w-full rounded-lg border px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300 focus:border-blue-200'
+        placeholder='할 일을 입력해 주세요'
+        aria-label='할 일을 입력해 주세요'
+        className='border-gray-150 bg-gray-0 text-body-02-r flex-1 rounded-lg border px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300 focus:border-blue-200'
       />
-    </div>
+      <Button
+        type='submit'
+        variant='check'
+        size='check'
+        disabled={isPending || !value.trim()}
+        className='h-auto shrink-0 px-4 py-3'
+      >
+        추가
+      </Button>
+    </form>
   );
 }

--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -37,6 +37,19 @@ export const axiosClient: AxiosInstance = axios.create({
 axiosClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
+    if (error.response?.data) {
+      const data = error.response.data;
+      if (typeof data === 'object' && data !== null && 'message' in data) {
+        error.message = String((data as Record<string, unknown>).message);
+      } else if (typeof data === 'string') {
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed.message) error.message = String(parsed.message);
+        } catch {
+          // JSON 파싱 실패 시 기존 error.message 유지
+        }
+      }
+    }
     if (!shouldAttemptRefresh(error)) throw error;
 
     const config = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined;


### PR DESCRIPTION
## ❓ 이슈

- close #265 

## ✍️ Description

- 내 할일 목록 개선(투두 추가 실패 시 에러메시지 토스트, 접근성 등
- 캐시 무효화 로직 추가

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
