### PR TITLE
[SM-183] fix: axiosClient 500-as-refresh 분기 제거로 무한 리다이렉트 루프 해소

### DIFF
--- a/src/lib/axiosClient.ts
+++ b/src/lib/axiosClient.ts
@@ -7,13 +7,9 @@ const refreshClient = axios.create({
   withCredentials: true,
 });
 
-// TODO: 백엔드에서 인증 없는 요청에 401 통일 후 500 조건 제거
 const shouldAttemptRefresh = (error: unknown) => {
   if (!axios.isAxiosError(error)) return false;
-  const status = error.response?.status;
-  if (status === 401) return true;
-  if (status === 500 && !error.config?.headers?.Authorization) return true;
-  return false;
+  return error.response?.status === 401;
 };
 
 let refreshPromise: Promise<unknown> | null = null;


### PR DESCRIPTION
## ❓ 이슈

- close #304

## ✍️ Description

`axiosClient`의 `shouldAttemptRefresh`가 500 응답까지 인증 실패로 분류해 강제 토큰 갱신 흐름에 진입시키던 분기를 제거합니다.

**근본 원인**

```ts
// before
if (status === 500 && !error.config?.headers?.Authorization) return true;
```

- 클라이언트 axios는 `Authorization` 헤더를 직접 부착하지 않습니다. BFF가 `src/lib/serverFetch.ts:39`에서 쿠키의 accessToken을 꺼내 백엔드 호출에 부착합니다.
- 따라서 클라이언트 axios의 `error.config.headers.Authorization`은 사실상 항상 `undefined` → `!undefined === true` → **모든 500 응답이 refresh 트리거**를 충족했습니다.

**발생하던 무한 리다이렉트 루프**

1. 정상 로그인 상태에서 `/main` 등 인증 페이지의 API가 500 반환 (DB 오류, 일시 장애 등).
2. axios 인터셉터가 500을 인증 실패로 판단 → `/api/auth/refresh` 호출.
3. refresh도 5xx로 실패 → `axiosClient.ts`의 catch에서 `window.location.href = '/login'`.
4. **쿠키 미삭제**: httpOnly라 클라이언트가 못 지움. BFF refresh 라우트는 401/403일 때만 `clearAuthCookies` 호출.
5. 브라우저가 `/login` 진입.
6. `proxy.ts`: `isAuthRoute && hasAccessToken` 매치 → `/main`으로 즉시 redirect.
7. `/main` 다시 진입 → 같은 500 → step 2로 돌아가 무한 반복.

사용자 체감: 로그인 상태인데 주소창이 `/login ↔ /main` 사이를 깜빡이며 반복.

**변경 내용**

- `shouldAttemptRefresh`를 401 단일 분기로 단순화.
- 500 분기와 관련 TODO 주석을 영구 삭제 (누군가 되살릴 위험 차단).
- 403은 axiosClient에서 가로채지 않음 (인증은 됐지만 권한만 없음). 도메인 핸들러에서 처리.
- 결과: `/login ↔ /main` 무한 루프 해소. 500은 도메인별 `onError`에서 토스트 등으로 자연스럽게 노출.

## 📸 스크린샷 (UI 변경 시)

UI 변경 없음.

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`fix/SM-183`)
- [x] Base Branch 확인 (`dev`)
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`, 0 errors)

