### PR TITLE
[SM-181] refactor: 카테고리 하드코딩 제거 및 동적 API 전환

### DIFF
--- a/src/api/gatherings/index.ts
+++ b/src/api/gatherings/index.ts
@@ -47,8 +47,11 @@ const normalizeDetail = (detail: GatheringDetail): GatheringDetail => normalizeG
 export const GATHERING_TAGS = {
   all: 'gatherings',
   main: 'gatherings-main',
+  categories: 'gatherings-categories',
   detail: (gatheringId: number) => `gatherings-detail-${gatheringId}`,
 } as const;
+
+const CATEGORIES_REVALIDATE_SECONDS = 3600;
 
 const getBaseUrl = () => {
   if (typeof window !== 'undefined') {
@@ -59,10 +62,24 @@ const getBaseUrl = () => {
   return baseUrl.replace(/\/+$/, '');
 };
 
-/** GET /v1/gatherings/categories — 카테고리 목록 조회 */
+/** GET /v1/gatherings/categories — 카테고리 목록 조회 (클라이언트 전용) */
 export const getCategories = async (): Promise<GetCategoriesResponse> => {
   const { data } = await axiosClient.get<ApiResponse<GetCategoriesResponse>>('/v1/gatherings/categories');
   return unwrapResponse(data);
+};
+
+/** GET /v1/gatherings/categories — 카테고리 목록 조회 (서버 전용, ISR 캐싱) */
+export const fetchCategories = async (): Promise<GetCategoriesResponse> => {
+  const res = await fetch(`${getBaseUrl()}/v1/gatherings/categories`, {
+    next: {
+      tags: [GATHERING_TAGS.all, GATHERING_TAGS.categories],
+      revalidate: CATEGORIES_REVALIDATE_SECONDS,
+    },
+  });
+
+  if (!res.ok) throw new Error(`gatherings/categories fetch failed: ${res.status}`);
+  const json: ApiResponse<GetCategoriesResponse> = await res.json();
+  return unwrapResponse(json);
 };
 
 /**

--- a/src/api/gatherings/queries.ts
+++ b/src/api/gatherings/queries.ts
@@ -3,6 +3,7 @@ import { queryOptions, useMutation, useQueryClient, isServer } from '@tanstack/r
 import { invalidateServerCache } from '@/lib/invalidateServerCache';
 import {
   getCategories,
+  fetchCategories,
   getApplicationStatus,
   fetchMainGatherings,
   fetchGatheringDetail,
@@ -39,7 +40,7 @@ export const gatheringQueries = {
   categories: () =>
     queryOptions({
       queryKey: gatheringKeys.categories(),
-      queryFn: () => getCategories(),
+      queryFn: () => (isServer ? fetchCategories() : getCategories()),
       staleTime: Infinity,
     }),
 

--- a/src/app/gatherings/[id]/edit/_components/EditGatheringContent.test.tsx
+++ b/src/app/gatherings/[id]/edit/_components/EditGatheringContent.test.tsx
@@ -1,0 +1,97 @@
+import { toFormValues } from './EditGatheringContent';
+
+import type { GatheringDetail } from '@/api/gatherings/types';
+
+const buildDetail = (overrides: Partial<GatheringDetail> = {}): GatheringDetail => ({
+  id: 1,
+  type: '스터디',
+  categories: ['개발', '디자인'],
+  title: '테스트 모임',
+  shortDescription: '한 줄 소개',
+  tags: ['React', 'TypeScript'],
+  maxMembers: 5,
+  currentMembers: 2,
+  recruitDeadline: '2026-06-01',
+  startDate: '2026-06-10',
+  endDate: '2026-07-10',
+  status: 'RECRUITING',
+  leader: { id: 1, nickname: 'leader', profileImage: null },
+  description: '상세 설명',
+  goal: '목표',
+  totalWeeks: 4,
+  images: [],
+  weeklyPlans: [
+    { week: 1, title: '주차 1', startDate: '2026-06-10', endDate: '2026-06-16', details: ['할 일 1', '할 일 2'] },
+    { week: 2, title: '주차 2', startDate: '2026-06-17', endDate: '2026-06-23' },
+  ],
+  members: [],
+  myApplicationStatus: null,
+  ...overrides,
+});
+
+describe('toFormValues (name→id 역매핑)', () => {
+  const nameToId: Record<string, number> = {
+    개발: 7,
+    어학: 8,
+    독서: 9,
+    자격증: 10,
+    디자인: 11,
+  };
+
+  it('detail.categories(이름 배열)를 categoryIds(숫자 배열)로 정확히 역매핑한다', () => {
+    const detail = buildDetail({ categories: ['개발', '디자인'] });
+    const result = toFormValues(detail, nameToId);
+
+    expect(result.categoryIds).toEqual([7, 11]);
+  });
+
+  it('nameToId 맵에 없는 이름은 필터링되어 categoryIds에서 제외된다', () => {
+    const detail = buildDetail({ categories: ['개발', '알수없음', '어학'] });
+    const result = toFormValues(detail, nameToId);
+
+    expect(result.categoryIds).toEqual([7, 8]);
+  });
+
+  it('빈 categories는 빈 categoryIds로 매핑된다', () => {
+    const detail = buildDetail({ categories: [] });
+    const result = toFormValues(detail, nameToId);
+
+    expect(result.categoryIds).toEqual([]);
+  });
+
+  it('백엔드 카테고리 id가 변경되어도 nameToId 맵 기준으로 정확히 복원된다', () => {
+    const newNameToId: Record<string, number> = {
+      개발: 101,
+      어학: 102,
+      독서: 103,
+      자격증: 104,
+      디자인: 105,
+    };
+    const detail = buildDetail({ categories: ['독서', '자격증'] });
+    const result = toFormValues(detail, newNameToId);
+
+    expect(result.categoryIds).toEqual([103, 104]);
+  });
+
+  it('상세 정보의 나머지 필드(type, title, weeklyGuides 등)를 GatheringForm 형태로 변환한다', () => {
+    const detail = buildDetail();
+    const result = toFormValues(detail, nameToId);
+
+    expect(result).toMatchObject({
+      type: '스터디',
+      title: '테스트 모임',
+      shortDescription: '한 줄 소개',
+      description: '상세 설명',
+      tags: ['React', 'TypeScript'],
+      goal: '목표',
+      maxMembers: 5,
+      recruitDeadline: '2026-06-01',
+      startDate: '2026-06-10',
+      endDate: '2026-07-10',
+    });
+    expect(result.weeklyGuides).toEqual([
+      { week: 1, title: '주차 1', details: ['할 일 1', '할 일 2'] },
+      { week: 2, title: '주차 2', details: [] },
+    ]);
+  });
+});

--- a/src/app/gatherings/[id]/edit/_components/EditGatheringContent.tsx
+++ b/src/app/gatherings/[id]/edit/_components/EditGatheringContent.tsx
@@ -1,18 +1,16 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useSuspenseQueries } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
-import { DEFAULT_CATEGORIES } from '@/constants/gathering';
 import { CreateGatheringForm } from '@/app/gatherings/new/CreateGatheringForm';
 
-import type { GatheringDetail, GatheringForm } from '@/api/gatherings/types';
+import type { Category, GatheringDetail, GatheringForm } from '@/api/gatherings/types';
 
-const CATEGORY_NAME_TO_ID = Object.fromEntries(DEFAULT_CATEGORIES.map((c) => [c.name, c.id])) as Record<string, number>;
-
-const toFormValues = (detail: GatheringDetail): Partial<GatheringForm> => ({
+export const toFormValues = (detail: GatheringDetail, nameToId: Record<string, number>): Partial<GatheringForm> => ({
   type: detail.type,
-  categoryIds: detail.categories.map((name) => CATEGORY_NAME_TO_ID[name]).filter(Boolean),
+  categoryIds: detail.categories.map((name) => nameToId[name]).filter((id): id is number => typeof id === 'number'),
   title: detail.title,
   shortDescription: detail.shortDescription,
   description: detail.description,
@@ -34,7 +32,16 @@ interface EditGatheringContentProps {
 }
 
 export function EditGatheringContent({ gatheringId }: EditGatheringContentProps) {
-  const { data } = useSuspenseQuery(gatheringQueries.detail(gatheringId));
+  const [{ data: detail }, { data: categoriesData }] = useSuspenseQueries({
+    queries: [gatheringQueries.detail(gatheringId), gatheringQueries.categories()],
+  });
 
-  return <CreateGatheringForm mode='edit' gatheringId={gatheringId} initialValues={toFormValues(data)} />;
+  const nameToId = useMemo(
+    () => Object.fromEntries(categoriesData.categories.map((c: Category) => [c.name, c.id])) as Record<string, number>,
+    [categoriesData.categories],
+  );
+
+  const initialValues = useMemo(() => toFormValues(detail, nameToId), [detail, nameToId]);
+
+  return <CreateGatheringForm mode='edit' gatheringId={gatheringId} initialValues={initialValues} />;
 }

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { differenceInDays, isValid, parseISO } from 'date-fns';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -16,9 +17,9 @@ import { useDropdown } from '@/components/ui/Dropdown/context';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
-import { useCreateGathering, useUpdateGathering } from '@/api/gatherings/queries';
+import { gatheringQueries, useCreateGathering, useUpdateGathering } from '@/api/gatherings/queries';
 import { gatheringFormSchema } from '@/api/gatherings/schemas';
-import { DEFAULT_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
+import { GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 
 import { ImageUpload } from './ImageUpload';
@@ -61,11 +62,6 @@ const TYPE_META = {
   프로젝트: { label: '프로젝트', subtitle: '함께 만들고 완성해요', Icon: ProjectIcon },
 } as const;
 
-const CATEGORY_META = Object.fromEntries(DEFAULT_CATEGORIES.map((c) => [c.id, { label: c.name }])) as Record<
-  number,
-  { label: string }
->;
-
 interface CreateGatheringFormProps {
   mode?: 'create' | 'edit';
   gatheringId?: number;
@@ -76,6 +72,13 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   const router = useRouter();
   const showToast = useToastStore((state) => state.showToast);
   const isEditMode = mode === 'edit';
+
+  const { data: categoriesData } = useSuspenseQuery(gatheringQueries.categories());
+  const categories = categoriesData.categories;
+  const categoryMeta = useMemo(
+    () => Object.fromEntries(categories.map((c) => [c.id, { label: c.name }])) as Record<number, { label: string }>,
+    [categories],
+  );
 
   const {
     register,
@@ -251,7 +254,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
             render={({ field }) => {
               const selected = field.value ?? [];
               const selectedLabel =
-                selected.length > 0 ? selected.map((id) => CATEGORY_META[id]?.label).join(', ') : null;
+                selected.length > 0 ? selected.map((id) => categoryMeta[id]?.label).join(', ') : null;
 
               const MAX_CATEGORIES = 3;
 
@@ -278,7 +281,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                                 카테고리({selected.length})
                               </span>
                               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-900'>
-                                {selected.map((id) => CATEGORY_META[id]?.label).join(', ')}
+                                {selected.map((id) => categoryMeta[id]?.label).join(', ')}
                               </span>
                             </div>
                           ) : (
@@ -294,11 +297,11 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                       containerClassName='w-full'
                       className='custom-scrollbar max-h-[240px] w-full overflow-y-auto rounded-lg border border-blue-100 bg-white p-2'
                     >
-                      {DEFAULT_CATEGORIES.map((cat) => (
+                      {categories.map((cat) => (
                         <Dropdown.Item
                           key={cat.id}
                           closeOnSelect={false}
-                          disabled={selected.length >= 3 && !selected.includes(cat.id)}
+                          disabled={selected.length >= MAX_CATEGORIES && !selected.includes(cat.id)}
                           onClick={() => toggleCategory(cat.id)}
                           className={cn(
                             'text-small-02-m md:text-body-02-m lg:text-body-01-m flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-gray-700 hover:bg-blue-100 hover:text-blue-400',

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -1,3 +1,5 @@
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+
 import { CreateGatheringForm } from './CreateGatheringForm';
 
 import type { Metadata } from 'next';
@@ -11,7 +13,21 @@ export default function CreateGatheringPage() {
   return (
     <main className='mx-auto max-w-[1680px] px-5 pt-20 pb-40'>
       <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
-      <CreateGatheringForm />
+      <SuspenseBoundary
+        pendingFallback={
+          <div className='flex flex-col gap-8'>
+            <div className='bg-gray-150 h-40 animate-pulse rounded-lg' />
+            <div className='bg-gray-150 h-60 animate-pulse rounded-lg' />
+          </div>
+        }
+        errorFallback={
+          <div className='rounded-lg border border-gray-200 bg-gray-50 px-4 py-6'>
+            <p className='text-body-02-r text-gray-500'>모임 만들기 정보를 불러올 수 없습니다</p>
+          </div>
+        }
+      >
+        <CreateGatheringForm />
+      </SuspenseBoundary>
     </main>
   );
 }

--- a/src/app/gatherings/page.tsx
+++ b/src/app/gatherings/page.tsx
@@ -1,8 +1,12 @@
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { GatheringList } from '@/components/Search/GatheringList';
 import { GatheringListSkeleton } from '@/components/Search/GatheringList/Skeleton';
 import { SearchForm } from '@/components/Search/SearchForm';
 import { SearchHero } from '@/components/Search/SearchHero';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
+import { getQueryClient } from '@/lib/getQueryClient';
 import { getDefaultOpenGraph } from '@/lib/seo';
 
 import type { Metadata } from 'next';
@@ -19,22 +23,30 @@ export const metadata: Metadata = {
   },
 };
 
-export default function GatheringsPage() {
+export const revalidate = 3600;
+
+export default async function GatheringsPage() {
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery(gatheringQueries.categories());
+
   return (
     <main className='min-h-screen'>
-      <SearchHero>
-        <SearchForm />
-      </SearchHero>
-      <section className='mx-auto flex max-w-[1680px] flex-col gap-12 px-4 py-10 md:px-7 md:py-15 xl:py-20'>
-        <SuspenseBoundary
-          pendingFallback={<GatheringListSkeleton />}
-          errorFallback={
-            <p className='text-body-02-r py-20 text-center text-gray-500'>데이터를 불러오는데 실패했습니다.</p>
-          }
-        >
-          <GatheringList />
-        </SuspenseBoundary>
-      </section>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <SearchHero>
+          <SearchForm />
+        </SearchHero>
+        <section className='mx-auto flex max-w-[1680px] flex-col gap-12 px-4 py-10 md:px-7 md:py-15 xl:py-20'>
+          <SuspenseBoundary
+            pendingFallback={<GatheringListSkeleton />}
+            errorFallback={
+              <p className='text-body-02-r py-20 text-center text-gray-500'>데이터를 불러오는데 실패했습니다.</p>
+            }
+          >
+            <GatheringList />
+          </SuspenseBoundary>
+        </section>
+      </HydrationBoundary>
     </main>
   );
 }

--- a/src/components/ErrorFallback/index.test.tsx
+++ b/src/components/ErrorFallback/index.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ErrorFallback } from '.';
+
+describe('ErrorFallback', () => {
+  describe('렌더링', () => {
+    it('전달된 에러 메시지를 렌더링한다', () => {
+      render(<ErrorFallback message='카테고리를 불러올 수 없습니다.' onRetry={() => {}} />);
+
+      expect(screen.getByText('카테고리를 불러올 수 없습니다.')).toBeInTheDocument();
+    });
+
+    it('기본 재시도 버튼 라벨로 "다시 시도"를 렌더링한다', () => {
+      render(<ErrorFallback message='에러' onRetry={() => {}} />);
+
+      expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument();
+    });
+
+    it('retryLabel을 지정하면 해당 라벨을 사용한다', () => {
+      render(<ErrorFallback message='에러' onRetry={() => {}} retryLabel='새로고침' />);
+
+      expect(screen.getByRole('button', { name: '새로고침' })).toBeInTheDocument();
+    });
+
+    it('role=alert를 부여해 보조 기술이 인지할 수 있도록 한다', () => {
+      render(<ErrorFallback message='에러' onRetry={() => {}} />);
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('className prop을 컨테이너에 병합한다', () => {
+      render(<ErrorFallback message='에러' onRetry={() => {}} className='custom-cls' />);
+
+      expect(screen.getByRole('alert')).toHaveClass('custom-cls');
+    });
+  });
+
+  describe('resetErrorBoundary 연동', () => {
+    it('재시도 버튼 클릭 시 onRetry 콜백을 호출한다', async () => {
+      const user = userEvent.setup();
+      const handleRetry = jest.fn();
+
+      render(<ErrorFallback message='에러' onRetry={handleRetry} />);
+
+      await user.click(screen.getByRole('button', { name: '다시 시도' }));
+
+      expect(handleRetry).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/ErrorFallback/index.tsx
+++ b/src/components/ErrorFallback/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { cn } from '@/lib/cn';
+
+interface ErrorFallbackProps {
+  /** 표시할 에러 메시지. */
+  message: string;
+  /** 재시도 버튼 클릭 시 호출되는 콜백 — `ErrorBoundary`의 `resetErrorBoundary` 함수를 연결한다. */
+  onRetry: () => void;
+  /** 재시도 버튼 라벨. 기본값 `'다시 시도'`. */
+  retryLabel?: string;
+  /** 외부 컨테이너 추가 클래스. 카테고리 필터 셀처럼 인라인 가로 배치가 필요할 때 사용. */
+  className?: string;
+}
+
+/**
+ * API 실패 시 표시하는 공통 에러 fallback UI.
+ * 에러 메시지 + 재시도 버튼으로 구성되며 `ErrorBoundary`의 reset 함수를 `onRetry`로 연결해 사용한다.
+ *
+ * @example
+ * <ErrorBoundary
+ *   fallback={(_, reset) => (
+ *     <ErrorFallback message='카테고리를 불러올 수 없습니다.' onRetry={reset} />
+ *   )}
+ * >
+ *   <CategoryMultiSelectContainer />
+ * </ErrorBoundary>
+ */
+export function ErrorFallback({ message, onRetry, retryLabel = '다시 시도', className }: ErrorFallbackProps) {
+  return (
+    <div role='alert' className={cn('flex flex-1 items-center justify-between px-5 py-4 md:px-7 md:py-5', className)}>
+      <p className='text-small-01-r md:text-body-01-r text-gray-500'>{message}</p>
+      <button type='button' onClick={onRetry} className='text-small-02-r text-blue-500 underline'>
+        {retryLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Search/SearchForm/ActiveFilters.tsx
+++ b/src/components/Search/SearchForm/ActiveFilters.tsx
@@ -1,14 +1,23 @@
 'use client';
 
-import { startTransition } from 'react';
+import { startTransition, useMemo } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { ReplayIcon } from '@/components/ui/Icon/ReplayIcon';
 import { Tag } from '@/components/ui/Tag';
-import { DEFAULT_CATEGORIES } from '@/constants/gathering';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
 
 export function ActiveFilters() {
   const { query, type, categoryIds, setParams } = useGatheringSearchParams();
+  const { data } = useQuery(gatheringQueries.categories());
+
+  const categoryNameById = useMemo<Map<number, string>>(() => {
+    const map = new Map<number, string>();
+    data?.categories.forEach((c) => map.set(c.id, c.name));
+    return map;
+  }, [data]);
 
   const hasActiveFilters = query !== '' || type !== null || categoryIds.length > 0;
   if (!hasActiveFilters) return null;
@@ -51,7 +60,7 @@ export function ActiveFilters() {
       )}
       {categoryIds.map((id) => (
         <Tag key={id} variant='filter' onRemove={() => handleRemoveCategory(id)}>
-          {DEFAULT_CATEGORIES.find((c) => c.id === id)?.name ?? id}
+          {categoryNameById.get(id) ?? id}
         </Tag>
       ))}
       <button

--- a/src/components/Search/SearchForm/CategoryFilterSection/Skeleton.tsx
+++ b/src/components/Search/SearchForm/CategoryFilterSection/Skeleton.tsx
@@ -1,0 +1,8 @@
+export function CategoryDropdownSkeleton() {
+  return (
+    <div className='flex flex-1 items-center justify-between px-5 py-4 md:px-7 md:py-5'>
+      <div className='h-5 w-32 animate-pulse rounded bg-gray-200 md:h-6 md:w-40' />
+      <div className='h-4 w-4 animate-pulse rounded bg-gray-200 md:h-6 md:w-6' />
+    </div>
+  );
+}

--- a/src/components/Search/SearchForm/CategoryFilterSection/index.test.tsx
+++ b/src/components/Search/SearchForm/CategoryFilterSection/index.test.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+
+import { gatheringKeys, gatheringQueries } from '@/api/gatherings/queries';
+import { server } from '@/mocks/server';
+
+import { CategoryFilterSection } from '.';
+
+import type { GetCategoriesResponse } from '@/api/gatherings/types';
+
+const MOCK_CATEGORIES: GetCategoriesResponse = {
+  categories: [
+    { id: 7, name: '개발' },
+    { id: 8, name: '어학' },
+    { id: 9, name: '독서' },
+    { id: 10, name: '자격증' },
+    { id: 11, name: '디자인' },
+  ],
+};
+
+interface RenderOptions {
+  prefetched?: GetCategoriesResponse;
+}
+
+const renderWithQueryClient = (ui: ReactNode, { prefetched }: RenderOptions = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: Infinity } },
+  });
+
+  if (prefetched) {
+    queryClient.setQueryData(gatheringQueries.categories().queryKey, prefetched);
+  }
+
+  const result = render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return { ...result, queryClient };
+};
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation();
+  jest.spyOn(console, 'group').mockImplementation();
+  jest.spyOn(console, 'groupEnd').mockImplementation();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('CategoryFilterSection (카테고리 ErrorBoundary 동작)', () => {
+  describe('정상 동작', () => {
+    it('prefetch된 카테고리가 있으면 멀티셀렉트 placeholder를 렌더링한다', () => {
+      renderWithQueryClient(<CategoryFilterSection selectedValues={[]} onChange={() => {}} />, {
+        prefetched: MOCK_CATEGORIES,
+      });
+
+      expect(screen.getByText('카테고리를 선택해주세요')).toBeInTheDocument();
+      expect(screen.queryByText('카테고리를 불러올 수 없습니다.')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('에러 격리', () => {
+    it('카테고리 API 실패 시 fallback을 렌더링하고 외부 영역에는 영향을 주지 않는다', async () => {
+      server.use(
+        http.get('*/v1/gatherings/categories', () =>
+          HttpResponse.json({ success: false, data: null, message: '서버 오류' }, { status: 500 }),
+        ),
+      );
+
+      renderWithQueryClient(
+        <div>
+          <div>키워드 필터 영역</div>
+          <CategoryFilterSection selectedValues={[]} onChange={() => {}} />
+          <div>타입 필터 영역</div>
+        </div>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('카테고리를 불러올 수 없습니다.')).toBeInTheDocument();
+      });
+
+      // 카테고리 섹션 내부의 ErrorBoundary가 에러를 잡아 외부 영역으로 전파되지 않는다
+      expect(screen.getByText('키워드 필터 영역')).toBeInTheDocument();
+      expect(screen.getByText('타입 필터 영역')).toBeInTheDocument();
+      expect(screen.queryByText('카테고리를 선택해주세요')).not.toBeInTheDocument();
+    });
+
+    it('에러 fallback에 다시 시도 버튼이 노출된다', async () => {
+      server.use(
+        http.get('*/v1/gatherings/categories', () =>
+          HttpResponse.json({ success: false, data: null, message: '서버 오류' }, { status: 500 }),
+        ),
+      );
+
+      renderWithQueryClient(<CategoryFilterSection selectedValues={[]} onChange={() => {}} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument();
+      });
+    });
+
+    it('다시 시도 버튼 클릭 시 카테고리 쿼리 캐시를 reset하여 refetch와 ErrorBoundary 리셋이 함께 일어난다', async () => {
+      server.use(
+        http.get('*/v1/gatherings/categories', () =>
+          HttpResponse.json({ success: false, data: null, message: '서버 오류' }, { status: 500 }),
+        ),
+      );
+
+      const user = userEvent.setup();
+
+      const { queryClient } = renderWithQueryClient(<CategoryFilterSection selectedValues={[]} onChange={() => {}} />);
+      const resetQueriesSpy = jest.spyOn(queryClient, 'resetQueries');
+
+      // 첫 fetch 실패로 fallback 노출까지 대기
+      const retryButton = await screen.findByRole('button', { name: '다시 시도' });
+
+      await user.click(retryButton);
+
+      // ErrorBoundary의 onReset이 호출되어 카테고리 쿼리 캐시를 resetQueries로 초기화한다.
+      // resetQueries는 활성 observer가 있으면 자동으로 refetch를 트리거하므로,
+      // 이 호출 하나로 "refetch + ErrorBoundary 리셋"이 모두 연결된다.
+      expect(resetQueriesSpy).toHaveBeenCalledWith({ queryKey: gatheringKeys.categories() });
+    });
+  });
+});

--- a/src/components/Search/SearchForm/CategoryFilterSection/index.tsx
+++ b/src/components/Search/SearchForm/CategoryFilterSection/index.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { gatheringKeys, gatheringQueries } from '@/api/gatherings/queries';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { ErrorFallback } from '@/components/ErrorFallback';
+import { CategoryIcon } from '@/components/ui/Icon/CategoryIcon';
+
+import { CategoryMultiSelect } from '../CategoryMultiSelect';
+
+interface CategoryFilterSectionProps {
+  selectedValues: number[];
+  onChange: (values: number[]) => void;
+}
+
+function CategoryMultiSelectContainer({ selectedValues, onChange }: CategoryFilterSectionProps) {
+  const { data, error } = useQuery(gatheringQueries.categories());
+
+  const categoryItems = useMemo(() => data?.categories.map((c) => ({ label: c.name, value: c.id })) ?? [], [data]);
+
+  if (error) throw error;
+  if (!data) throw new Error('카테고리 목록을 불러올 수 없습니다.');
+
+  return (
+    <CategoryMultiSelect
+      icon={<CategoryIcon size={20} className='shrink-0 text-gray-800 md:size-7' />}
+      placeholder='카테고리를 선택해주세요'
+      selectedValues={selectedValues}
+      items={categoryItems}
+      onChange={onChange}
+    />
+  );
+}
+
+export function CategoryFilterSection({ selectedValues, onChange }: CategoryFilterSectionProps) {
+  const queryClient = useQueryClient();
+
+  const handleReset = () => {
+    // 캐시에 남아 있는 실패 상태를 초기화해 ErrorBoundary 리셋과 함께 카테고리 쿼리를 다시 페칭한다.
+    queryClient.resetQueries({ queryKey: gatheringKeys.categories() });
+  };
+
+  return (
+    <ErrorBoundary
+      onReset={handleReset}
+      fallback={(_, reset) => <ErrorFallback message='카테고리를 불러올 수 없습니다.' onRetry={reset} />}
+    >
+      <CategoryMultiSelectContainer selectedValues={selectedValues} onChange={onChange} />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/Search/SearchForm/CategoryFilterSection/index.tsx
+++ b/src/components/Search/SearchForm/CategoryFilterSection/index.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringKeys, gatheringQueries } from '@/api/gatherings/queries';
-import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { ErrorFallback } from '@/components/ErrorFallback';
+import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { CategoryIcon } from '@/components/ui/Icon/CategoryIcon';
 
 import { CategoryMultiSelect } from '../CategoryMultiSelect';
+import { CategoryDropdownSkeleton } from './Skeleton';
 
 interface CategoryFilterSectionProps {
   selectedValues: number[];
@@ -16,12 +17,9 @@ interface CategoryFilterSectionProps {
 }
 
 function CategoryMultiSelectContainer({ selectedValues, onChange }: CategoryFilterSectionProps) {
-  const { data, error } = useQuery(gatheringQueries.categories());
+  const { data } = useSuspenseQuery(gatheringQueries.categories());
 
-  const categoryItems = useMemo(() => data?.categories.map((c) => ({ label: c.name, value: c.id })) ?? [], [data]);
-
-  if (error) throw error;
-  if (!data) throw new Error('카테고리 목록을 불러올 수 없습니다.');
+  const categoryItems = useMemo(() => data.categories.map((c) => ({ label: c.name, value: c.id })), [data]);
 
   return (
     <CategoryMultiSelect
@@ -43,11 +41,12 @@ export function CategoryFilterSection({ selectedValues, onChange }: CategoryFilt
   };
 
   return (
-    <ErrorBoundary
+    <SuspenseBoundary
       onReset={handleReset}
-      fallback={(_, reset) => <ErrorFallback message='카테고리를 불러올 수 없습니다.' onRetry={reset} />}
+      pendingFallback={<CategoryDropdownSkeleton />}
+      errorFallback={(_, reset) => <ErrorFallback message='카테고리를 불러올 수 없습니다.' onRetry={reset} />}
     >
       <CategoryMultiSelectContainer selectedValues={selectedValues} onChange={onChange} />
-    </ErrorBoundary>
+    </SuspenseBoundary>
   );
 }

--- a/src/components/Search/SearchForm/index.tsx
+++ b/src/components/Search/SearchForm/index.tsx
@@ -3,18 +3,16 @@
 import { startTransition, useState } from 'react';
 
 import { Button } from '@/components/ui/Button';
-import { CategoryIcon } from '@/components/ui/Icon/CategoryIcon';
 import { TypeIcon } from '@/components/ui/Icon/TypeIcon';
-import { DEFAULT_CATEGORIES, GATHERING_TYPES } from '@/constants/gathering';
+import { GATHERING_TYPES } from '@/constants/gathering';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
 
 import { ActiveFilters } from './ActiveFilters';
-import { CategoryMultiSelect } from './CategoryMultiSelect';
+import { CategoryFilterSection } from './CategoryFilterSection';
 import { FilterDropdown } from './FilterDropdown';
 import { SearchInput } from './SearchInput';
 
 const TYPE_ITEMS = [{ label: '전체', value: null }, ...GATHERING_TYPES.map((t) => ({ label: t, value: t }))] as const;
-const CATEGORY_ITEMS = DEFAULT_CATEGORIES.map((c) => ({ label: c.name, value: c.id }));
 
 export function SearchForm() {
   const { type, categoryIds, query, setParams } = useGatheringSearchParams();
@@ -68,13 +66,7 @@ export function SearchForm() {
 
           <div className='mx-5 border-t border-gray-200 md:mx-0 md:my-2 md:border-t-0 md:border-l' />
 
-          <CategoryMultiSelect
-            icon={<CategoryIcon size={20} className='shrink-0 text-gray-800 md:size-7' />}
-            placeholder='카테고리를 선택해주세요'
-            selectedValues={categoryIds}
-            items={CATEGORY_ITEMS}
-            onChange={handleCategoryChange}
-          />
+          <CategoryFilterSection selectedValues={categoryIds} onChange={handleCategoryChange} />
         </div>
 
         <Button variant={searchVariant} size='search' onClick={handleSearch} className='relative z-1 hidden xl:block'>

--- a/src/constants/gathering.ts
+++ b/src/constants/gathering.ts
@@ -13,11 +13,3 @@ export const GATHERING_STATUS_LABEL = {
   IN_PROGRESS: '진행중',
   COMPLETED: '진행완료',
 } as const;
-
-export const DEFAULT_CATEGORIES = [
-  { id: 7, name: '개발' },
-  { id: 8, name: '어학' },
-  { id: 9, name: '독서' },
-  { id: 10, name: '자격증' },
-  { id: 11, name: '디자인' },
-] as const;

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -66,6 +66,11 @@ export const authHandlers = [
     return new HttpResponse(null, { status: 200 });
   }),
 
+  /** POST /api/auth/refresh — 토큰 재발급 (axiosClient 인터셉터가 401/500 시 자동 호출) */
+  http.post('/api/auth/refresh', () =>
+    HttpResponse.json(createApiError('Unauthorized', 'UNAUTHORIZED'), { status: 401 }),
+  ),
+
   /** GET /api/v1/auth/check/email — 이메일 중복 확인 */
   http.get(`${BASE}/check/email`, async ({ request }) => {
     await delay(300);

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -5,8 +5,10 @@ import { getTotalWeeks } from '@/lib/formatGatheringDate';
 import { createApiResponse } from '../utils';
 
 import type {
+  Category,
   GatheringListItem,
   GatheringDetail,
+  GetCategoriesResponse,
   GetGatheringsResponse,
   GetMainGatheringsResponse,
   CreateGatheringResponse,
@@ -52,6 +54,15 @@ const PARAM_TO_TYPE: Record<string, GatheringType> = {
 };
 
 // ─── 목 데이터 ────────────────────────────────────────────────────────────────
+
+// 카테고리 목록 (GET /api/v1/gatherings/categories 응답)
+const MOCK_CATEGORIES: Category[] = [
+  { id: 7, name: '개발' },
+  { id: 8, name: '어학' },
+  { id: 9, name: '독서' },
+  { id: 10, name: '자격증' },
+  { id: 11, name: '디자인' },
+];
 
 // 카테고리: DEVELOPMENT, LANGUAGE, BOOK, CERTIFICATE / 유형: STUDY, PROJECT
 export const BASE_GATHERINGS: GatheringListItem[] = [
@@ -443,6 +454,12 @@ const paginate = (list: GatheringListItem[], url: URL) => {
 const BASE = '/api/v1/gatherings';
 
 export const gatheringsHandlers = [
+  /** GET /api/v1/gatherings/categories — 카테고리 목록 */
+  http.get(`${BASE}/categories`, async () => {
+    await delay(200);
+    return HttpResponse.json(createApiResponse<GetCategoriesResponse>({ categories: MOCK_CATEGORIES }));
+  }),
+
   /** GET /api/v1/gatherings/:gatheringId/application-status — 모임 신청 상태 */
   http.get(`${BASE}/:gatheringId/application-status`, async () => {
     await delay(200);


### PR DESCRIPTION
## ❓ 이슈

- close #299

## ✍️ Description

- `src/constants/gathering.ts`의 `DEFAULT_CATEGORIES` 하드코딩을 제거하고, 4개 소비처(검색 멀티셀렉트/활성 필터 칩/생성 폼 드롭다운/수정 페이지 역매핑)가 `GET /v1/gatherings/categories`를 동적 데이터 소스로 사용하도록 전환
- 백엔드가 카테고리를 추가/이름 변경해도 프론트 코드 수정 없이 반영되는 구조 확보
- 검색 페이지는 prefetch + `ErrorBoundary` 격리, 폼 페이지는 통합 Suspense boundary로 페이지 특성별 차별화된 페칭/에러 처리 전략 적용

### 주요 변경

**API 레이어 (`src/api/gatherings/`)**
- `fetchCategories` 신설 (서버 전용 `fetch` + `next.tags` + `revalidate: 3600`)
- `GATHERING_TAGS.categories` 태그 상수 추가
- `gatheringQueries.categories`의 `queryFn`을 `isServer ? fetchCategories() : getCategories()`로 분기

**MSW 핸들러**
- `GET /v1/gatherings/categories` 핸들러 신규(`src/mocks/handlers/gatherings.ts`)

**검색 페이지 (`/gatherings`)**
- `page.tsx`: `prefetchQuery` + `HydrationBoundary`
- `CategoryFilterSection` 신설: `CategoryMultiSelect` + `ActiveFilters`를 묶어 `ErrorBoundary`로 격리 — 카테고리 API 실패 시 키워드/타입 필터에는 영향 없음, 재시도 버튼으로 `resetQueries` 트리거
- `SearchForm` / `ActiveFilters`: `DEFAULT_CATEGORIES` import 제거 → 동적 `useQuery`로 전환

**생성 페이지 (`/gatherings/new`)**
- `SuspenseBoundary` 신규 + 폼 윤곽 Skeleton fallback
- `CreateGatheringForm`이 `useSuspenseQuery(gatheringQueries.categories())` 사용, `CATEGORY_META`는 인라인 `useMemo`로 생성

**수정 페이지 (`/gatherings/[id]/edit`)**
- `EditGatheringContent`가 `useSuspenseQueries`로 detail + categories 병렬 페칭 — 카테고리는 `CATEGORY_NAME_TO_ID` 역매핑에 필수 의존이므로 detail과 동일 boundary 통합 처리

**신규 공용 컴포넌트**
- `src/components/ErrorFallback/`: ErrorBoundary fallback prop으로 사용하는 **파생 데이터 처리 방침**
- `CATEGORY_META`, `CATEGORY_NAME_TO_ID`, 옵션 배열은 각 소비처 컴포넌트 내부 인라인 `useMemo`로 구성 (공유 훅/유틸 추출하지 않음 — 각 derived shape이 1곳에서만 쓰이므로 over-engineering 회피)

## 설계 결정 메모
- **검색 vs 폼 에러 처리 비대칭은 의도된 설계**: 검색 페이지에서 카테고리는 보조 필터(실패해도 키워드/타입은 동작해야 함) → 격리, 폼에서는 필수 입력 의존성(`initialValues` 계산용 `CATEGORY_NAME_TO_ID`, 드롭다운 옵션) → 통합 boundary로 fail-fast
- `.claude/rules/rendering.md`의 "prefetch 있음 → ErrorBoundary 필요" 규칙과 메인페이지 3개 섹션 패턴을 검색 페이지가 따름

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
