### PR TITLE
[SM-180] fix: 페이지별 OG 메타 머지 누락 수정

### DIFF
--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -3,7 +3,14 @@ import { Suspense } from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { fetchGatheringDetail } from '@/api/gatherings';
 import { JsonLd } from '@/components/seo/JsonLd';
-import { OG_IMAGES, SITE_DESCRIPTION, SITE_NAME, TWITTER_IMAGE_PATH, buildGatheringEventJsonLd } from '@/lib/seo';
+import {
+  OG_IMAGES,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  TWITTER_IMAGE_PATH,
+  buildGatheringEventJsonLd,
+  getDefaultOpenGraph,
+} from '@/lib/seo';
 import { GatheringHero } from './_components/GatheringHero';
 import { GatheringDetailContainer } from './_components/GatheringDetailContainer';
 import { GatheringDetailSkeleton } from './_components/GatheringDetailSkeleton';
@@ -42,6 +49,7 @@ export const generateMetadata = async ({ params }: GatheringDetailPageProps): Pr
       description,
       alternates: { canonical },
       openGraph: {
+        ...getDefaultOpenGraph(),
         type: 'article',
         url: canonical,
         title: ogTitle,

--- a/src/app/gatherings/page.tsx
+++ b/src/app/gatherings/page.tsx
@@ -3,6 +3,7 @@ import { GatheringListSkeleton } from '@/components/Search/GatheringList/Skeleto
 import { SearchForm } from '@/components/Search/SearchForm';
 import { SearchHero } from '@/components/Search/SearchHero';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+import { getDefaultOpenGraph } from '@/lib/seo';
 
 import type { Metadata } from 'next';
 
@@ -11,7 +12,11 @@ export const metadata: Metadata = {
   description:
     '카테고리·키워드로 스터디와 프로젝트 모임을 찾아보세요. 완성도에서 함께할 팀원을 만나 끝까지 완주하세요.',
   alternates: { canonical: '/gatherings' },
-  openGraph: { url: '/gatherings', title: '모임 검색 | 완성도' },
+  openGraph: {
+    ...getDefaultOpenGraph(),
+    url: '/gatherings',
+    title: '모임 검색 | 완성도',
+  },
 };
 
 export default function GatheringsPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,11 +13,10 @@ import {
   SITE_TITLE_DEFAULT,
   SITE_DESCRIPTION,
   SITE_KEYWORDS,
-  SITE_LOCALE,
-  OG_IMAGES,
   TWITTER_IMAGE_PATH,
   buildOrganizationJsonLd,
   buildWebSiteJsonLd,
+  getDefaultOpenGraph,
   getSiteUrl,
 } from '@/lib/seo';
 
@@ -38,13 +37,8 @@ export const generateMetadata = async (): Promise<Metadata> => {
       canonical: '/',
     },
     openGraph: {
-      type: 'website',
-      locale: SITE_LOCALE,
-      siteName: SITE_NAME,
+      ...getDefaultOpenGraph(),
       url: '/',
-      title: SITE_TITLE_DEFAULT,
-      description: SITE_DESCRIPTION,
-      images: OG_IMAGES.map((img) => ({ ...img })),
     },
     twitter: {
       card: 'summary_large_image',

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -2,6 +2,7 @@ import { HeroSection } from './components/HeroSection';
 import { MyGatheringSection } from './components/MyGatheringSection';
 import { MainGatheringContainer } from './components/MainGatheringContainer';
 import { MainGatheringStreaming } from './components/MainGatheringStreaming';
+import { getDefaultOpenGraph } from '@/lib/seo';
 
 import type { Metadata } from 'next';
 
@@ -10,7 +11,11 @@ export const metadata: Metadata = {
   description:
     '인기·마감임박·최신 스터디와 프로젝트 모임을 한눈에. 완성도에서 관심사 맞는 팀원을 찾아 함께 완주하세요.',
   alternates: { canonical: '/main' },
-  openGraph: { url: '/main', title: '추천 모임 | 완성도' },
+  openGraph: {
+    ...getDefaultOpenGraph(),
+    url: '/main',
+    title: '추천 모임 | 완성도',
+  },
 };
 
 export const revalidate = 3600;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,18 @@ import { LandingFinalCta } from '@/components/landing/LandingFinalCta';
 import { LandingHero } from '@/components/landing/LandingHero';
 import { LandingHowToUse } from '@/components/landing/LandingHowToUse';
 
+import { getDefaultOpenGraph } from '@/lib/seo';
+
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: '함께 완주하는 스터디·프로젝트 모임',
   alternates: { canonical: '/' },
-  openGraph: { url: '/' },
+  openGraph: {
+    ...getDefaultOpenGraph(),
+    url: '/',
+    title: '함께 완주하는 스터디·프로젝트 모임 | 완성도',
+  },
 };
 
 export default function Home() {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -34,6 +34,21 @@ export const OG_IMAGES = [
 /** Twitter Card는 단일 이미지만 지원 → 1200×630 기본을 사용. */
 export const TWITTER_IMAGE_PATH = '/og/og-default.png';
 
+/**
+ * 기본 openGraph 객체. Next.js Metadata API는 openGraph를 객체 단위로 통째
+ * 교체하므로(shallow merge가 아님), 페이지별로 openGraph를 override할 때
+ * 반드시 이 헬퍼를 spread해서 누락된 필드를 채워야 한다.
+ * 함수로 둔 이유: 호출마다 새 객체를 반환해 mutable share를 피하기 위함.
+ */
+export const getDefaultOpenGraph = () => ({
+  type: 'website' as const,
+  locale: SITE_LOCALE,
+  siteName: SITE_NAME,
+  title: SITE_TITLE_DEFAULT,
+  description: SITE_DESCRIPTION,
+  images: OG_IMAGES.map((img) => ({ ...img })),
+});
+
 export const getSiteUrl = (): string => {
   const explicit = process.env.NEXT_PUBLIC_APP_URL;
   if (explicit) return explicit.replace(/\/+$/, '');


### PR DESCRIPTION
## ❓ 이슈

- close #297 

## ✍️ Description

- SM-179 머지 후 카카오 공유 디버거에서`og:image`·`og:type`·`og:site_name`·`og:locale` 4개 필드가 빈 값으로 표시되는 문제 발견. `twitter:image`는 정상.

  ### 원인

- Next.js Metadata API는 `openGraph` 객체 필드를 **shallow merge가 아니라 객체 단위 통째 교체**로 머지함. 페이지에서 `openGraph: { url: '/main' }` 같이 부분 명시를 하면 layout에 정의된 나머지 필드(type, locale, siteName, images)가 모두 누락됨. `twitter`는 페이지에서 override하지 않아 상속되어 정상 동작했던

  ```ts
  openGraph: {
    ...getDefaultOpenGraph(),
    url: '/main',
    title: '추천 모임 | 완성도',
  }

- 적용 페이지: layout.tsx, /, /main, /gatherings, /gatherings/[id] 5개.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- PR preview URL에서 카카오 디버거 캐시 초기화 후 재테스트
- 머지 후 dev preview에서 한 번 더 확인
- production 배포 직후 카카오 디버거로 production 도메인 OG 캐시 선점