### PR TITLE
[SM-176] feat:  나의 모임 카드 리뷰 쓰기 연결·카운트 배지 추가 및 리뷰 목록 API 응답 정규화

### DIFF
--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -27,8 +27,8 @@ export interface MembershipGathering {
   endDate: string;
   status: GatheringStatus;
   myRole: MemberRole;
-  /** 리뷰 작성 여부 — 백엔드 연동 전까지 응답에 포함되지 않으므로 optional. undefined는 미작성(false)으로 처리 */
-  hasReviewed?: boolean;
+  /** 리뷰 작성 여부 — 최소 1명 이상 리뷰 작성 시 true */
+  hasReviewed: boolean;
   pendingApplicationCount: number;
 }
 

--- a/src/api/memberships/types.ts
+++ b/src/api/memberships/types.ts
@@ -29,6 +29,8 @@ export interface MembershipGathering {
   myRole: MemberRole;
   /** 리뷰 작성 여부 — 최소 1명 이상 리뷰 작성 시 true */
   hasReviewed: boolean;
+  /** 현재 유저가 리뷰한 멤버 수 */
+  reviewedMembersCount: number;
   pendingApplicationCount: number;
 }
 

--- a/src/api/reviews/index.ts
+++ b/src/api/reviews/index.ts
@@ -1,7 +1,26 @@
 import { axiosClient } from '@/lib/axiosClient';
 import { unwrapResponse } from '../common/utils';
-import { CreateReviewsForm, CreateReviewsResponse, UserReviewListResponse, UserReviewsParams } from './types';
+import { CreateReviewsForm, CreateReviewsResponse, Review, UserReviewListResponse, UserReviewsParams } from './types';
 import { ApiResponse } from '../common/types';
+
+// 백엔드가 flat 필드(reviewerId, reviewerNickname)로 응답하므로 중첩 reviewer 객체로 변환
+const normalizeReview = (
+  raw: Review & {
+    reviewerId?: number;
+    reviewerNickname?: string;
+    reviewerProfileImage?: string;
+  },
+): Review => {
+  if (raw.reviewer) return raw;
+  return {
+    ...raw,
+    reviewer: {
+      id: raw.reviewerId!,
+      nickname: raw.reviewerNickname!,
+      profileImage: raw.reviewerProfileImage,
+    },
+  };
+};
 
 /** POST /v1/gatherings/:gatheringId/reviews — 리뷰 작성 */
 export const createReviews = async (gatheringId: number, body: CreateReviewsForm): Promise<CreateReviewsResponse> => {
@@ -20,5 +39,6 @@ export const getUserReviewList = async (
   const { data } = await axiosClient.get<ApiResponse<UserReviewListResponse>>(`/v1/users/${userId}/reviews`, {
     params,
   });
-  return unwrapResponse(data);
+  const result = unwrapResponse(data);
+  return { ...result, reviews: result.reviews.map(normalizeReview) };
 };

--- a/src/app/my/_components/MyGatheringsCard/ReviewWriteButton/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/ReviewWriteButton/index.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { ReviewIcon } from '@/components/ui/Icon';
+
+interface ReviewWriteButtonProps {
+  gatheringId: number;
+}
+
+export function ReviewWriteButton({ gatheringId }: ReviewWriteButtonProps) {
+  const router = useRouter();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    router.push(`/gatherings/${gatheringId}/dashboard?tab=members`);
+  };
+
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      className='flex h-[54px] w-full cursor-pointer items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'
+    >
+      <div className='flex items-center gap-2'>
+        <ReviewIcon size={16} className='text-blue-300 md:size-6' />
+        <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>리뷰 쓰기</span>
+      </div>
+    </button>
+  );
+}

--- a/src/app/my/_components/MyGatheringsCard/ReviewWriteButton/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/ReviewWriteButton/index.tsx
@@ -2,13 +2,15 @@
 
 import { useRouter } from 'next/navigation';
 
-import { ReviewIcon } from '@/components/ui/Icon';
+import { PersonIcon, ReviewIcon } from '@/components/ui/Icon';
 
 interface ReviewWriteButtonProps {
   gatheringId: number;
+  reviewedCount: number;
+  totalCount: number;
 }
 
-export function ReviewWriteButton({ gatheringId }: ReviewWriteButtonProps) {
+export function ReviewWriteButton({ gatheringId, reviewedCount, totalCount }: ReviewWriteButtonProps) {
   const router = useRouter();
 
   const handleClick = (e: React.MouseEvent) => {
@@ -21,11 +23,17 @@ export function ReviewWriteButton({ gatheringId }: ReviewWriteButtonProps) {
     <button
       type='button'
       onClick={handleClick}
-      className='flex h-[54px] w-full cursor-pointer items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'
+      className='relative flex h-[54px] w-full cursor-pointer items-center justify-center rounded-[8px] bg-blue-300 md:h-[72px]'
     >
       <div className='flex items-center gap-2'>
-        <ReviewIcon size={16} className='text-blue-300 md:size-6' />
-        <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>리뷰 쓰기</span>
+        <ReviewIcon size={16} className='text-white md:size-6' />
+        <span className='text-small-01-sb md:text-body-01-sb text-white'>리뷰 쓰기</span>
+      </div>
+      <div className='bg-gray-0 absolute right-3 flex h-[25px] w-[59px] items-center justify-center gap-1 rounded-[8px] md:right-5 md:h-[32px] md:w-[71px]'>
+        <PersonIcon size={10} className='text-blue-300 md:size-5' />
+        <span className='text-small-02-sb md:text-body-02-sb text-blue-300'>
+          {reviewedCount}/{totalCount}
+        </span>
       </div>
     </button>
   );

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -2,14 +2,17 @@ import { differenceInDays, startOfDay } from 'date-fns';
 
 import { formatDateDot, getCurrentWeek } from '@/lib/formatGatheringDate';
 
+import Link from 'next/link';
+
 import { GatheringCard } from '@/components/ui/GatheringCard';
-import { CalendarIcon, ProjectIcon, ReviewIcon, StudyIcon } from '@/components/ui/Icon';
+import { CalendarIcon, ProjectIcon, StudyIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { Tag } from '@/components/ui/Tag';
 import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 
+import { ReviewWriteButton } from './ReviewWriteButton';
+
 import type { MembershipGathering } from '@/api/memberships/types';
-import Link from 'next/link';
 
 interface MyGatheringsCardProps {
   gathering: MembershipGathering;
@@ -107,14 +110,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
               </div>
             </div>
           )}
-          {isFinished && !hasReviewed && (
-            <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
-              <div className='flex items-center gap-2'>
-                <ReviewIcon size={16} className='text-blue-300 md:size-6' />
-                <span className='text-small-01-sb md:text-body-01-sb text-blue-300'>리뷰 쓰기</span>
-              </div>
-            </div>
-          )}
+          {isFinished && !hasReviewed && <ReviewWriteButton gatheringId={gathering.id} />}
           {isFinished && hasReviewed && (
             <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
               <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성완료</span>

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -1,13 +1,12 @@
-import { differenceInDays, startOfDay } from 'date-fns';
-
-import { formatDateDot, getCurrentWeek } from '@/lib/formatGatheringDate';
-
 import Link from 'next/link';
+
+import { differenceInDays, startOfDay } from 'date-fns';
 
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { CalendarIcon, ProjectIcon, StudyIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { Tag } from '@/components/ui/Tag';
+import { formatDateDot, getCurrentWeek } from '@/lib/formatGatheringDate';
 import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 
 import { ReviewWriteButton } from './ReviewWriteButton';

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -33,7 +33,7 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
   const progressRate = totalDays > 0 ? Math.min(100, Math.max(0, Math.floor((passedDays / totalDays) * 100))) : 0;
 
   const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] ?? ProjectIcon;
-  const hasReviewed = !!gathering.hasReviewed;
+  const allReviewed = gathering.reviewedMembersCount === gathering.currentMembers;
 
   const { displayLabel, tagState, isFinished } = getGatheringDisplayStatus(gathering);
 
@@ -109,10 +109,16 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
               </div>
             </div>
           )}
-          {isFinished && !hasReviewed && <ReviewWriteButton gatheringId={gathering.id} />}
-          {isFinished && hasReviewed && (
+          {isFinished && !allReviewed && (
+            <ReviewWriteButton
+              gatheringId={gathering.id}
+              reviewedCount={gathering.reviewedMembersCount}
+              totalCount={gathering.currentMembers}
+            />
+          )}
+          {isFinished && allReviewed && (
             <div className='flex h-[54px] w-full items-center justify-center rounded-[8px] bg-blue-50 md:h-[72px]'>
-              <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성완료</span>
+              <span className='text-small-01-sb md:text-body-01-sb text-gray-600'>리뷰 작성 완료</span>
             </div>
           )}
         </GatheringCard.Footer>

--- a/src/mocks/handlers/memberships.ts
+++ b/src/mocks/handlers/memberships.ts
@@ -35,6 +35,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'IN_PROGRESS',
     myRole: 'LEADER',
     hasReviewed: false,
+    reviewedMembersCount: 0,
     pendingApplicationCount: 2,
   },
   {
@@ -51,6 +52,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: false,
+    reviewedMembersCount: 0,
     pendingApplicationCount: 2,
   },
   {
@@ -67,6 +69,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'COMPLETED',
     myRole: 'MEMBER',
     hasReviewed: false,
+    reviewedMembersCount: 4,
     pendingApplicationCount: 9,
   },
   {
@@ -83,6 +86,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: false,
+    reviewedMembersCount: 0,
     pendingApplicationCount: 1,
   },
   {
@@ -99,6 +103,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: false,
+    reviewedMembersCount: 0,
     pendingApplicationCount: 5,
   },
   {
@@ -115,6 +120,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: false,
+    reviewedMembersCount: 0,
     pendingApplicationCount: 7,
   },
   {
@@ -131,6 +137,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: false,
+    reviewedMembersCount: 0,
     pendingApplicationCount: 1,
   },
   {
@@ -147,6 +154,7 @@ const mockGatherings: MembershipGathering[] = [
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: true,
+    reviewedMembersCount: 3,
     pendingApplicationCount: 4,
   },
 ];


### PR DESCRIPTION
## ❓ 이슈

- close #290 

## ✍️ Description

### 나의 모임 카드 "리뷰 쓰기" 연결

완료된 모임 카드의 "리뷰 쓰기" 클릭 시 대시보드 기본탭(summary)으로 이동하던 문제를 수정했습니다.

- `ReviewWriteButton` 클라이언트 컴포넌트 신규 생성
  - `e.preventDefault()` + `e.stopPropagation()`으로 부모 `<Link>` 이동 차단
  - `router.push('/gatherings/{id}/dashboard?tab=members')`로 멤버탭 직접 이동
- `MyGatheringsCard`에서 인라인 div → `<ReviewWriteButton>`으로 교체

- `MembershipGathering.hasReviewed` 백엔드 연동 확인에 따라 `optional` 제거 및 주석 현행화
  - 기존: `hasReviewed?: boolean` (백엔드 미연동으로 optional 처리)
  - 변경: `hasReviewed: boolean` (최소 1명 리뷰 작성 시 true로 응답 확인)

### 리뷰 목록 API 응답 정규화 버그 수정

`GET /v1/users/:userId/reviews` 실제 응답이 flat 구조(`reviewerId`, `reviewerNickname`)로 내려오지만 변환 없이 반환해, `r.reviewer`가 항상 `undefined`가 되는 버그를 수정했습니다.

- `normalizeReview` 함수 추가 — flat 필드를 중첩 `reviewer` 객체로 변환
- `getUserReviewList` 반환 시 일괄 적용
- 영향 범위: 대시보드 멤버 카드 `hasReviewed` 판단, 받은 리뷰 목록, 멤버 상세 모달 모두 해결

### 나의 모임 카드 리뷰 카운트 배지 추가

**배경**
리뷰 쓰기 버튼에 (현재 유저가 리뷰한 수 / 전체 멤버 수)를 표시하려 했으나, 기존 API는 `hasReviewed: boolean`만 반환해 리뷰한 멤버 수를 알 수 없었습니다.

프론트엔드에서 직접 계산하려면 종료된 모임별로 멤버 목록을 불러온 뒤 각 멤버의 리뷰 목록을 조회해야 하는데, 리뷰 작성 후 갱신 시 종료된 모임 수 × 멤버 수만큼 쿼리가 한꺼번에 발생해(예: 모임 3개 × 9명 = 27회) 비용이 크다고 판단했습니다. 이에 백엔드에 `reviewedMembersCount` 필드 추가를 요청했으며, 백엔드 레포에서 추가된 것을 확인했습니다.

**변경 내용**
- `MembershipGathering` 타입에 `reviewedMembersCount: number` 필드 추가
- `ReviewWriteButton`에 리뷰 카운트 배지(현재 유저가 리뷰한 수 / 전체 멤버 수) 추가
- "리뷰 작성 완료" 표시 조건 변경: `hasReviewed` → `reviewedMembersCount === currentMembers` (전원 리뷰 완료 시에만 표시)

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->


