### PR TITLE
[SM-193] feat: GA4 도입 Phase 2 - lib/analytics 인프라 + 타입 안전한 이벤트 API

### DIFF
--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,30 @@
+// AnalyticsEventMap이 GA4 커스텀 이벤트의 단일 진실 원천이다.
+
+export type AuthMethod = 'kakao' | 'google' | 'email';
+
+/**
+ * 모임 상세 페이지로 진입한 경로.
+ * - search: 검색 결과에서 클릭
+ * - recommendation: 메인 페이지 추천 섹션에서 클릭
+ * - direct: URL 직접 입력 (외부 referrer / no referrer)
+ * - profile: 마이페이지·다른 유저 프로필에서 진입
+ * - shared_link: UTM 또는 source 쿼리가 붙은 공유 링크에서 진입
+ *
+ * 라우트별 판정 규칙 구현은 후속 PR(탐색/상세)에서.
+ */
+export type GatheringEntrySource = 'search' | 'recommendation' | 'direct' | 'profile' | 'shared_link';
+
+export interface AnalyticsEventMap {
+  sign_up: { method: AuthMethod };
+  login: { method: AuthMethod };
+  search: { query: string; category?: string; result_count: number };
+  view_gathering: { gathering_id: string; category: string; source: GatheringEntrySource };
+  create_gathering_start: Record<string, never>;
+  create_gathering_submit: { category: string; member_count: number };
+  join_gathering: { gathering_id: string; category: string };
+}
+
+export interface UserProperties {
+  signup_date?: string;
+  auth_method?: AuthMethod;
+}

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -1,0 +1,14 @@
+export const gtagEvent = (eventName: string, params: Record<string, unknown>) => {
+  if (typeof window === 'undefined' || !window.gtag) return;
+  window.gtag('event', eventName, params);
+};
+
+export const gtagConfig = (targetId: string, config: Record<string, unknown>) => {
+  if (typeof window === 'undefined' || !window.gtag) return;
+  window.gtag('config', targetId, config);
+};
+
+export const gtagSetUserProperties = (properties: Record<string, unknown>) => {
+  if (typeof window === 'undefined' || !window.gtag) return;
+  window.gtag('set', 'user_properties', properties);
+};

--- a/src/lib/analytics/index.test.ts
+++ b/src/lib/analytics/index.test.ts
@@ -1,0 +1,100 @@
+import { identifyUser, setUserProperties, trackEvent } from './index';
+
+describe('lib/analytics', () => {
+  const originalGaId = process.env.NEXT_PUBLIC_GA_ID;
+  let consoleDebugSpy: jest.SpyInstance;
+  let gtagMock: jest.Mock;
+
+  beforeEach(() => {
+    consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    gtagMock = jest.fn();
+    window.gtag = gtagMock;
+  });
+
+  afterEach(() => {
+    consoleDebugSpy.mockRestore();
+    delete window.gtag;
+    process.env.NEXT_PUBLIC_GA_ID = originalGaId;
+  });
+
+  describe('trackEvent', () => {
+    it('dev 환경에서는 console.debug만 호출하고 gtag을 호출하지 않는다', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'development');
+
+      trackEvent('sign_up', { method: 'kakao' });
+
+      expect(consoleDebugSpy).toHaveBeenCalledWith('[analytics:dev] trackEvent', 'sign_up', { method: 'kakao' });
+      expect(gtagMock).not.toHaveBeenCalled();
+    });
+
+    it('production 환경에서는 window.gtag을 event 커맨드로 호출한다', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+
+      trackEvent('join_gathering', { gathering_id: '42', category: '스터디' });
+
+      expect(gtagMock).toHaveBeenCalledWith('event', 'join_gathering', { gathering_id: '42', category: '스터디' });
+      expect(consoleDebugSpy).not.toHaveBeenCalled();
+    });
+
+    it('production 환경이라도 window.gtag이 미로드면 no-op (예외 없음)', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+      delete window.gtag;
+
+      expect(() => trackEvent('login', { method: 'google' })).not.toThrow();
+    });
+  });
+
+  describe('identifyUser', () => {
+    it('dev 환경에서는 console.debug만 호출한다', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'development');
+
+      identifyUser('user-123');
+
+      expect(consoleDebugSpy).toHaveBeenCalledWith('[analytics:dev] identifyUser', 'user-123');
+      expect(gtagMock).not.toHaveBeenCalled();
+    });
+
+    it('production + NEXT_PUBLIC_GA_ID 모두 있으면 config 커맨드로 user_id를 전송한다', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+      process.env.NEXT_PUBLIC_GA_ID = 'G-TEST123';
+
+      identifyUser('user-123');
+
+      expect(gtagMock).toHaveBeenCalledWith('config', 'G-TEST123', { user_id: 'user-123' });
+    });
+
+    it('production이라도 NEXT_PUBLIC_GA_ID 미설정 시 no-op', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+      delete process.env.NEXT_PUBLIC_GA_ID;
+
+      identifyUser('user-123');
+
+      expect(gtagMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setUserProperties', () => {
+    it('dev 환경에서는 console.debug만 호출한다', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'development');
+
+      setUserProperties({ signup_date: '2026-05-19', auth_method: 'kakao' });
+
+      expect(consoleDebugSpy).toHaveBeenCalledWith('[analytics:dev] setUserProperties', {
+        signup_date: '2026-05-19',
+        auth_method: 'kakao',
+      });
+      expect(gtagMock).not.toHaveBeenCalled();
+    });
+
+    it('production 환경에서는 set 커맨드로 user_properties를 전송한다', () => {
+      jest.replaceProperty(process.env, 'NODE_ENV', 'production');
+
+      setUserProperties({ signup_date: '2026-05-19', auth_method: 'google' });
+
+      expect(gtagMock).toHaveBeenCalledWith('set', 'user_properties', {
+        signup_date: '2026-05-19',
+        auth_method: 'google',
+      });
+    });
+  });
+});

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,0 +1,31 @@
+import { gtagConfig, gtagEvent, gtagSetUserProperties } from './gtag';
+
+import type { AnalyticsEventMap, UserProperties } from './events';
+
+export const trackEvent = <K extends keyof AnalyticsEventMap>(name: K, params: AnalyticsEventMap[K]) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.debug('[analytics:dev] trackEvent', name, params);
+    return;
+  }
+  gtagEvent(name, params);
+};
+
+export const identifyUser = (userId: string) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.debug('[analytics:dev] identifyUser', userId);
+    return;
+  }
+  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  if (!gaId) return;
+  gtagConfig(gaId, { user_id: userId });
+};
+
+export const setUserProperties = (properties: UserProperties) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.debug('[analytics:dev] setUserProperties', properties);
+    return;
+  }
+  gtagSetUserProperties(properties as Record<string, unknown>);
+};
+
+export type { AnalyticsEventMap, AuthMethod, GatheringEntrySource, UserProperties } from './events';

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,15 @@
+type GtagFn = {
+  (command: 'event', eventName: string, eventParams?: Record<string, unknown>): void;
+  (command: 'config', targetId: string, configParams?: Record<string, unknown>): void;
+  (command: 'set', target: 'user_properties', properties: Record<string, unknown>): void;
+  (command: 'set', config: Record<string, unknown>): void;
+};
+
+declare global {
+  interface Window {
+    gtag?: GtagFn;
+    dataLayer?: unknown[];
+  }
+}
+
+export {};


### PR DESCRIPTION
## ❓ 이슈

- close #322

## ✍️ Description

GA4 Phase 2(P0 커스텀 이벤트) 진입을 위한 `lib/analytics` 모듈을 단독 PR로 분리한다. 타입 안전한 `trackEvent` API와 dev 환경 `console.debug` 분기까지를 본 PR에 포함하고, 실제 이벤트 발사 지점(인증/탐색/전환)은 후속 PR(SM-194/195/196)로 분리.

이벤트 명세는 `events.ts`(`AnalyticsEventMap`)를 **단일 진실 원천**으로 둔다.

### 추가된 파일

- **`src/types/gtag.d.ts`** — `window.gtag`, `window.dataLayer` 전역 타입 선언. `declare global` + `export {}`로 모듈화해 `GtagFn` 타입 전역 오염 방지
- **`src/lib/analytics/gtag.ts`** — 저수준 래퍼 (`gtagEvent`, `gtagConfig`, `gtagSetUserProperties`). `window.gtag` 미로드 / SSR 환경에서 no-op 가드
- **`src/lib/analytics/events.ts`** — `AnalyticsEventMap`에 P0 7개 이벤트 명세 + 공통 타입(`AuthMethod`, `GatheringEntrySource`, `UserProperties`). `GatheringEntrySource` 값은 코드 일관성·디버깅 우선해 영문 enum 채택
- **`src/lib/analytics/index.ts`** — 공개 API
  - `trackEvent<K>(name, params)`: 컴파일 타임에 이벤트명/파라미터 오타 차단
  - `identifyUser(userId)`: `user_id`를 GA config로 전송
  - `setUserProperties(props)`: `user_properties` 갱신
  - `NODE_ENV !== 'production'`일 때 `console.debug`로 대체해 dev/test 통계 오염 방지
- **`src/lib/analytics/index.test.ts`** — dev/prod 분기, `NEXT_PUBLIC_GA_ID` 미설정 시 no-op, `window.gtag` 미로드 시 안전성 등 8개 케이스 단위 테스트

### 후속 PR

본 PR 머지 후 병렬 진행 가능:

- **SM-194 (인증)** — `sign_up`, `login` + `identifyUser` / `setUserProperties`
- **SM-195 (탐색/상세)** — `search`, `view_gathering` + source 판정 규칙
- **SM-196 (핵심 전환)** — `create_gathering_start`, `create_gathering_submit`, `join_gathering`

### GA4 콘솔 (코드 외 작업, 본 PR과 무관)

- 커스텀 측정기준 등록: `gathering_id`, `category`, `source`, `method`, `result_count`
- 주요 이벤트 마킹: `sign_up`, `login`, `join_gathering`, `create_gathering_submit`

## 📸 스크린샷 (UI 변경 시)

해당 없음 (인프라 PR, UI 변경 없음).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-193`)
- [x] Base Branch 확인 (`dev`)
- [x] 적절한 Label 지정 (`feature`)
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (단위 테스트 8/8 통과 — `npx jest src/lib/analytics`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)