### PR TITLE
[SM-194] feat: GA4 도입 Phase 2 - 인증 이벤트(sign_up, login) + 유저 식별

### DIFF
--- a/src/app/(auth)/login/EmailLoginForm/index.tsx
+++ b/src/app/(auth)/login/EmailLoginForm/index.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { VisibilityIcon } from '@/components/ui/Icon';
 import { useLogin } from '@/api/auth/queries';
+import { trackAuthLogin } from '@/lib/analytics/auth';
 
 import type { LoginForm } from '@/api/auth/types';
 
@@ -29,7 +30,10 @@ export function EmailLoginForm() {
   });
 
   const { mutate: loginMutate, isPending } = useLogin({
-    onSuccess: () => router.push('/main'),
+    onSuccess: (data) => {
+      trackAuthLogin({ userId: String(data.user.id), method: 'email' });
+      router.push('/main');
+    },
     onError: () => setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' }),
   });
 

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { CheckIcon, VisibilityIcon } from '@/components/ui/Icon';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { trackAuthSignUp } from '@/lib/analytics/auth';
 
 import { useEmailRegister } from './useEmailRegister';
 
@@ -25,7 +26,8 @@ export function EmailRegisterForm() {
     }
 
     handlers.registerMutate(data, {
-      onSuccess: () => {
+      onSuccess: (response) => {
+        trackAuthSignUp({ userId: String(response.userId), method: 'email' });
         showToast({ title: '회원가입이 완료되었습니다.', variant: 'success' });
         router.push('/main');
       },

--- a/src/app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx
+++ b/src/app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx
@@ -2,13 +2,24 @@
 
 import { useEffect, useRef } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSocialLoginCallback } from '@/api/auth/queries';
+import { userQueries } from '@/api/users/queries';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { trackAuthLogin, trackAuthSignUp } from '@/lib/analytics/auth';
+
+import type { AuthMethod } from '@/lib/analytics/events';
+
+const toAuthMethod = (provider: string): AuthMethod | null => {
+  if (provider === 'kakao' || provider === 'google') return provider;
+  return null;
+};
 
 export function OAuthCallbackClient() {
   const router = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const provider = params.provider as string;
   const code = searchParams.get('code');
   const { showToast } = useToastStore();
@@ -16,6 +27,22 @@ export function OAuthCallbackClient() {
   const { mutate: loginCallback, isPending } = useSocialLoginCallback({
     onSuccess: (data) => {
       console.log('[OAuth 성공 응답 데이터]:', data);
+      // OAuth 응답에는 user.id가 없어 /users/me 를 보강 호출해 GA identifyUser 에 전달.
+      // GA 발사 실패가 로그인 흐름을 막지 않도록 fire-and-forget.
+      const method = toAuthMethod(provider);
+      if (method) {
+        queryClient
+          .fetchQuery(userQueries.me())
+          .then((me) => {
+            const userId = String(me.id);
+            if (data.newUser) trackAuthSignUp({ userId, method });
+            else trackAuthLogin({ userId, method });
+          })
+          .catch((error) => {
+            console.warn('[GA] OAuth tracking 실패 (로그인은 정상 진행):', error);
+          });
+      }
+
       // 신규 유저인 경우 무조건 메인으로 이동
       if (data.newUser) {
         router.replace('/main');

--- a/src/components/AuthModal/AuthFunnel/LoginStep.tsx
+++ b/src/components/AuthModal/AuthFunnel/LoginStep.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { VisibilityIcon } from '@/components/ui/Icon';
 import { useLogin } from '@/api/auth/queries';
 import { loginFormSchema } from '@/api/auth/schemas';
+import { trackAuthLogin } from '@/lib/analytics/auth';
 
 import type { LoginForm } from '@/api/auth/types';
 
@@ -25,7 +26,10 @@ export function LoginStep({ email, onSuccess, onBack }: { email: string; onSucce
   });
 
   const { mutate: loginMutate, isPending } = useLogin({
-    onSuccess,
+    onSuccess: (data) => {
+      trackAuthLogin({ userId: String(data.user.id), method: 'email' });
+      onSuccess();
+    },
     onError: () => setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' }),
   });
 

--- a/src/components/AuthModal/AuthFunnel/RegisterStep.tsx
+++ b/src/components/AuthModal/AuthFunnel/RegisterStep.tsx
@@ -9,6 +9,7 @@ import { VisibilityIcon } from '@/components/ui/Icon';
 import { useCheckNickname, useRegister } from '@/api/auth/queries';
 import { signupFormSchema } from '@/api/auth/schemas';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { trackAuthSignUp } from '@/lib/analytics/auth';
 
 import type { SignupForm } from '@/api/auth/types';
 
@@ -65,7 +66,8 @@ export function RegisterStep({
       return;
     }
     registerMutate(data, {
-      onSuccess: () => {
+      onSuccess: (response) => {
+        trackAuthSignUp({ userId: String(response.userId), method: 'email' });
         showToast({ title: '회원가입이 완료되었습니다.', variant: 'success' });
         onSuccess();
       },

--- a/src/lib/analytics/auth.test.ts
+++ b/src/lib/analytics/auth.test.ts
@@ -1,0 +1,63 @@
+import { identifyUser, setUserProperties, trackEvent } from './index';
+import { trackAuthLogin, trackAuthSignUp } from './auth';
+
+jest.mock('./index', () => ({
+  trackEvent: jest.fn(),
+  identifyUser: jest.fn(),
+  setUserProperties: jest.fn(),
+}));
+
+describe('lib/analytics/auth', () => {
+  const trackEventMock = trackEvent as jest.Mock;
+  const identifyUserMock = identifyUser as jest.Mock;
+  const setUserPropertiesMock = setUserProperties as jest.Mock;
+
+  beforeEach(() => {
+    trackEventMock.mockClear();
+    identifyUserMock.mockClear();
+    setUserPropertiesMock.mockClear();
+  });
+
+  describe('trackAuthLogin', () => {
+    it('login 이벤트 + identifyUser + auth_method user property 를 발사한다', () => {
+      trackAuthLogin({ userId: '42', method: 'kakao' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('login', { method: 'kakao' });
+      expect(identifyUserMock).toHaveBeenCalledWith('42');
+      expect(setUserPropertiesMock).toHaveBeenCalledWith({ auth_method: 'kakao' });
+    });
+
+    it('login에서는 signup_date를 설정하지 않는다 (가입 시점 보존)', () => {
+      trackAuthLogin({ userId: '42', method: 'email' });
+
+      expect(setUserPropertiesMock).toHaveBeenCalledWith({ auth_method: 'email' });
+      expect(setUserPropertiesMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ signup_date: expect.anything() }),
+      );
+    });
+  });
+
+  describe('trackAuthSignUp', () => {
+    it('sign_up 이벤트 + identifyUser + signup_date/auth_method user properties 를 발사한다', () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-05-19T12:00:00Z'));
+
+      trackAuthSignUp({ userId: '99', method: 'google' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('sign_up', { method: 'google' });
+      expect(identifyUserMock).toHaveBeenCalledWith('99');
+      expect(setUserPropertiesMock).toHaveBeenCalledWith({
+        signup_date: '2026-05-19',
+        auth_method: 'google',
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('signup_date 는 YYYY-MM-DD 포맷이다', () => {
+      trackAuthSignUp({ userId: '1', method: 'email' });
+
+      const properties = setUserPropertiesMock.mock.calls[0][0];
+      expect(properties.signup_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+});

--- a/src/lib/analytics/auth.ts
+++ b/src/lib/analytics/auth.ts
@@ -1,0 +1,22 @@
+import { identifyUser, setUserProperties, trackEvent } from './index';
+
+import type { AuthMethod } from './events';
+
+interface AuthTrackingParams {
+  userId: string;
+  method: AuthMethod;
+}
+
+const getTodayIsoDate = () => new Date().toISOString().slice(0, 10);
+
+export const trackAuthLogin = ({ userId, method }: AuthTrackingParams) => {
+  trackEvent('login', { method });
+  identifyUser(userId);
+  setUserProperties({ auth_method: method });
+};
+
+export const trackAuthSignUp = ({ userId, method }: AuthTrackingParams) => {
+  trackEvent('sign_up', { method });
+  identifyUser(userId);
+  setUserProperties({ signup_date: getTodayIsoDate(), auth_method: method });
+};


### PR DESCRIPTION
## ❓ 이슈

- close #323

## ✍️ Description

GA4 Phase 2의 두 번째 PR. P0 활성화 깔때기의 첫 관문인 인증 이벤트를 구현해 회원가입/로그인 성공 시 GA에 이벤트를 발사하고, `user_id`(내부 UUID) + `user_properties`(`signup_date`, `auth_method`)를 함께 설정한다.

이메일·전화번호 등 PII는 `user_id` 및 파라미터에 포함하지 않으며 내부 `user.id`(number)를 문자열로만 변환해 사용 

콜백 배치는 tanstack-query 규칙에 따라 `mutate()` 호출 레벨 onSuccess에 둔다. 훅 내부 onSuccess(`api/auth/queries.ts`)는 캐시 무효화만 담당.

### 추가된 파일

- **`src/lib/analytics/auth.ts`** — 도메인 헬퍼
  - `trackAuthLogin({userId, method})`: `login` 이벤트 + `identifyUser` + `setUserProperties({auth_method})`
  - `trackAuthSignUp({userId, method})`: `sign_up` 이벤트 + `identifyUser` + `setUserProperties({signup_date, auth_method})`
  - `signup_date`는 sign_up 시점에만 set (로그인 시 미설정 → 가입 시점 보존)
  - `signup_date` 포맷 `YYYY-MM-DD` (ISO 8601 date)
- **`src/lib/analytics/auth.test.ts`** — login/sign_up 정확성, `signup_date` 포맷, login 시 `signup_date` 미설정 보장 등 4개 케이스 (12/12 통과)

### 수정된 파일 (5개 호출 지점에 헬퍼 부착)

| 파일 | 부착 |
|---|---|
| `app/(auth)/login/EmailLoginForm/index.tsx` | `trackAuthLogin` |
| `app/(auth)/register/EmailRegisterForm/index.tsx` | `trackAuthSignUp` |
| `components/AuthModal/AuthFunnel/LoginStep.tsx` | `trackAuthLogin` (모달 버전) |
| `components/AuthModal/AuthFunnel/RegisterStep.tsx` | `trackAuthSignUp` (모달 버전) |
| `app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx` | OAuth 분기 |

### OAuth 처리 보강

`POST /auth/{provider}/callback` 응답은 `{ newUser: boolean }`만 반환해 `user.id`가 없음. → onSuccess에서 `queryClient.fetchQuery(userQueries.me())`로 me를 보강한 뒤 `newUser` 분기에 따라 `sign_up` / `login` 발사.

- GA tracking 실패가 로그인 흐름을 막지 않도록 fire-and-forget + `console.warn`으로 가시성 확보
- `provider` → `AuthMethod` 타입 가드(`toAuthMethod`)로 `kakao`/`google` 외 값은 안전하게 스킵

### 동작 매트릭스

| 시나리오 | 이벤트 | user_properties |
|---|---|---|
| 이메일 로그인 (페이지/모달) | `login` | `auth_method: email` |
| 이메일 회원가입 (페이지/모달) | `sign_up` | `signup_date`, `auth_method: email` |
| 카카오 OAuth — 기존 유저 | `login` | `auth_method: kakao` |
| 카카오 OAuth — 신규 유저 | `sign_up` | `signup_date`, `auth_method: kakao` |
| 구글 OAuth — 기존 유저 | `login` | `auth_method: google` |
| 구글 OAuth — 신규 유저 | `sign_up` | `signup_date`, `auth_method: google` |

### 순환 의존 회피

`lib/analytics/index.ts`에서 `auth` 헬퍼는 재export하지 않음 (index → auth → index 위험). 소비처는 `@/lib/analytics/auth`에서 직접 import.

### 후속 PR

- **SM-195** — 탐색/상세 이벤트 (`search`, `view_gathering`)
- **SM-196** — 핵심 전환 이벤트 (`create_gathering_start/submit`, `join_gathering`)

### GA4 콘솔 (코드 외 작업, 본 PR과 무관)

- 주요 이벤트 마킹: `sign_up`, `login`

## 📸 스크린샷 (UI 변경 시)

해당 없음 (UI 변경 없음, 행동 추적만 부착).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-194`)
- [x] Base Branch 확인 (`dev`)
- [x] 적절한 Label 지정 (`feature`)
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (단위 테스트 12/12 통과 — `npx jest src/lib/analytics`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)