### PR TITLE
[SM-187] feat: 모임 상세/만들기/대시보드 페이지 UX 개선

### DIFF
--- a/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContent/index.tsx
@@ -40,7 +40,7 @@ export function GatheringDetailContent({ gatheringId }: GatheringDetailContentPr
               </div>
             }
           >
-            <PendingApplications gatheringId={gatheringId} />
+            <PendingApplications gatheringId={gatheringId} gatheringStatus={data.status} />
           </SuspenseBoundary>
         </section>
       )}

--- a/src/app/gatherings/[id]/_components/PendingApplications/ApplicationCard.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/ApplicationCard.tsx
@@ -19,9 +19,10 @@ import type { ApplicationDetail } from '@/api/applications/types';
 interface ApplicationCardProps {
   gatheringId: number;
   application: ApplicationDetail;
+  isRecruiting: boolean;
 }
 
-export function ApplicationCard({ gatheringId, application }: ApplicationCardProps) {
+export function ApplicationCard({ gatheringId, application, isRecruiting }: ApplicationCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { showToast } = useToastStore();
   const overlay = useOverlay();
@@ -112,11 +113,21 @@ export function ApplicationCard({ gatheringId, application }: ApplicationCardPro
 
             {/* 승인/거부 버튼 */}
             <div className='flex items-center gap-2 md:gap-4'>
-              <Button variant='approve' size='approve-reject' onClick={handleApprove} disabled={isPending}>
+              <Button
+                variant='approve'
+                size='approve-reject'
+                onClick={handleApprove}
+                disabled={isPending || !isRecruiting}
+              >
                 <CheckIcon size={32} />
                 승인
               </Button>
-              <Button variant='reject' size='approve-reject' onClick={handleReject} disabled={isPending}>
+              <Button
+                variant='reject'
+                size='approve-reject'
+                onClick={handleReject}
+                disabled={isPending || !isRecruiting}
+              >
                 <CloseIcon size={32} />
                 거부
               </Button>

--- a/src/app/gatherings/[id]/_components/PendingApplications/index.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/index.tsx
@@ -72,6 +72,8 @@ export function PendingApplications({ gatheringId, gatheringStatus }: PendingApp
         )}
       </div>
 
+      {!isRecruiting && <p className='text-body-02-r text-gray-500'>모집이 마감되어 신청을 처리할 수 없습니다</p>}
+
       {/* 카드 목록 */}
       <div className='flex flex-col gap-2 md:gap-4'>
         {currentItems.map((application) => (

--- a/src/app/gatherings/[id]/_components/PendingApplications/index.tsx
+++ b/src/app/gatherings/[id]/_components/PendingApplications/index.tsx
@@ -9,15 +9,20 @@ import { Pagination } from '@/components/ui/Pagination';
 
 import { ApplicationCard } from './ApplicationCard';
 
+import type { GatheringStatus } from '@/api/gatherings/types';
+
 const ITEMS_PER_PAGE = 5;
 
 interface PendingApplicationsProps {
   gatheringId: number;
+  gatheringStatus: GatheringStatus;
 }
 
-export function PendingApplications({ gatheringId }: PendingApplicationsProps) {
+export function PendingApplications({ gatheringId, gatheringStatus }: PendingApplicationsProps) {
   const { data } = useSuspenseQuery(applicationQueries.list(gatheringId));
   const [page, setPage] = useState(1);
+
+  const isRecruiting = gatheringStatus === 'RECRUITING';
 
   const pendingApplications = useMemo(
     () => data.applications.filter((app) => app.status === 'PENDING'),
@@ -70,7 +75,12 @@ export function PendingApplications({ gatheringId }: PendingApplicationsProps) {
       {/* 카드 목록 */}
       <div className='flex flex-col gap-2 md:gap-4'>
         {currentItems.map((application) => (
-          <ApplicationCard key={application.id} gatheringId={gatheringId} application={application} />
+          <ApplicationCard
+            key={application.id}
+            gatheringId={gatheringId}
+            application={application}
+            isRecruiting={isRecruiting}
+          />
         ))}
       </div>
     </div>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/index.tsx
@@ -36,27 +36,33 @@ export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps)
   const totalPages = Math.ceil(ranking.length / itemsPerPage);
   const currentItems = ranking.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
 
-  const leftItems = currentItems.slice(0, 5);
-  const rightItems = currentItems.slice(5, 10);
+  const leftItems = currentItems.filter((_, i) => i % 2 === 0);
+  const rightItems = currentItems.filter((_, i) => i % 2 === 1);
 
   return (
     <div className='border-gray-150 bg-gray-0 shadow-02 rounded-2xl border p-6'>
       <h2 className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb mb-4 text-gray-900'>멤버 달성률 랭킹 🏆</h2>
 
-      <div className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
-        <div className='flex flex-col gap-4'>
-          {leftItems.map((item) => (
-            <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
-          ))}
-        </div>
-        {rightItems.length > 0 && (
+      {isDesktop ? (
+        <div className='grid grid-cols-2 gap-4'>
+          <div className='flex flex-col gap-4'>
+            {leftItems.map((item) => (
+              <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
+            ))}
+          </div>
           <div className='flex flex-col gap-4'>
             {rightItems.map((item) => (
               <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
             ))}
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className='flex flex-col gap-4'>
+          {currentItems.map((item) => (
+            <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
+          ))}
+        </div>
+      )}
 
       {totalPages > 1 && (
         <div className='mt-6'>

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -41,7 +41,7 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
   };
 
   return (
-    <div className='flex flex-col gap-1.5'>
+    <div className='flex flex-col gap-3'>
       <div className='flex items-stretch gap-3'>
         <div
           className={cn(
@@ -51,25 +51,15 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
         >
           <div
             className={cn(
-              'flex min-h-[43px] flex-wrap items-center gap-2 px-3 py-2 md:min-h-[58px] lg:min-h-[72px] lg:px-7',
+              'flex min-h-[43px] items-center px-3 py-2 md:min-h-[58px] lg:min-h-[72px] lg:px-7',
               !hasError && 'bg-gray-0 rounded-[calc(0.375rem-1px)]',
             )}
           >
-            {value.map((tag) => (
-              <Tag
-                key={tag}
-                variant='hashtag'
-                onRemove={() => handleRemove(tag)}
-                className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-2 py-0.5 md:px-2.5 md:py-1 lg:px-3 lg:py-1'
-              >
-                #{tag}
-              </Tag>
-            ))}
             <input
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder={value.length === 0 ? '태그를 입력해주세요 (최대 5개)' : ''}
+              placeholder='태그를 입력해주세요 (최대 5개)'
               maxLength={MAX_TAG_LENGTH}
               disabled={value.length >= MAX_TAGS}
               onBlur={onBlur}
@@ -89,6 +79,20 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
           추가
         </button>
       </div>
+      {value.length > 0 && (
+        <div className='flex flex-wrap gap-2'>
+          {value.map((tag) => (
+            <Tag
+              key={tag}
+              variant='hashtag'
+              onRemove={() => handleRemove(tag)}
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-2 py-0.5 md:px-2.5 md:py-1 lg:px-3 lg:py-1'
+            >
+              #{tag}
+            </Tag>
+          ))}
+        </div>
+      )}
       {error && (
         <p className='text-xs text-red-200' role='alert'>
           {error}

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { Button } from '@/components/ui/Button';
 import { fieldGradientFocusWrapperClass } from '@/components/ui/fieldControlVariants';
 import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
@@ -59,7 +60,7 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
-              placeholder='태그를 입력해주세요 (최대 5개)'
+              placeholder={value.length >= MAX_TAGS ? '최대 5개까지 입력했어요' : '태그를 입력해주세요 (최대 5개)'}
               maxLength={MAX_TAG_LENGTH}
               disabled={value.length >= MAX_TAGS}
               onBlur={onBlur}
@@ -67,17 +68,16 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
             />
           </div>
         </div>
-        <button
+        <Button
           type='button'
+          variant='primary'
+          size={null}
           onClick={handleAdd}
           disabled={isButtonDisabled}
-          className={cn(
-            'text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-0 w-[80px] shrink-0 rounded-lg transition-colors md:w-[140px] lg:w-[200px]',
-            isButtonDisabled ? 'bg-gray-300' : 'bg-gradient-primary',
-          )}
+          className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb w-[80px] shrink-0 md:w-[140px] lg:w-[200px]'
         >
           추가
-        </button>
+        </Button>
       </div>
       {value.length > 0 && (
         <div className='flex flex-wrap gap-2'>

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -7,6 +7,7 @@ import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
 
 const MAX_TAGS = 5;
+const MAX_TAG_LENGTH = 15;
 
 interface TagInputProps {
   value: string[];
@@ -20,7 +21,8 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
   const hasError = !!error;
 
   const trimmedInput = inputValue.trim();
-  const isButtonDisabled = !trimmedInput || value.length >= MAX_TAGS || value.includes(trimmedInput);
+  const isButtonDisabled =
+    !trimmedInput || trimmedInput.length > MAX_TAG_LENGTH || value.length >= MAX_TAGS || value.includes(trimmedInput);
 
   const handleAdd = () => {
     if (isButtonDisabled) return;
@@ -68,6 +70,7 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={value.length === 0 ? '태그를 입력해주세요 (최대 5개)' : ''}
+              maxLength={MAX_TAG_LENGTH}
               disabled={value.length >= MAX_TAGS}
               onBlur={onBlur}
               className='text-small-02-r md:text-body-02-r lg:text-body-01-r min-w-0 flex-1 bg-transparent outline-none placeholder:text-gray-400'

--- a/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/TagInput/index.tsx
@@ -19,19 +19,19 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
   const [inputValue, setInputValue] = useState('');
   const hasError = !!error;
 
+  const trimmedInput = inputValue.trim();
+  const isButtonDisabled = !trimmedInput || value.length >= MAX_TAGS || value.includes(trimmedInput);
+
+  const handleAdd = () => {
+    if (isButtonDisabled) return;
+    onChange([...value, trimmedInput]);
+    setInputValue('');
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
     e.preventDefault();
-
-    const trimmed = inputValue.trim();
-    const isDuplicate = value.includes(trimmed);
-    const isAtLimit = value.length >= MAX_TAGS;
-
-    // 빈 값, 중복, 최대 개수 초과 시 silently 무시
-    if (!trimmed || isDuplicate || isAtLimit) return;
-
-    onChange([...value, trimmed]);
-    setInputValue('');
+    handleAdd();
   };
 
   const handleRemove = (tag: string) => {
@@ -40,33 +40,51 @@ export function TagInput({ value, onChange, onBlur, error }: TagInputProps) {
 
   return (
     <div className='flex flex-col gap-1.5'>
-      <div className={hasError ? 'bg-gray-0 rounded-md border border-red-200' : fieldGradientFocusWrapperClass}>
+      <div className='flex items-stretch gap-3'>
         <div
           className={cn(
-            'flex min-h-[43px] flex-wrap items-center gap-2 px-3 py-2 md:min-h-[58px] lg:min-h-[72px] lg:px-7',
-            !hasError && 'bg-gray-0 rounded-[calc(0.375rem-1px)]',
+            hasError ? 'bg-gray-0 rounded-md border border-red-200' : fieldGradientFocusWrapperClass,
+            'flex-1',
           )}
         >
-          {value.map((tag) => (
-            <Tag
-              key={tag}
-              variant='hashtag'
-              onRemove={() => handleRemove(tag)}
-              className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-2 py-0.5 md:px-2.5 md:py-1 lg:px-3 lg:py-1'
-            >
-              #{tag}
-            </Tag>
-          ))}
-          <input
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={value.length === 0 ? '태그를 입력해주세요 (최대 5개)' : ''}
-            disabled={value.length >= MAX_TAGS}
-            onBlur={onBlur}
-            className='text-small-02-r md:text-body-02-r lg:text-body-01-r min-w-0 flex-1 bg-transparent outline-none placeholder:text-gray-400'
-          />
+          <div
+            className={cn(
+              'flex min-h-[43px] flex-wrap items-center gap-2 px-3 py-2 md:min-h-[58px] lg:min-h-[72px] lg:px-7',
+              !hasError && 'bg-gray-0 rounded-[calc(0.375rem-1px)]',
+            )}
+          >
+            {value.map((tag) => (
+              <Tag
+                key={tag}
+                variant='hashtag'
+                onRemove={() => handleRemove(tag)}
+                className='text-small-02-r md:text-body-02-r lg:text-body-01-r px-2 py-0.5 md:px-2.5 md:py-1 lg:px-3 lg:py-1'
+              >
+                #{tag}
+              </Tag>
+            ))}
+            <input
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={value.length === 0 ? '태그를 입력해주세요 (최대 5개)' : ''}
+              disabled={value.length >= MAX_TAGS}
+              onBlur={onBlur}
+              className='text-small-02-r md:text-body-02-r lg:text-body-01-r min-w-0 flex-1 bg-transparent outline-none placeholder:text-gray-400'
+            />
+          </div>
         </div>
+        <button
+          type='button'
+          onClick={handleAdd}
+          disabled={isButtonDisabled}
+          className={cn(
+            'text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-0 w-[80px] shrink-0 rounded-lg transition-colors md:w-[140px] lg:w-[200px]',
+            isButtonDisabled ? 'bg-gray-300' : 'bg-gradient-primary',
+          )}
+        >
+          추가
+        </button>
       </div>
       {error && (
         <p className='text-xs text-red-200' role='alert'>


### PR DESCRIPTION
## ❓ 이슈

- close #312 

## ✍️ Description

**1. 진행 중/종료된 모임 신청 승인·거절 버튼 비활성화**
- 모임 상태가 `RECRUITING`이 아닐 때 승인·거절 버튼 `disabled` 처리
- 신청 대기 목록은 모임 상태와 무관하게 유지 (과거 신청 내역 확인 가능)

**2. 모임 만들기 태그 입력 UX 개선**
- Enter 키 외 추가 버튼으로도 태그 추가 가능 (모바일·태블릿 대응)
- 버튼 비활성 시 `gray-300`, 활성 시 `gradient/primary/main` 스타일 적용
- 버튼 너비·글자 크기 반응형 적용 (`sm` / `md` / `lg`)
- 태그 최대 글자 수 15자 제한 (`maxLength` + 방어 로직)
- 태그 목록을 input 내부에서 input 아래 외부로 레이아웃 변경

**3. 멤버 달성률 랭킹 레이아웃 개선**

- 데스크톱: 1·3·5위 왼쪽 / 2·4·6위 오른쪽 교차 2열 배치
- 모바일/태블릿: 순위 순서대로 1열 나열 (기존 짝수 인덱스 누락 버그 수정)

## 📸 스크린샷 (UI 변경 시)
<img width="1760" height="672" alt="image" src="https://github.com/user-attachments/assets/9c992fb0-a3a7-426c-9d75-2df47c3d01f1" />

<img width="1858" height="1028" alt="image" src="https://github.com/user-attachments/assets/3c85c781-069a-4847-93be-8a13e4549835" />
<img width="1856" height="206" alt="image" src="https://github.com/user-attachments/assets/47f31319-231a-47ab-9ce4-fe2533636c65" />
<img width="1798" height="240" alt="image" src="https://github.com/user-attachments/assets/285e804b-84d9-4f16-8b63-1d4af43b45f2" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] 태그 입력 시 태그 목록을 input 아래에 표시하는 레이아웃으로 구현했습니다. 해당 방향으로 이야기가 나왔으나 회의 참여 인원이 적어 월요일에 다시 논의 후 최종 결정하기로 디자이너님께 안내받았습니다. 추후 논의 결과에 따라 변경될 수 있습니다.