### PR TITLE
[SM-189] feat: 회원가입 약관 동의 체크박스 UI 구현

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -12,7 +12,12 @@ import type {
 } from './types';
 
 /** POST /v1/auth/register — 이메일 회원가입 */
-export const register = async ({ passwordConfirmation, ...body }: SignupForm): Promise<RegisterResponse> => {
+export const register = async ({
+  passwordConfirmation,
+  agreementTerms,
+  agreementPrivacy,
+  ...body
+}: SignupForm): Promise<RegisterResponse> => {
   const { data } = await axiosClient.post<ApiResponse<RegisterResponse>>('/v1/auth/register', body);
   return unwrapResponse(data);
 };

--- a/src/api/auth/schemas.ts
+++ b/src/api/auth/schemas.ts
@@ -27,6 +27,12 @@ export const signupFormSchema = z
         { message: '비밀번호는 숫자, 영문, 특수문자를 포함해야 합니다.' },
       ),
     passwordConfirmation: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
+    agreementTerms: z.boolean().refine((v) => v === true, {
+      message: '이용약관에 동의해주세요.',
+    }),
+    agreementPrivacy: z.boolean().refine((v) => v === true, {
+      message: '개인정보처리방침에 동의해주세요.',
+    }),
   })
   .refine((data) => data.password === data.passwordConfirmation, {
     message: '비밀번호가 일치하지 않습니다.',

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { cn } from '@/lib/cn';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
-import { VisibilityIcon } from '@/components/ui/Icon';
+import { CheckIcon, VisibilityIcon } from '@/components/ui/Icon';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 
 import { useEmailRegister } from './useEmailRegister';
@@ -142,6 +144,68 @@ export function EmailRegisterForm() {
         >
           <VisibilityIcon variant={state.showPasswordConfirm ? 'on' : 'off'} size={20} />
         </button>
+      </div>
+
+      <div className='flex flex-col gap-3'>
+        <label className='flex cursor-pointer items-center gap-2'>
+          <input
+            type='checkbox'
+            className='peer sr-only'
+            checked={!!form.isAllAgreed}
+            onChange={handlers.handleToggleAll}
+          />
+          <CheckIcon className={cn('size-5 transition-colors', form.isAllAgreed ? 'text-blue-300' : 'text-gray-500')} />
+          <span
+            className={cn(
+              'text-small-01-m md:text-body-02-m transition-colors',
+              form.isAllAgreed ? 'text-blue-300' : 'text-gray-500',
+            )}
+          >
+            전체 동의
+          </span>
+        </label>
+
+        <div className='border-t border-gray-200' />
+
+        <div className='flex items-center justify-between'>
+          <label className='flex cursor-pointer items-center gap-2'>
+            <input type='checkbox' className='peer sr-only' {...form.agreementTermsProps} />
+            <CheckIcon
+              className={cn('size-5 transition-colors', form.agreementTerms ? 'text-blue-300' : 'text-gray-500')}
+            />
+            <span
+              className={cn(
+                'text-small-01-r md:text-body-02-r transition-colors',
+                form.agreementTerms ? 'text-blue-300' : 'text-gray-500',
+              )}
+            >
+              (필수) 이용약관 동의
+            </span>
+          </label>
+          <Link href='/terms' target='_blank' className='text-small-02-r text-gray-400 underline'>
+            내용 보기
+          </Link>
+        </div>
+
+        <div className='flex items-center justify-between'>
+          <label className='flex cursor-pointer items-center gap-2'>
+            <input type='checkbox' className='peer sr-only' {...form.agreementPrivacyProps} />
+            <CheckIcon
+              className={cn('size-5 transition-colors', form.agreementPrivacy ? 'text-blue-300' : 'text-gray-500')}
+            />
+            <span
+              className={cn(
+                'text-small-01-r md:text-body-02-r transition-colors',
+                form.agreementPrivacy ? 'text-blue-300' : 'text-gray-500',
+              )}
+            >
+              (필수) 개인정보처리방침 동의
+            </span>
+          </label>
+          <Link href='/privacy' target='_blank' className='text-small-02-r text-gray-400 underline'>
+            내용 보기
+          </Link>
+        </div>
       </div>
 
       <Button

--- a/src/app/(auth)/register/EmailRegisterForm/useEmailRegister.ts
+++ b/src/app/(auth)/register/EmailRegisterForm/useEmailRegister.ts
@@ -17,15 +17,35 @@ export function useEmailRegister() {
     handleSubmit,
     trigger,
     watch,
+    setValue,
     setError,
     formState: { errors, isValid },
   } = useForm<SignupForm>({
     resolver: zodResolver(signupFormSchema),
     mode: 'onBlur',
+    defaultValues: { agreementTerms: false, agreementPrivacy: false },
   });
 
   const emailValue = watch('email');
   const nicknameValue = watch('nickname');
+  const agreementTerms = watch('agreementTerms');
+  const agreementPrivacy = watch('agreementPrivacy');
+
+  const isAllAgreed = agreementTerms && agreementPrivacy;
+
+  const agreementTermsProps = register('agreementTerms', {
+    onChange: () => trigger(['agreementTerms', 'agreementPrivacy']),
+  });
+
+  const agreementPrivacyProps = register('agreementPrivacy', {
+    onChange: () => trigger(['agreementTerms', 'agreementPrivacy']),
+  });
+
+  const handleToggleAll = () => {
+    const nextValue = !isAllAgreed;
+    setValue('agreementTerms', nextValue, { shouldValidate: true });
+    setValue('agreementPrivacy', nextValue, { shouldValidate: true });
+  };
 
   const checkEmailMutation = useCheckEmail();
   const checkNicknameMutation = useCheckNickname();
@@ -86,10 +106,16 @@ export function useEmailRegister() {
       isValid,
       emailValue,
       nicknameValue,
+      agreementTerms,
+      agreementPrivacy,
+      isAllAgreed,
+      agreementTermsProps,
+      agreementPrivacyProps,
     },
     handlers: {
       handleCheckEmail,
       handleCheckNickname,
+      handleToggleAll,
       registerMutate,
     },
   };


### PR DESCRIPTION
## ❓ 이슈

- close #317

## ✍️ Description

회원가입 폼에 이용약관 및 개인정보처리방침 동의 체크박스 UI를 추가합니다.
두 항목 모두 동의해야 회원가입 버튼이 활성화되며, 전체 동의 체크박스로 일괄 선택/해제가 가능합니다.
약관 내용은 '내용 보기' 링크로 새 탭에서 확인할 수 있습니다.

## 📸 스크린샷 (UI 변경 시)
<img width="638" height="1022" alt="image" src="https://github.com/user-attachments/assets/e6e373e5-a8d9-472f-b8f7-f1a686e15c8f" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

