### PR TITLE
[SM-167] fix: 마이페이지 대기중 모임 탭 404 에러 방어 및 탭 전환 시 에러 전파 수정

### DIFF
--- a/src/api/applications/index.ts
+++ b/src/api/applications/index.ts
@@ -1,7 +1,10 @@
+import axios from 'axios';
+
 import { axiosClient } from '@/lib/axiosClient';
 
 import { unwrapResponse } from '../common/utils';
-import { ApiResponse } from '../common/types';
+
+import type { ApiResponse } from '../common/types';
 
 import {
   ApplicationListResponse,
@@ -52,6 +55,20 @@ export const deleteApplication = async (gatheringId: number, applicationId: numb
 
 /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */
 export const getMyApplicationList = async (): Promise<MyApplicationListResponse> => {
-  const { data } = await axiosClient.get<ApiResponse<MyApplicationListResponse>>(`/v1/users/me/applications`);
-  return unwrapResponse(data);
+  try {
+    const { data } = await axiosClient.get<ApiResponse<MyApplicationListResponse>>(`/v1/users/me/applications`);
+
+    // 백엔드가 신청 없을 때 success: false로 반환하는 이슈 방어
+    if (!data.success && data.data === null) {
+      return { applications: [] };
+    }
+
+    return unwrapResponse(data);
+  } catch (error) {
+    // 백엔드가 신청 없을 때 404 GATHERING_NOT_FOUND를 반환하는 이슈 방어
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return { applications: [] };
+    }
+    throw error;
+  }
 };

--- a/src/app/my/_components/MyPageContent/index.tsx
+++ b/src/app/my/_components/MyPageContent/index.tsx
@@ -28,6 +28,7 @@ export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'my-gatherings')
     return (
       <SuspenseBoundary
+        key={activeTab}
         pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
         errorFallback={
           <p className='flex h-40 items-center justify-center text-gray-500'>모임을 불러올 수 없습니다.</p>
@@ -39,6 +40,7 @@ export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'created-gatherings')
     return (
       <SuspenseBoundary
+        key={activeTab}
         pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
         errorFallback={
           <p className='flex h-40 items-center justify-center text-gray-500'>모임을 불러올 수 없습니다.</p>
@@ -50,6 +52,7 @@ export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'pending-gatherings') {
     return (
       <SuspenseBoundary
+        key={activeTab}
         pendingFallback={<PendingGatheringsSkeleton />}
         errorFallback={
           <p className='text-body-02-r mt-6 py-10 text-center text-gray-500'>
@@ -64,6 +67,7 @@ export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'received-reviews') {
     return (
       <SuspenseBoundary
+        key={activeTab}
         pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
         errorFallback={
           <p className='flex h-40 items-center justify-center text-gray-500'>리뷰를 불러올 수 없습니다.</p>
@@ -76,6 +80,7 @@ export function MyPageContent({ activeTab, pendingSort }: MyPageContentProps) {
   if (activeTab === 'liked-gatherings') {
     return (
       <SuspenseBoundary
+        key={activeTab}
         pendingFallback={<div className='flex h-40 items-center justify-center text-gray-400'>불러오는 중...</div>}
         errorFallback={
           <p className='flex h-40 items-center justify-center text-gray-500'>찜한 모임을 불러올 수 없습니다.</p>


### PR DESCRIPTION
## ❓ 이슈

  - close #276

  ## ✍️ Description

  ### 문제
  - `/my` 대기중인 모임 탭에서 신청 내역이 없을 때 백엔드가 빈 배열 대신 HTTP 404 (`GATHERING_NOT_FOUND`)를 반환
  - TanStack Query 기본 retry 3회로 로딩이 느려지고 에러 fallback 노출
  - 대기중 탭 에러 발생 후 다른 탭으로 이동하면 모든 탭이 에러 fallback을 보여줌 (새로고침 전까지 복구 안 됨)

  ### 해결
  1. **`getMyApplicationList` API 함수에서 404 방어** (`src/api/applications/index.ts`)
     - axios는 4xx 응답에서 자동 throw하므로 try-catch로 감싸 404를 빈 목록으로 변환
     - HTTP 200이지만 `success: false`인 경우도 방어

  2. **`SuspenseBoundary`에 `key={activeTab}` 추가** (`src/app/my/_components/MyPageContent/index.tsx`)
     - React Reconciliation이 같은 위치 + 같은 타입의 컴포넌트를 인스턴스 재사용하여 ErrorBoundary의 error 상태가
  다른 탭으로 전파되는 문제
     - `key`가 변경되면 인스턴스를 파괴 후 새로 생성하므로 탭 간 에러 상태 격리

  ## 📸 스크린샷 (UI 변경 시)

  ## ✅ Checklist

  ### PR

  - [x] Branch Convention 확인
  - [x] Base Branch 확인
  - [x] 적절한 Label 지정
  - [x] Assignee 및 Reviewer 지정

  ### Test

  - [x] 로컬 작동 확인
  - [x] 빌드 통과 (`npm run build`)
  - [x] 린트 통과 (`npm run lint`)

  ### Additional Notes

  - [ ] 근본 원인은 백엔드가 빈 목록을 404로 반환하는 것이므로 백엔드 수정도 필요