### PR TITLE
[SM-188] fix: 라이브킷 회의 토큰 발급 API의 에러 응답을 errorCode 기반으로 표준화

### DIFF
--- a/src/app/api/livekit/token/route.ts
+++ b/src/app/api/livekit/token/route.ts
@@ -1,18 +1,38 @@
-import { AccessToken } from 'livekit-server-sdk';
 import { NextRequest, NextResponse } from 'next/server';
+
+import * as Sentry from '@sentry/nextjs';
+import { AccessToken } from 'livekit-server-sdk';
+
 import { requestBackend } from '@/lib/serverFetch';
 import { withBffErrorHandling } from '@/lib/withBffErrorHandling';
+
+interface BffErrorParams {
+  errorCode: string;
+  message: string;
+  status: number;
+}
+
+const bffError = ({ errorCode, message, status }: BffErrorParams) =>
+  NextResponse.json({ success: false, data: null, message, errorCode }, { status });
 
 export const GET = withBffErrorHandling(async (req: NextRequest) => {
   const room = req.nextUrl.searchParams.get('room');
 
   if (!room) {
-    return NextResponse.json({ error: 'Missing "room" query parameter' }, { status: 400 });
+    return bffError({
+      errorCode: 'INVALID_ROOM_PARAM',
+      message: 'Missing "room" query parameter',
+      status: 400,
+    });
   }
 
   const roomPattern = /^gathering-\d+$/;
   if (!roomPattern.test(room)) {
-    return NextResponse.json({ error: 'Invalid room format' }, { status: 400 });
+    return bffError({
+      errorCode: 'INVALID_ROOM_FORMAT',
+      message: 'Invalid room format',
+      status: 400,
+    });
   }
 
   const gatheringId = parseInt(room.split('-')[1], 10);
@@ -29,26 +49,51 @@ export const GET = withBffErrorHandling(async (req: NextRequest) => {
     }),
   ]);
 
+  // 멤버 검증 — 확실한 비멤버 신호(403/404)만 MEMBER_REQUIRED 로 처리.
+  // 5xx 등 모호한 상태는 UPSTREAM_ERROR 로 분리해 "비멤버 메시지" 오노출을 방지한다.
   if (!memberResponse.ok) {
-    return NextResponse.json(
-      {
-        error: 'Unauthorized: You must be a member to join this meeting',
-      },
-      {
+    if (memberResponse.status === 401) {
+      return bffError({
+        errorCode: 'LOGIN_REQUIRED',
+        message: 'Auth required for member check',
+        status: 401,
+      });
+    }
+    if (memberResponse.status === 403 || memberResponse.status === 404) {
+      return bffError({
+        errorCode: 'MEMBER_REQUIRED',
+        message: 'Not a gathering member',
         status: 403,
-      },
-    );
+      });
+    }
+    Sentry.captureMessage('livekit token: member check upstream error', {
+      level: 'error',
+      extra: { status: memberResponse.status, gatheringId },
+    });
+    return bffError({
+      errorCode: 'UPSTREAM_ERROR',
+      message: `Member check upstream error: ${memberResponse.status}`,
+      status: 503,
+    });
   }
 
   if (!userResponse.ok) {
-    return NextResponse.json(
-      {
-        error: 'Unauthorized: You must be logged in to join a meeting',
-      },
-      {
+    if (userResponse.status === 401) {
+      return bffError({
+        errorCode: 'LOGIN_REQUIRED',
+        message: 'User not authenticated',
         status: 401,
-      },
-    );
+      });
+    }
+    Sentry.captureMessage('livekit token: user fetch upstream error', {
+      level: 'error',
+      extra: { status: userResponse.status, gatheringId },
+    });
+    return bffError({
+      errorCode: 'UPSTREAM_ERROR',
+      message: `User fetch upstream error: ${userResponse.status}`,
+      status: 503,
+    });
   }
 
   const user = await userResponse.json();
@@ -56,7 +101,11 @@ export const GET = withBffErrorHandling(async (req: NextRequest) => {
   const nickname = user?.data?.nickname;
 
   if (!userId || !nickname) {
-    return NextResponse.json({ error: 'Failed to retrieve valid user info' }, { status: 401 });
+    return bffError({
+      errorCode: 'INVALID_USER_INFO',
+      message: 'Failed to retrieve valid user info',
+      status: 401,
+    });
   }
 
   const apiKey = process.env.LIVEKIT_API_KEY;
@@ -64,7 +113,11 @@ export const GET = withBffErrorHandling(async (req: NextRequest) => {
   const wsUrl = process.env.LIVEKIT_URL;
 
   if (!apiKey || !apiSecret || !wsUrl) {
-    return NextResponse.json({ error: 'Server misconfigured: LiveKit credentials missing' }, { status: 500 });
+    return bffError({
+      errorCode: 'SERVER_MISCONFIG',
+      message: 'LiveKit credentials missing',
+      status: 500,
+    });
   }
 
   const participantIdentity = `user-${userId}`;

--- a/src/app/gatherings/[id]/dashboard/_components/MeetingSection/getTokenErrorMessage.ts
+++ b/src/app/gatherings/[id]/dashboard/_components/MeetingSection/getTokenErrorMessage.ts
@@ -1,0 +1,16 @@
+const MEETING_TOKEN_ERROR_MESSAGES: Record<string, string> = {
+  MEMBER_REQUIRED: '모임 멤버만 회의에 참여할 수 있어요.',
+  LOGIN_REQUIRED: '로그인 후 다시 시도해 주세요.',
+  INVALID_ROOM_PARAM: '회의방 정보가 올바르지 않아요.',
+  INVALID_ROOM_FORMAT: '회의방 정보가 올바르지 않아요.',
+  INVALID_USER_INFO: '사용자 정보를 불러오지 못했어요. 다시 로그인해 주세요.',
+  SERVER_MISCONFIG: '회의 서버 설정에 문제가 있어요. 잠시 후 다시 시도해 주세요.',
+  UPSTREAM_ERROR: '회의 입장에 일시적인 문제가 발생했어요. 잠시 후 다시 시도해 주세요.',
+};
+
+const FALLBACK_TOKEN_ERROR_MESSAGE = '회의 토큰을 가져오는데 실패했습니다.';
+
+export const getTokenErrorMessage = (errorCode: unknown): string => {
+  if (typeof errorCode !== 'string') return FALLBACK_TOKEN_ERROR_MESSAGE;
+  return MEETING_TOKEN_ERROR_MESSAGES[errorCode] ?? FALLBACK_TOKEN_ERROR_MESSAGE;
+};

--- a/src/app/gatherings/[id]/dashboard/_components/MeetingSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MeetingSection/index.tsx
@@ -4,6 +4,7 @@ import { Suspense, useState } from 'react';
 
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 
+import { getTokenErrorMessage } from './getTokenErrorMessage';
 import { MeetingContent } from './MeetingContent';
 import { MeetingLobby } from './MeetingLobby';
 
@@ -29,7 +30,7 @@ export function MeetingSection({ gatheringId }: MeetingSectionProps) {
 
       if (!resp.ok) {
         const errorData = await resp.json().catch(() => ({}));
-        showToast({ variant: 'error', title: errorData.error || '회의 토큰을 가져오는데 실패했습니다.' });
+        showToast({ variant: 'error', title: getTokenErrorMessage(errorData?.errorCode) });
         setStatus('error');
         return;
       }


### PR DESCRIPTION
## ❓ 이슈

- close #314

## ✍️ Description

LiveKit 회의 토큰 발급 API의 에러 응답을 errorCode 기반으로 표준화하고, 클라이언트에서 한글 토스트 메시지로 매핑하도록 변경했습니다.

### `src/app/api/livekit/token/route.ts`
- `bffError({ errorCode, message, status })` 헬퍼를 추가해 응답 형태를 `{ success, data, message, errorCode }`로 통일했습니다.
- 멤버 체크·유저 조회 실패를 status에 따라 세분화했습니다. 기존에는 모든 실패를 비멤버/미로그인으로 단정해 백엔드 5xx 장애에도 잘못된 안내가 노출됐습니다. 이제 403/404만 `MEMBER_REQUIRED`로 처리하고, 그 외는
`UPSTREAM_ERROR`(503)로 분리합니다.
- 각 케이스에 errorCode를 부여했습니다: `INVALID_ROOM_PARAM`, `INVALID_ROOM_FORMAT`, `LOGIN_REQUIRED`, `MEMBER_REQUIRED`, `UPSTREAM_ERROR`, `INVALID_USER_INFO`, `SERVER_MISCONFIG`.
- `UPSTREAM_ERROR` 분기에 `Sentry.captureMessage`로 상위 시스템 상태 코드와 gatheringId를 기록합니다.

### `getTokenErrorMessage.ts` (신규)
- errorCode → 한글 메시지 매핑 테이블과 조회 함수. 매칭이 없으면 fallback 메시지를 반환합니다.

### `MeetingSection/index.tsx`
- 토큰 fetch 실패 시 토스트 제목을 `errorData.error`(영어) 대신 `getTokenErrorMessage(errorData?.errorCode)` 결과로 표시합니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
