### PR TITLE
[SM-171] feat: 실시간 회의 토큰 발급 API 및 상숫값 정의

### DIFF
--- a/src/app/api/livekit/token/route.ts
+++ b/src/app/api/livekit/token/route.ts
@@ -68,11 +68,10 @@ export async function GET(req: NextRequest) {
 
   const participantIdentity = `user-${userId}`;
 
-  // 2. 보안: 토큰 유효기간을 10분으로 짧게 설정 (입장 유효 시간)
   const at = new AccessToken(apiKey, apiSecret, {
     identity: participantIdentity,
     name: nickname,
-    ttl: '10m',
+    ttl: '1h',
   });
 
   at.addGrant({ roomJoin: true, room: room });

--- a/src/app/api/livekit/token/route.ts
+++ b/src/app/api/livekit/token/route.ts
@@ -1,0 +1,69 @@
+import { AccessToken } from 'livekit-server-sdk';
+import { NextRequest, NextResponse } from 'next/server';
+import { requestBackend } from '@/lib/serverFetch';
+
+export async function GET(req: NextRequest) {
+  const room = req.nextUrl.searchParams.get('room');
+
+  if (!room) {
+    return NextResponse.json({ error: 'Missing "room" query parameter' }, { status: 400 });
+  }
+
+  const roomPattern = /^gathering-\d+$/;
+  if (!roomPattern.test(room)) {
+    return NextResponse.json({ error: 'Invalid room format' }, { status: 400 });
+  }
+
+  // 1. 보안: 클라이언트 요청 파라미터를 신뢰하지 않고, 서버 단에서 직접 모임 참여자인지 검증
+  const gatheringId = parseInt(room.split('-')[1], 10);
+  const memberResponse = await requestBackend({
+    request: req,
+    endpoint: `v1/gatherings/${gatheringId}/members`,
+    overrideSearchParams: new URLSearchParams(),
+  });
+
+  if (!memberResponse.ok) {
+    return NextResponse.json({ error: 'Unauthorized: You must be a member to join this meeting' }, { status: 403 });
+  }
+
+  // user 정보는 users/me 에서 가져오거나 memberResponse에서 찾아서 사용해야 함.
+  // 코드 리뷰에 따라 로그인 정보 검증 로직을 유지하면서, memberResponse 도 확인하도록 수정.
+  const userResponse = await requestBackend({
+    request: req,
+    endpoint: 'v1/users/me',
+    overrideSearchParams: new URLSearchParams(),
+  });
+
+  if (!userResponse.ok) {
+    return NextResponse.json({ error: 'Unauthorized: You must be logged in to join a meeting' }, { status: 401 });
+  }
+
+  const user = await userResponse.json();
+  const userId = user?.data?.id;
+  const nickname = user?.data?.nickname;
+
+  if (!userId || !nickname) {
+    return NextResponse.json({ error: 'Failed to retrieve valid user info' }, { status: 401 });
+  }
+
+  const apiKey = process.env.LIVEKIT_API_KEY;
+  const apiSecret = process.env.LIVEKIT_API_SECRET;
+  const wsUrl = process.env.LIVEKIT_URL;
+
+  if (!apiKey || !apiSecret || !wsUrl) {
+    return NextResponse.json({ error: 'Server misconfigured: LiveKit credentials missing' }, { status: 500 });
+  }
+
+  const participantIdentity = `user-${userId}`;
+
+  // 2. 보안: 토큰 유효기간을 10분으로 짧게 설정 (입장 유효 시간)
+  const at = new AccessToken(apiKey, apiSecret, {
+    identity: participantIdentity,
+    name: nickname,
+    ttl: '10m',
+  });
+
+  at.addGrant({ roomJoin: true, room: room });
+
+  return NextResponse.json({ token: await at.toJwt() });
+}

--- a/src/app/api/livekit/token/route.ts
+++ b/src/app/api/livekit/token/route.ts
@@ -14,28 +14,40 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid room format' }, { status: 400 });
   }
 
-  // 1. 보안: 클라이언트 요청 파라미터를 신뢰하지 않고, 서버 단에서 직접 모임 참여자인지 검증
   const gatheringId = parseInt(room.split('-')[1], 10);
-  const memberResponse = await requestBackend({
-    request: req,
-    endpoint: `v1/gatherings/${gatheringId}/members`,
-    overrideSearchParams: new URLSearchParams(),
-  });
+  const [memberResponse, userResponse] = await Promise.all([
+    requestBackend({
+      request: req,
+      endpoint: `v1/gatherings/${gatheringId}/members`,
+      overrideSearchParams: new URLSearchParams(),
+    }),
+    requestBackend({
+      request: req,
+      endpoint: 'v1/users/me',
+      overrideSearchParams: new URLSearchParams(),
+    }),
+  ]);
 
   if (!memberResponse.ok) {
-    return NextResponse.json({ error: 'Unauthorized: You must be a member to join this meeting' }, { status: 403 });
+    return NextResponse.json(
+      {
+        error: 'Unauthorized: You must be a member to join this meeting',
+      },
+      {
+        status: 403,
+      },
+    );
   }
 
-  // user 정보는 users/me 에서 가져오거나 memberResponse에서 찾아서 사용해야 함.
-  // 코드 리뷰에 따라 로그인 정보 검증 로직을 유지하면서, memberResponse 도 확인하도록 수정.
-  const userResponse = await requestBackend({
-    request: req,
-    endpoint: 'v1/users/me',
-    overrideSearchParams: new URLSearchParams(),
-  });
-
   if (!userResponse.ok) {
-    return NextResponse.json({ error: 'Unauthorized: You must be logged in to join a meeting' }, { status: 401 });
+    return NextResponse.json(
+      {
+        error: 'Unauthorized: You must be logged in to join a meeting',
+      },
+      {
+        status: 401,
+      },
+    );
   }
 
   const user = await userResponse.json();

--- a/src/app/gatherings/[id]/dashboard/_constants.ts
+++ b/src/app/gatherings/[id]/dashboard/_constants.ts
@@ -2,6 +2,7 @@ export const DASHBOARD_TAB_ITEMS = [
   { key: 'summary', label: '활동 요약' },
   { key: 'weekly', label: '주차별 현황' },
   { key: 'members', label: '멤버' },
+  { key: 'meeting', label: '회의' },
 ] as const;
 
 export type DashboardTab = (typeof DASHBOARD_TAB_ITEMS)[number]['key'];


### PR DESCRIPTION
## ❓ 이슈

- close #280 

## ✍️ Description

실시간 화상 회의 기능을 연결하기 위한 백엔드 API와 프론트엔드 공통 상숫값을 구축합니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
