### PR TITLE
[SM-178] feat: 서비스 소개, 이용 약관, 개인정보 처리방침 정적 페이지 구현

### DIFF
--- a/src/app/(info)/about/page.tsx
+++ b/src/app/(info)/about/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '서비스 소개 | 완성도',
+  description: '완성도는 스터디와 프로젝트 모임을 더 쉽게 만들고 관리할 수 있는 플랫폼입니다.',
+};
+
+const FEATURES = [
+  {
+    title: '함께하는 모임 관리',
+    description:
+      '스터디, 프로젝트 등 다양한 모임을 직접 만들거나 참여할 수 있습니다. 모임 정보와 멤버를 한곳에서 관리하세요.',
+  },
+  {
+    title: '주차별 계획 관리',
+    description:
+      '모임의 목표와 진행 상황을 주차별로 기록하고 공유할 수 있습니다. 체계적인 일정 관리로 모임을 완성도 있게 이끌어가세요.',
+  },
+  {
+    title: '리뷰 & 평가',
+    description:
+      '모임이 완료된 후 리뷰를 남기고 서로 평가할 수 있습니다. 솔직한 피드백으로 더 나은 모임 문화를 만들어가요.',
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <div>
+      <h1 className='text-h5-b md:text-h4-b mb-4 text-gray-900'>서비스 소개</h1>
+      <p className='text-body-02-r md:text-body-01-r mb-8 text-gray-600 md:mb-12'>
+        완성도는 스터디와 프로젝트 모임을 더 쉽게 만들고 관리할 수 있는 플랫폼입니다. 함께하는 사람들과 목표를 세우고,
+        꾸준히 실천하며, 의미 있는 결과를 만들어보세요.
+      </p>
+      <ul className='flex flex-col gap-4 md:gap-6'>
+        {FEATURES.map(({ title, description }) => (
+          <li key={title} className='rounded-2xl bg-gray-50 p-5 md:p-8'>
+            <h2 className='text-body-01-b md:text-h5-b mb-2 text-gray-900 md:mb-3'>{title}</h2>
+            <p className='text-body-02-r md:text-body-01-r text-gray-600'>{description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(info)/layout.tsx
+++ b/src/app/(info)/layout.tsx
@@ -1,0 +1,3 @@
+export default function InfoLayout({ children }: { children: React.ReactNode }) {
+  return <main className='mx-auto max-w-[800px] px-4 py-10 md:px-6 md:py-12 xl:py-16'>{children}</main>;
+}

--- a/src/app/(info)/privacy/page.tsx
+++ b/src/app/(info)/privacy/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '개인정보 처리방침 | 완성도',
+};
+
+const SECTIONS = [
+  {
+    title: '1. 수집하는 개인정보 항목',
+    content:
+      '서비스는 회원 가입 및 서비스 이용 과정에서 다음과 같은 개인정보를 수집합니다.\n\n필수 항목: 이메일 주소, 닉네임, 비밀번호\n선택 항목: 프로필 이미지',
+  },
+  {
+    title: '2. 개인정보 수집 및 이용 목적',
+    content:
+      '수집한 개인정보는 다음의 목적을 위해 이용합니다.\n\n• 회원 식별 및 인증\n• 서비스 제공 및 운영 (모임 생성, 참여, 리뷰 등)',
+  },
+  {
+    title: '3. 개인정보 보유 및 이용 기간',
+    content: '서비스는 서비스 운영 기간 동안 개인정보를 보유합니다. 서비스 종료 시 개인정보를 지체 없이 파기합니다.',
+  },
+  {
+    title: '4. 개인정보의 제3자 제공',
+    content:
+      '서비스는 원칙적으로 회원의 개인정보를 외부에 제공하지 않습니다. 다만, 회원이 사전에 동의한 경우 또는 법령에 따라 수사기관 등이 요청하는 경우에는 예외로 합니다.',
+  },
+  {
+    title: '5. 개인정보 파기 절차 및 방법',
+    content:
+      '서비스는 개인정보 보유 기간이 경과하거나 처리 목적이 달성된 경우 지체 없이 해당 개인정보를 파기합니다.\n\n• 전자적 파일 형태: 복구 불가능한 방법으로 영구 삭제\n• 종이 문서: 분쇄 또는 소각',
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <div>
+      <h1 className='text-h5-b md:text-h4-b mb-2 text-gray-900'>개인정보 처리방침</h1>
+      <p className='text-small-01-r md:text-body-02-r mb-8 text-gray-400 md:mb-12'>최종 업데이트: 2026년 5월 8일</p>
+      <div className='flex flex-col gap-6 md:gap-8'>
+        {SECTIONS.map(({ title, content }) => (
+          <section key={title}>
+            <h2 className='text-body-02-b md:text-body-01-b mb-2 text-gray-900'>{title}</h2>
+            <p className='text-body-02-r md:text-body-01-r whitespace-pre-line text-gray-600'>{content}</p>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(info)/terms/page.tsx
+++ b/src/app/(info)/terms/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '이용 약관 | 완성도',
+};
+
+const TERMS = [
+  {
+    title: '제1조 (목적)',
+    content:
+      '이 약관은 완성도(이하 "서비스")가 제공하는 모든 서비스의 이용 조건 및 절차, 서비스와 회원 간의 권리·의무 및 책임 사항을 규정함을 목적으로 합니다.',
+  },
+  {
+    title: '제2조 (회원 가입)',
+    content:
+      '서비스를 이용하려는 자는 약관에 동의한 후 회원 가입을 신청할 수 있습니다. 회원 가입은 이용자가 약관의 내용에 동의하고, 서비스가 정한 양식에 따라 필요한 정보를 기입한 후 신청 버튼을 클릭함으로써 완료됩니다.',
+  },
+  {
+    title: '제3조 (서비스 이용)',
+    content:
+      '서비스는 회원에게 모임 생성, 모임 참여, 주차별 계획 관리, 리뷰 작성 등의 기능을 제공합니다. 서비스는 연중무휴 24시간 제공을 원칙으로 하나, 시스템 정기 점검이나 장애 등 불가피한 사유 발생 시 일시적으로 중단될 수 있습니다.',
+  },
+  {
+    title: '제4조 (회원의 의무)',
+    content:
+      '회원은 서비스 이용 시 다른 회원의 권리를 침해하거나, 허위 정보를 등록하거나, 타인의 계정 정보를 도용하거나, 서비스의 정상적인 운영을 방해하는 행위를 해서는 안 됩니다. 이를 위반할 경우 서비스는 해당 회원의 이용을 제한할 수 있습니다.',
+  },
+  {
+    title: '제5조 (개인정보 보호)',
+    content:
+      '서비스는 관련 법령이 정하는 바에 따라 회원의 개인정보를 보호합니다. 개인정보의 수집·이용·제공에 관한 사항은 개인정보 처리방침에 따릅니다.',
+  },
+  {
+    title: '제6조 (서비스 이용 제한)',
+    content:
+      '서비스는 회원이 본 약관의 의무를 위반하거나 서비스의 정상적인 운영을 방해한 경우, 경고·일시 정지·영구 이용 정지 등으로 서비스 이용을 단계적으로 제한할 수 있습니다.',
+  },
+];
+
+export default function TermsPage() {
+  return (
+    <div>
+      <h1 className='text-h5-b md:text-h4-b mb-2 text-gray-900'>이용 약관</h1>
+      <p className='text-small-01-r md:text-body-02-r mb-8 text-gray-400 md:mb-12'>최종 업데이트: 2026년 5월 8일</p>
+      <ol className='flex flex-col gap-6 md:gap-8'>
+        {TERMS.map(({ title, content }) => (
+          <li key={title}>
+            <h2 className='text-body-02-b md:text-body-01-b mb-2 text-gray-900'>{title}</h2>
+            <p className='text-body-02-r md:text-body-01-r text-gray-600'>{content}</p>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}


### PR DESCRIPTION
## ❓ 이슈

- close #293 

## ✍️ Description

푸터 링크에 대응하는 정적 페이지 3개를 구현했습니다.

- `/about` — 서비스 소개 (핵심 기능 카드 3개)
- `/terms` — 이용 약관 (제1조~제6조)
- `/privacy` — 개인정보 처리방침 (5개 항목)

`(info)` 라우트 그룹으로 공통 레이아웃을 공유하며, 모바일/태블릿/데스크톱 반응형을 적용했습니다.

## 📸 스크린샷 (UI 변경 시)

<img width="1898" height="1054" alt="image" src="https://github.com/user-attachments/assets/39b4c0f9-8764-4587-81e2-b48868fa1fd8" />

<img width="1904" height="1320" alt="image" src="https://github.com/user-attachments/assets/0df44ba4-5047-458f-ad8c-c44b864fd25b" />

<img width="1894" height="1310" alt="image" src="https://github.com/user-attachments/assets/a28a5ba2-11a4-41cf-a715-82aa1476efa7" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->


