### PR TITLE
[SM-166] fix: 모임 생성 폼 태그 선택 조건 버그 수정

### DIFF
--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -105,7 +105,6 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   const shortDescValue = watch('shortDescription') ?? '';
   const descValue = watch('description') ?? '';
   const goalValue = watch('goal') ?? '';
-  const tagsValue = watch('tags') ?? [];
   const maxMembersValue = watch('maxMembers');
   const recruitDeadlineValue = watch('recruitDeadline');
   const startDateValue = watch('startDate');
@@ -132,7 +131,6 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     !!shortDescValue &&
     !!descValue &&
     !!goalValue &&
-    tagsValue.length > 0 &&
     typeof maxMembersValue === 'number' &&
     maxMembersValue >= 2 &&
     maxMembersValue <= 10 &&


### PR DESCRIPTION
## ❓ 이슈

- close #274 

## ✍️ Description

모임 생성 폼에서 태그는 `(선택)` 필드임에도 `isFormComplete` 조건에 `tagsValue.length > 0`이 포함되어, 태그를 입력하지 않으면 작성 완료 버튼이 활성화되지 않는 버그 수정

- `isFormComplete`에서 `tagsValue.length > 0` 조건 제거
- 미사용 변수 `tagsValue` 제거

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


