### PR TITLE
[SM-186] feat: GA4 도입 Phase 1 - 스크립트 마운트 및 처리방침 GA 고지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@livekit/components-react": "^2.9.20",
         "@livekit/components-styles": "^1.2.0",
+        "@next/third-parties": "^16.2.6",
         "@sentry/nextjs": "^10.43.0",
         "@supabase/supabase-js": "^2.103.0",
         "@tanstack/react-query": "^5.90.21",
@@ -3190,6 +3191,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
+      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -16082,6 +16096,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@livekit/components-react": "^2.9.20",
     "@livekit/components-styles": "^1.2.0",
+    "@next/third-parties": "^16.2.6",
     "@sentry/nextjs": "^10.43.0",
     "@supabase/supabase-js": "^2.103.0",
     "@tanstack/react-query": "^5.90.21",

--- a/src/app/(info)/privacy/page.tsx
+++ b/src/app/(info)/privacy/page.tsx
@@ -29,13 +29,18 @@ const SECTIONS = [
     content:
       '서비스는 개인정보 보유 기간이 경과하거나 처리 목적이 달성된 경우 지체 없이 해당 개인정보를 파기합니다.\n\n• 전자적 파일 형태: 복구 불가능한 방법으로 영구 삭제\n• 종이 문서: 분쇄 또는 소각',
   },
+  {
+    title: '6. 쿠키 및 웹사이트 분석 도구',
+    content:
+      '서비스는 회원의 서비스 이용 패턴을 분석하고 서비스 품질을 개선하기 위해 Google LLC가 제공하는 Google Analytics 4를 사용합니다.\n\n• 수집 항목: 쿠키(_ga, _ga_* 등), IP 주소(익명화 처리), 디바이스 및 브라우저 정보, 페이지 이동·클릭 등 이용 행동 데이터, 회원이 발생시키는 주요 행동 이벤트(회원가입, 로그인, 모임 조회, 모임 참여 등)\n• 이용 목적: 서비스 이용 패턴 분석 및 서비스 개선\n• 처리 위탁: Google LLC (미국)\n• 보유 기간: 수집일로부터 14개월\n• 거부 방법:\n  - 브라우저 설정에서 쿠키 차단 (서비스 일부 기능이 제한될 수 있음)\n  - Google Analytics 옵트아웃 부가기능 설치: https://tools.google.com/dlpage/gaoptout\n\n서비스는 이름·이메일·전화번호 등 개인을 직접 식별할 수 있는 정보를 Google Analytics로 전송하지 않습니다.',
+  },
 ];
 
 export default function PrivacyPage() {
   return (
     <div>
       <h1 className='text-h5-b md:text-h4-b mb-2 text-gray-900'>개인정보 처리방침</h1>
-      <p className='text-small-01-r md:text-body-02-r mb-8 text-gray-400 md:mb-12'>최종 업데이트: 2026년 5월 8일</p>
+      <p className='text-small-01-r md:text-body-02-r mb-8 text-gray-400 md:mb-12'>최종 업데이트: 2026년 5월 17일</p>
       <div className='flex flex-col gap-6 md:gap-8'>
         {SECTIONS.map(({ title, content }) => (
           <section key={title}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import { pretendard } from './fonts';
+import { AnalyticsScripts } from '@/components/analytics/AnalyticsScripts';
 import { Header } from '@/components/Header';
 import { MSWProvider } from '@/providers/MSWProvider';
 import { QueryParamsProvider } from '@/providers/QueryParamsProvider';
@@ -84,6 +85,7 @@ export default function RootLayout({
         </MSWProvider>
         <JsonLd data={buildOrganizationJsonLd()} />
         <JsonLd data={buildWebSiteJsonLd()} />
+        <AnalyticsScripts />
       </body>
     </html>
   );

--- a/src/components/analytics/AnalyticsScripts/index.tsx
+++ b/src/components/analytics/AnalyticsScripts/index.tsx
@@ -1,0 +1,10 @@
+import { GoogleAnalytics } from '@next/third-parties/google';
+
+export function AnalyticsScripts() {
+  if (process.env.NODE_ENV !== 'production') return null;
+
+  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  if (!gaId) return null;
+
+  return <GoogleAnalytics gaId={gaId} />;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #311 

## ✍️ Description

5/18 첫 배포 릴리즈 직후부터 사용자 행동을 정량 측정하기 위한 GA4 도입 1단계.

이번 PR에서는 자동 측정 이벤트(`page_view`, `scroll`, `outbound_click`, `file_download` 등) 수집만 활성화. 커스텀 이벤트(`sign_up`, `search`, `view_gathering` 등)는 Phase 2에서 별도 이슈로 분리.

**변경 요약**
- `AnalyticsScripts` (신규) — `@next/third-parties`의 `GoogleAnalytics` 컴포넌트를 서버 컴포넌트로 래핑. `production` 환경 + `NEXT_PUBLIC_GA_ID`가 모두 있을 때에만 렌더해 dev 통계 오염 차단
- `layout.tsx` — `<body>` 끝(JsonLd 다음)에 `<AnalyticsScripts />` 마운트
- `privacy/page.tsx` — PIPA·정보통신망법 준수를 위해 §6 "쿠키 및 웹사이트 분석 도구" 섹션 추가 (수집 항목 / 이용 목적 / 처리 위탁자 / 보유 기간 14개월 / 거부 방법 / PII 미전송 보장 명시). 최종 업데이트 일자 갱신

**환경 / 콘솔 사전 작업 (PR 외 처리됨)**
- Vercel 환경변수 `NEXT_PUBLIC_GA_ID` 등록 (Production / Preview)
- GA4 콘솔: 데이터 보존 14개월 변경 완료, 원치 않는 추천 도메인 등록 완료

**검증 방법 (머지·재배포 후)**

1. https://completionisland.vercel.app 방문
2. GA4 콘솔 → 실시간 보고서에 활성 사용자 노출 확인
3. GA4 콘솔 → DebugView (GA Debugger Chrome 확장 ON 상태)에서 `page_view` 이벤트 도착 확인

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
