### PR TITLE
[SM-184] fix: 모바일 모임 상세 찜 버튼 mutation 연결

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { applicationQueries } from '@/api/applications/queries';
+import { useLikeToggle } from '@/api/likes/hooks';
 import { getGatheringDisplayStatus, getJoinButtonText } from '@/lib/gatheringStatus';
 import { Button } from '@/components/ui/Button';
 import { HeartIcon } from '@/components/ui/Icon';
@@ -32,7 +31,7 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
   const hasPendingApplication =
     myApplications?.applications.some((app) => app.gathering.id === gatheringId && app.status === 'PENDING') ?? false;
   const isLeader = isLoggedIn && user?.id === data.leader.id;
-  const [isFavorite, setIsFavorite] = useState(false);
+  const { isLiked, isPending: isLikePending, toggleLike } = useLikeToggle(gatheringId);
   const overlay = useOverlay();
 
   const { isJoinable, isFinished, isFull, isDeadlinePassed } = getGatheringDisplayStatus(data);
@@ -46,21 +45,14 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
           <Button
             variant='bookmark'
             size='bookmark-lg'
-            data-selected={isFavorite}
+            data-selected={isLiked}
             aria-label='찜하기'
-            aria-pressed={isFavorite}
-            onClick={async () => {
-              if (!isLoggedIn) {
-                const isLoginSuccessful = await overlay.open(({ isOpen, close }) => {
-                  return <AuthModal isOpen={isOpen} onClose={() => close(false)} onSuccess={() => close(true)} />;
-                });
-                if (!isLoginSuccessful) return;
-              }
-              setIsFavorite((prev) => !prev);
-            }}
+            aria-pressed={isLiked}
+            onClick={toggleLike}
+            disabled={isLikePending}
             className='h-13.5 md:h-18'
           >
-            <HeartIcon size={24} variant={isFavorite ? 'filled' : 'outline'} />
+            <HeartIcon size={24} variant={isLiked ? 'filled' : 'outline'} />
           </Button>
           <Button
             variant='action'


### PR DESCRIPTION
## ❓ 이슈

- close #305

## ✍️ Description

모바일 모임 상세 페이지의 플로팅 액션 바 찜 버튼이 실제 API를 호출하지 않고 로컬 `useState` 토글만 하던 문제를 수정합니다.

**기존 동작**

`src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx`의 찜 버튼이 `useState(false)` 토글만 호출 → 새로고침/다른 기기/데스크탑 뷰에서 찜 상태가 사라지고, `/my`의 관심 모임 목록에도 추가되지 않음.

데스크탑(`GatheringInfoAside`)은 `useLikeToggle` 훅을 사용해 정상 작동 중 → 같은 페이지에서 디바이스에 따라 동작이 갈리는 일관성 문제.

**변경 내용**

- 데스크탑과 동일하게 `useLikeToggle(gatheringId)` 훅으로 교체.
- 인증 분기(`AuthModal`), 낙관적 업데이트, 토스트("관심 모임에 추가/제외되었습니다") 모두 훅이 캡슐화 → 모바일/데스크탑 동작 일원화.
- 진행 중에는 버튼 `disabled` 처리로 중복 호출 방지.

**비교 — `useLikeToggle` 훅이 담당하는 책임** (`src/api/likes/hooks.tsx`)

- 비로그인 사용자에게 `AuthModal` 띄움 → 로그인 성공 시 즉시 add
- 로그인 사용자: 현재 `isLiked` 상태에 따라 add/remove 분기
- 성공/실패 토스트
- 캐시 무효화는 mutation 훅 내부에서 처리

## 📸 스크린샷 (UI 변경 시)

UI 외관 변경 없음 (기능만 실제로 동작하도록 연결).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`fix/SM-184`)
- [x] Base Branch 확인 (`dev`)
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (모바일 뷰포트에서 찜 → 새로고침 후 유지, `/my` 관심 모임 목록 반영)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`, 0 errors)