### PR TITLE
[SM-195] feat: GA4 도입 Phase 2 - 탐색/상세 이벤트(search, view_gathering)

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -60,7 +60,10 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
             disabled={!isJoinableStatus}
             onClick={async () => {
               if (isLeader) {
-                await navigator.clipboard.writeText(window.location.href);
+                // 추적용 쿼리(?source=, utm_*)가 묻어 나가면 받은 사람의 view_gathering 이
+                // 잘못된 source 로 분류되므로 origin + path 로 재구성해 깔끔한 URL 만 공유한다.
+                const shareUrl = `${window.location.origin}/gatherings/${gatheringId}`;
+                await navigator.clipboard.writeText(shareUrl);
                 showToast({ variant: 'success', title: '링크가 복사되었습니다.' });
                 return;
               }

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -161,7 +161,10 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
               disabled={(!isJoinable && !isLeader) || hasPendingApplication}
               onClick={async () => {
                 if (isLeader) {
-                  await navigator.clipboard.writeText(window.location.href);
+                  // 추적용 쿼리(?source=, utm_*)가 묻어 나가면 받은 사람의 view_gathering 이
+                  // 잘못된 source 로 분류되므로 origin + path 로 재구성해 깔끔한 URL 만 공유한다.
+                  const shareUrl = `${window.location.origin}/gatherings/${gatheringId}`;
+                  await navigator.clipboard.writeText(shareUrl);
                   showToast({ variant: 'success', title: '링크가 복사되었습니다.' });
                   return;
                 }

--- a/src/app/gatherings/[id]/_components/GatheringDetailTracker/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailTracker/index.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { gatheringQueries } from '@/api/gatherings/queries';
+import { resolveGatheringEntrySource, trackGatheringView } from '@/lib/analytics/gathering';
+
+interface GatheringDetailTrackerProps {
+  gatheringId: number;
+}
+
+export function GatheringDetailTracker({ gatheringId }: GatheringDetailTrackerProps) {
+  const searchParams = useSearchParams();
+  const { data } = useQuery(gatheringQueries.detail(gatheringId));
+  const hasFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (!data || hasFiredRef.current) return;
+    hasFiredRef.current = true;
+
+    const source = resolveGatheringEntrySource(new URLSearchParams(searchParams.toString()));
+    const category = data.categories[0] ?? 'unknown';
+    trackGatheringView({ gatheringId: String(gatheringId), category, source });
+  }, [data, gatheringId, searchParams]);
+
+  return null;
+}

--- a/src/app/gatherings/[id]/_components/GatheringDetailTracker/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailTracker/index.tsx
@@ -15,13 +15,17 @@ interface GatheringDetailTrackerProps {
 export function GatheringDetailTracker({ gatheringId }: GatheringDetailTrackerProps) {
   const searchParams = useSearchParams();
   const { data } = useQuery(gatheringQueries.detail(gatheringId));
-  const hasFiredRef = useRef(false);
+  // (gatheringId, source) 조합을 키로 두어 동일 모임이라도 진입 경로가 바뀌면 다시 발사한다.
+  // 같은 조합에 대해선 1회만 발사.
+  const lastFiredSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!data || hasFiredRef.current) return;
-    hasFiredRef.current = true;
-
+    if (!data) return;
     const source = resolveGatheringEntrySource(new URLSearchParams(searchParams.toString()));
+    const signature = `${gatheringId}|${source}`;
+    if (lastFiredSignatureRef.current === signature) return;
+    lastFiredSignatureRef.current = signature;
+
     const category = data.categories[0] ?? 'unknown';
     trackGatheringView({ gatheringId: String(gatheringId), category, source });
   }, [data, gatheringId, searchParams]);

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { GatheringHero } from './_components/GatheringHero';
 import { GatheringDetailContainer } from './_components/GatheringDetailContainer';
 import { GatheringDetailSkeleton } from './_components/GatheringDetailSkeleton';
+import { GatheringDetailTracker } from './_components/GatheringDetailTracker';
 import { MainGatheringStreaming } from './_components/GatheringStreaming';
 
 import type { Metadata } from 'next';
@@ -84,6 +85,7 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
   return (
     <main className='mb-20 min-h-screen'>
       {detail && <JsonLd data={buildGatheringEventJsonLd(detail)} />}
+      {!Number.isNaN(gatheringId) && <GatheringDetailTracker gatheringId={gatheringId} />}
       <MainGatheringStreaming>
         <GatheringDetailContainer gatheringId={gatheringId} />
       </MainGatheringStreaming>

--- a/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
+++ b/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
@@ -13,7 +13,7 @@ export function DeadlineGatheringList() {
   const { page, setPage, totalPages, visibleGatherings } = useDeadlineGatherings();
 
   const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}`);
+    router.push(`/gatherings/${id}?source=recommendation`);
   };
 
   return (

--- a/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
+++ b/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
@@ -13,7 +13,7 @@ export function LatestGatheringList() {
   const { page, setPage, totalPages, visibleGatherings } = useLatestGatherings();
 
   const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}`);
+    router.push(`/gatherings/${id}?source=recommendation`);
   };
 
   return (

--- a/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
+++ b/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
@@ -13,7 +13,7 @@ export function PopularGatheringList() {
   const { page, setPage, totalPages, visibleGatherings } = usePopularGatherings();
 
   const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}`);
+    router.push(`/gatherings/${id}?source=recommendation`);
   };
 
   return (

--- a/src/app/my/_components/LikedGatheringCard/index.tsx
+++ b/src/app/my/_components/LikedGatheringCard/index.tsx
@@ -130,7 +130,7 @@ export function LikedGatheringCard({
           size='participation'
           className='w-full min-w-0 flex-1'
           disabled={!display.isJoinable}
-          onClick={() => router.push(`/gatherings/${gathering.id}`)}
+          onClick={() => router.push(`/gatherings/${gathering.id}?source=profile`)}
         >
           참여하기
         </Button>

--- a/src/app/my/_components/MyCreatedGatheringCard/index.tsx
+++ b/src/app/my/_components/MyCreatedGatheringCard/index.tsx
@@ -31,7 +31,7 @@ export function MyCreatedGatheringCard({ gathering, className }: MyCreatedGather
   const { displayLabel, tagState } = getGatheringDisplayStatus(gathering);
 
   return (
-    <Link href={`/gatherings/${gathering.id}`}>
+    <Link href={`/gatherings/${gathering.id}?source=profile`}>
       <GatheringCard className={cn('w-full transition-transform hover:-translate-y-1', className)}>
         <GatheringCard.Header className='mb-6 items-center'>
           <div className='flex gap-1'>

--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { startTransition } from 'react';
+import { startTransition, useEffect, useRef } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { MainGatheringCard } from '@/components/MainGatheringCard';
 import { GatheringFilterBar } from '@/components/Search/GatheringFilterBar';
@@ -12,6 +12,7 @@ import { Pagination } from '@/components/ui/Pagination';
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { GATHERING_TYPE_TO_PARAM } from '@/api/gatherings/types';
 import { useGatheringSearchParams } from '@/hooks/useGatheringSearchParams';
+import { trackGatheringSearch } from '@/lib/analytics/gathering';
 
 const PAGE_LIMIT = 12;
 
@@ -31,6 +32,10 @@ export function GatheringList() {
     }),
   );
 
+  // 카테고리 데이터는 page.tsx 에서 prefetched. cache hit 으로 비용 없음.
+  // GA 이벤트에 categoryIds → 이름 매핑 용도로만 사용.
+  const { data: categoriesData } = useQuery(gatheringQueries.categories());
+
   const handlePageChange = (newPage: number) => {
     startTransition(() => {
       setParams({ page: newPage }, { history: 'push' });
@@ -38,8 +43,25 @@ export function GatheringList() {
   };
 
   const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}`);
+    router.push(`/gatherings/${id}?source=search`);
   };
+
+  // query / category 조합이 변경되어 새 결과가 도착할 때 1회 search 이벤트 발사.
+  // 페이지네이션·정렬 변경은 새 "검색"이 아니므로 signature 에서 제외.
+  const lastSearchedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!query) return;
+    const signature = `${query}|${categoryIds.join(',')}`;
+    if (lastSearchedRef.current === signature) return;
+    lastSearchedRef.current = signature;
+
+    const categoryNames = categoryIds
+      .map((id) => categoriesData?.categories.find((c) => c.id === id)?.name)
+      .filter((name): name is string => !!name);
+    const category = categoryNames.length ? categoryNames.join(',') : undefined;
+
+    trackGatheringSearch({ query, category, resultCount: data.totalCount });
+  }, [query, categoryIds, data.totalCount, categoriesData]);
 
   if (data.gatherings.length === 0) {
     return (

--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -51,6 +51,10 @@ export function GatheringList() {
   const lastSearchedRef = useRef<string | null>(null);
   useEffect(() => {
     if (!query) return;
+    // 카테고리 필터가 적용된 검색인데 카테고리 데이터가 아직 도착 안 했다면 대기.
+    // 필터 없는 검색은 매핑 자체가 불필요하므로 곧장 발사.
+    if (categoryIds.length > 0 && !categoriesData) return;
+
     const signature = `${query}|${categoryIds.join(',')}`;
     if (lastSearchedRef.current === signature) return;
     lastSearchedRef.current = signature;

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -10,7 +10,15 @@ export type AuthMethod = 'kakao' | 'google' | 'email';
  * - profile: 마이페이지·다른 유저 프로필에서 진입
  * - shared_link: UTM 또는 source 쿼리가 붙은 공유 링크에서 진입
  *
- * 라우트별 판정 규칙 구현은 후속 PR(탐색/상세)에서.
+ * 판정 규칙 (src/lib/analytics/gathering.ts `resolveGatheringEntrySource`):
+ * 1. URL 쿼리 `?source=`가 'search' | 'recommendation' | 'profile' 중 하나면 그대로 사용
+ * 2. 그 외 + `utm_*` 파라미터 존재 → 'shared_link'
+ * 3. 둘 다 아님 → 'direct'
+ *
+ * 박는 지점 (?source=...):
+ * - 검색 결과(Search/GatheringList) → ?source=search
+ * - 메인 추천 섹션(Popular/Deadline/Latest) → ?source=recommendation
+ * - 마이페이지 카드(LikedGathering, MyCreatedGathering) → ?source=profile
  */
 export type GatheringEntrySource = 'search' | 'recommendation' | 'direct' | 'profile' | 'shared_link';
 

--- a/src/lib/analytics/gathering.test.ts
+++ b/src/lib/analytics/gathering.test.ts
@@ -1,0 +1,87 @@
+import { trackEvent } from './index';
+import { resolveGatheringEntrySource, trackGatheringSearch, trackGatheringView } from './gathering';
+
+jest.mock('./index', () => ({
+  trackEvent: jest.fn(),
+}));
+
+describe('lib/analytics/gathering', () => {
+  const trackEventMock = trackEvent as jest.Mock;
+
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
+
+  describe('trackGatheringSearch', () => {
+    it('query / result_count 와 함께 search 이벤트를 발사한다', () => {
+      trackGatheringSearch({ query: '리액트', resultCount: 12 });
+
+      expect(trackEventMock).toHaveBeenCalledWith('search', { query: '리액트', result_count: 12 });
+    });
+
+    it('category 가 있으면 같이 전송한다', () => {
+      trackGatheringSearch({ query: '리액트', category: '1,3', resultCount: 5 });
+
+      expect(trackEventMock).toHaveBeenCalledWith('search', {
+        query: '리액트',
+        category: '1,3',
+        result_count: 5,
+      });
+    });
+
+    it('category 가 빈 문자열이면 키를 누락시킨다 (값 없음)', () => {
+      trackGatheringSearch({ query: '리액트', category: '', resultCount: 0 });
+
+      expect(trackEventMock).toHaveBeenCalledWith('search', { query: '리액트', result_count: 0 });
+    });
+  });
+
+  describe('trackGatheringView', () => {
+    it('gathering_id / category / source 와 함께 view_gathering 이벤트를 발사한다', () => {
+      trackGatheringView({ gatheringId: '42', category: '스터디', source: 'search' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('view_gathering', {
+        gathering_id: '42',
+        category: '스터디',
+        source: 'search',
+      });
+    });
+  });
+
+  describe('resolveGatheringEntrySource', () => {
+    it('명시적 source=search 를 그대로 사용한다', () => {
+      const params = new URLSearchParams('source=search');
+      expect(resolveGatheringEntrySource(params)).toBe('search');
+    });
+
+    it('source=recommendation 을 그대로 사용한다', () => {
+      const params = new URLSearchParams('source=recommendation');
+      expect(resolveGatheringEntrySource(params)).toBe('recommendation');
+    });
+
+    it('source=profile 을 그대로 사용한다', () => {
+      const params = new URLSearchParams('source=profile');
+      expect(resolveGatheringEntrySource(params)).toBe('profile');
+    });
+
+    it('허용되지 않은 source 값은 무시한다 (direct 로 fallback)', () => {
+      const params = new URLSearchParams('source=hacker');
+      expect(resolveGatheringEntrySource(params)).toBe('direct');
+    });
+
+    it('source 미설정 + utm_source 존재 시 shared_link 로 판정한다', () => {
+      const params = new URLSearchParams('utm_source=instagram&utm_medium=social');
+      expect(resolveGatheringEntrySource(params)).toBe('shared_link');
+    });
+
+    it('source 와 utm 모두 없으면 direct 로 판정한다', () => {
+      const params = new URLSearchParams('');
+      expect(resolveGatheringEntrySource(params)).toBe('direct');
+    });
+
+    it('source 가 우선이며, utm 과 함께 박혀 있어도 source 가 이긴다', () => {
+      const params = new URLSearchParams('source=search&utm_source=instagram');
+      expect(resolveGatheringEntrySource(params)).toBe('search');
+    });
+  });
+});

--- a/src/lib/analytics/gathering.ts
+++ b/src/lib/analytics/gathering.ts
@@ -1,0 +1,37 @@
+import { trackEvent } from './index';
+
+import type { GatheringEntrySource } from './events';
+
+interface TrackGatheringSearchParams {
+  query: string;
+  category?: string;
+  resultCount: number;
+}
+
+interface TrackGatheringViewParams {
+  gatheringId: string;
+  category: string;
+  source: GatheringEntrySource;
+}
+
+export const trackGatheringSearch = ({ query, category, resultCount }: TrackGatheringSearchParams) => {
+  trackEvent('search', { query, ...(category && { category }), result_count: resultCount });
+};
+
+export const trackGatheringView = ({ gatheringId, category, source }: TrackGatheringViewParams) => {
+  trackEvent('view_gathering', { gathering_id: gatheringId, category, source });
+};
+
+/**
+ * URL searchParams 에서 모임 상세 진입 경로를 판정한다.
+ * 판정 규칙은 events.ts 의 GatheringEntrySource JSDoc 참고.
+ */
+export const resolveGatheringEntrySource = (searchParams: URLSearchParams): GatheringEntrySource => {
+  const source = searchParams.get('source');
+  if (source === 'search' || source === 'recommendation' || source === 'profile') return source;
+
+  const hasUtm = searchParams.has('utm_source') || searchParams.has('utm_medium') || searchParams.has('utm_campaign');
+  if (hasUtm) return 'shared_link';
+
+  return 'direct';
+};


### PR DESCRIPTION
## ❓ 이슈

- close #324

## ✍️ Description

GA4 Phase 2의 세 번째 PR. 검색 → 모임 상세 진입 깔때기 측정을 위해 `search` 이벤트와 `view_gathering` 이벤트를 구현한다. `view_gathering`에 `source` 파라미터를 함께 발사해 어느 경로(검색/추천/직접/프로필/공유링크)로 진입했는지 정량화한다.

`source` 판정은 **URL 쿼리(`?source=`) 방식 채택**. SPA 라우팅에서 `document.referrer`가 신뢰 불가하고, `sessionStorage`는 race 위험이 있어 결정론적이고 깔때기 분석에 친화적인 URL 쿼리 패턴을 선택.

### 추가된 파일

- **`src/lib/analytics/gathering.ts`** — 도메인 헬퍼
  - `trackGatheringSearch({ query, category?, resultCount })`
  - `trackGatheringView({ gatheringId, category, source })`
  - `resolveGatheringEntrySource(searchParams)` — 판정 규칙
    1. `?source=`가 `'search' | 'recommendation' | 'profile'` 중 하나면 그대로 사용
    2. `utm_*` 파라미터 존재 → `'shared_link'`
    3. 둘 다 아님 → `'direct'`
- **`src/lib/analytics/gathering.test.ts`** — 11개 케이스 (총 23/23 통과)
- **`src/app/gatherings/[id]/_components/GatheringDetailTracker/index.tsx`** — 클라이언트 트래커. `useQuery(detail)`로 자체 데이터 수신해 SSR fetch 실패 시에도 발사 보장, `useRef`로 1회 발사 가드

### 수정된 파일

| 파일 | 변경 |
|---|---|
| `lib/analytics/events.ts` | `GatheringEntrySource` JSDoc에 판정 규칙·박는 지점 명시 |
| `app/gatherings/[id]/page.tsx` | `<GatheringDetailTracker>` 마운트 |
| `components/Search/GatheringList/index.tsx` | search 이벤트 발사 + `?source=search` 박기. `useQuery(categories)`로 카테고리 데이터 받아 `categoryIds[]` → 이름 매핑 후 join (대시보드 가독성 우선) |
| `app/main/components/{Popular,Deadline,Latest}GatheringList/index.tsx` (3개) | `?source=recommendation` 박기 |
| `app/my/_components/LikedGatheringCard/index.tsx` | `?source=profile` 박기 |
| `app/my/_components/MyCreatedGatheringCard/index.tsx` | `?source=profile` 박기 |
| `app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx` | 공유 URL 정제 |
| `app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx` | 공유 URL 정제 |

### 공유 URL 정제 (데이터 오염 방지)

모임장이 `?source=search` 박힌 URL에서 "공유하기" 누르면 `window.location.href` 그대로 클립보드 복사 → 받은 사람의 `view_gathering`이 `source=search`로 잘못 분류되는 문제 발견. 추적용 쿼리(`?source=`, `utm_*`)가 새어 나가지 않도록 origin + path로 재구성.

```ts
// Before
navigator.clipboard.writeText(window.location.href);

// After
const shareUrl = `${window.location.origin}/gatherings/${gatheringId}`;
navigator.clipboard.writeText(shareUrl);
```

### 동작 매트릭스

| 행위 | 발사되는 이벤트 |
|---|---|
| 검색결과 페이지에서 검색어 입력 | `search { query, category?, result_count }` |
| 검색결과 카드 클릭 → 상세 진입 | `view_gathering { ..., source: "search" }` |
| 메인 추천 카드 클릭 → 상세 진입 | `view_gathering { ..., source: "recommendation" }` |
| 마이페이지 카드 클릭 → 상세 진입 | `view_gathering { ..., source: "profile" }` |
| URL 직접 입력 / 북마크 → 상세 진입 | `view_gathering { ..., source: "direct" }` |
| UTM 붙은 광고 링크 → 상세 진입 | `view_gathering { ..., source: "shared_link" }` |
| 모임장 "공유하기" → 친구 클릭 → 상세 진입 | `view_gathering { ..., source: "direct" }` (✅ 깔끔하게 잡힘) |

### 핵심 설계 결정

- **`search.category`** — `categoryIds[]`를 ID join (`"1,3"`)이 아닌 카테고리 **이름 join** (`"프로그래밍,디자인"`). 카테고리 데이터는 이미 prefetched라 추가 비용 없음
- **`view_gathering.category`** — `categories[0]` 단일값 사용. GA4 array 미지원 + 카디널리티 폭발 방지
- **트래커 데이터 흐름** — `useQuery(detail)`로 자체 수신. SSR fetch 실패 시에도 발사 보장
- **search 발사 시점** — `useEffect` + `useRef` 가드. query/categoryIds 조합 변경 시 1회. 페이지네이션·정렬 변경은 signature에서 제외

### 후속 PR

- **SM-196 (핵심 전환)** — `create_gathering_start`, `create_gathering_submit`, `join_gathering`

### GA4 콘솔 (코드 외 작업, 본 PR과 무관)

- 커스텀 측정기준 등록: `gathering_id`, `category`, `source`, `result_count`

## 📸 스크린샷 (UI 변경 시)

해당 없음 (UI 변경 없음, 행동 추적 부착 + 공유 URL 정제).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-195`)
- [x] Base Branch 확인 (`dev`)
- [x] 적절한 Label 지정 (`feature`)
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (단위 테스트 23/23 통과 — `npx jest src/lib/analytics`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)