### PR TITLE
[SM-196] feat: GA4 도입 Phase 2 - 핵심 전환 이벤트(create_gathering_start/submit, join_gathering)

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import axios from 'axios';
+import { useQuery } from '@tanstack/react-query';
 import { useCreateApplication } from '@/api/applications/queries';
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { BottomSheet } from '@/components/ui/BottomSheet';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { useFunnel } from '@/hooks/useFunnel';
+import { trackGatheringJoin } from '@/lib/analytics/gathering';
 import { GatheringApplyForm } from '../../GatheringApplyForm';
 import { GatheringApplySuccess } from '../../GatheringApplySuccess';
 
@@ -24,8 +27,17 @@ export function GatheringApplyBottomSheet({
   const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
   const { showToast } = useToastStore();
 
+  // 모임 상세 데이터는 부모 페이지에서 prefetched. cache hit 으로 비용 없음.
+  // join_gathering 이벤트의 category 파라미터 매핑용.
+  const { data: detailData } = useQuery(gatheringQueries.detail(gatheringId));
+
   const { mutate, isPending } = useCreateApplication(gatheringId, {
-    onSuccess: () => setStep('SUCCESS'),
+    onSuccess: () => {
+      if (detailData) {
+        trackGatheringJoin({ gatheringId: String(gatheringId), category: detailData.categories[0] ?? 'unknown' });
+      }
+      setStep('SUCCESS');
+    },
     onError: (error) => {
       if (axios.isAxiosError(error) && error.response?.data?.message) {
         showToast({ variant: 'error', title: error.response.data.message });

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import axios from 'axios';
-import { useQuery } from '@tanstack/react-query';
 import { useCreateApplication } from '@/api/applications/queries';
-import { gatheringQueries } from '@/api/gatherings/queries';
 import { BottomSheet } from '@/components/ui/BottomSheet';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { useFunnel } from '@/hooks/useFunnel';
@@ -16,6 +14,7 @@ interface GatheringApplyBottomSheetProps {
   onClose: () => void;
   gatheringId: number;
   gatheringTitle: string;
+  category: string;
 }
 
 export function GatheringApplyBottomSheet({
@@ -23,19 +22,14 @@ export function GatheringApplyBottomSheet({
   onClose,
   gatheringId,
   gatheringTitle,
+  category,
 }: GatheringApplyBottomSheetProps) {
   const { Funnel, Step, setStep, currentStep } = useFunnel<'APPLY' | 'SUCCESS'>('APPLY');
   const { showToast } = useToastStore();
 
-  // 모임 상세 데이터는 부모 페이지에서 prefetched. cache hit 으로 비용 없음.
-  // join_gathering 이벤트의 category 파라미터 매핑용.
-  const { data: detailData } = useQuery(gatheringQueries.detail(gatheringId));
-
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
-      if (detailData) {
-        trackGatheringJoin({ gatheringId: String(gatheringId), category: detailData.categories[0] ?? 'unknown' });
-      }
+      trackGatheringJoin({ gatheringId: String(gatheringId), category });
       setStep('SUCCESS');
     },
     onError: (error) => {

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -77,6 +77,7 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
                 <GatheringApplyBottomSheet
                   gatheringId={gatheringId}
                   gatheringTitle={data.title}
+                  category={data.categories[0] ?? 'unknown'}
                   isOpen={isOpen}
                   onClose={() => close(false)}
                 />

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -23,6 +23,7 @@ import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
 
 import { getGatheringDisplayStatus, getJoinButtonText } from '@/lib/gatheringStatus';
+import { trackGatheringJoin } from '@/lib/analytics/gathering';
 
 import type { GatheringType } from '@/api/gatherings/types';
 
@@ -54,6 +55,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
   const { mutate, isPending } = useCreateApplication(gatheringId, {
     onSuccess: () => {
+      trackGatheringJoin({ gatheringId: String(gatheringId), category: data.categories[0] ?? 'unknown' });
       setStep('SUCCESS');
     },
     onError: (error) => {

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { differenceInDays, isValid, parseISO } from 'date-fns';
@@ -21,6 +21,7 @@ import { gatheringQueries, useCreateGathering, useUpdateGathering } from '@/api/
 import { gatheringFormSchema } from '@/api/gatherings/schemas';
 import { GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
+import { trackGatheringCreateStart, trackGatheringCreateSubmit } from '@/lib/analytics/gathering';
 
 import { ImageUpload } from './ImageUpload';
 import { TagInput } from './TagInput';
@@ -86,7 +87,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     control,
     watch,
     trigger,
-    formState: { errors, touchedFields },
+    formState: { errors, touchedFields, isDirty },
   } = useForm<GatheringForm>({
     resolver: zodResolver(gatheringFormSchema),
     mode: 'onBlur',
@@ -101,6 +102,16 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   const { mutate: updateMutate, isPending: isUpdatePending } = useUpdateGathering(gatheringId ?? 0);
   const mutate = isEditMode ? updateMutate : createMutate;
   const isPending = isEditMode ? isUpdatePending : isCreatePending;
+
+  // 단순 페이지 진입(헤더 호기심 클릭 등)은 page_view 자동 측정으로 잡히므로 제외.
+  // isDirty 가 true 가 되는 순간 = 사용자가 어느 필드든 처음으로 값을 변경한 시점 =
+  // 실제 "모임 만들기를 시작했다"는 의도. 그 시점에 1회 발사.
+  const hasFiredStartRef = useRef(false);
+  useEffect(() => {
+    if (isEditMode || !isDirty || hasFiredStartRef.current) return;
+    hasFiredStartRef.current = true;
+    trackGatheringCreateStart();
+  }, [isDirty, isEditMode]);
 
   const typeValue = watch('type');
   const categoryIdsValue = watch('categoryIds') ?? [];
@@ -145,6 +156,10 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
   const onSubmit = (data: GatheringForm) => {
     mutate(data, {
       onSuccess: () => {
+        if (!isEditMode) {
+          const category = categories.find((c) => c.id === data.categoryIds[0])?.name ?? 'unknown';
+          trackGatheringCreateSubmit({ category, memberCount: data.maxMembers });
+        }
         showToast({ variant: 'success', title: isEditMode ? '모임이 수정되었습니다.' : '모임이 생성되었습니다.' });
         if (isEditMode && gatheringId) {
           router.push(`/gatherings/${gatheringId}`);

--- a/src/lib/analytics/gathering.test.ts
+++ b/src/lib/analytics/gathering.test.ts
@@ -1,5 +1,12 @@
 import { trackEvent } from './index';
-import { resolveGatheringEntrySource, trackGatheringSearch, trackGatheringView } from './gathering';
+import {
+  resolveGatheringEntrySource,
+  trackGatheringCreateStart,
+  trackGatheringCreateSubmit,
+  trackGatheringJoin,
+  trackGatheringSearch,
+  trackGatheringView,
+} from './gathering';
 
 jest.mock('./index', () => ({
   trackEvent: jest.fn(),
@@ -44,6 +51,36 @@ describe('lib/analytics/gathering', () => {
         gathering_id: '42',
         category: '스터디',
         source: 'search',
+      });
+    });
+  });
+
+  describe('trackGatheringCreateStart', () => {
+    it('파라미터 없이 create_gathering_start 이벤트를 발사한다', () => {
+      trackGatheringCreateStart();
+
+      expect(trackEventMock).toHaveBeenCalledWith('create_gathering_start', {});
+    });
+  });
+
+  describe('trackGatheringCreateSubmit', () => {
+    it('category / member_count 와 함께 create_gathering_submit 이벤트를 발사한다', () => {
+      trackGatheringCreateSubmit({ category: '프로그래밍', memberCount: 5 });
+
+      expect(trackEventMock).toHaveBeenCalledWith('create_gathering_submit', {
+        category: '프로그래밍',
+        member_count: 5,
+      });
+    });
+  });
+
+  describe('trackGatheringJoin', () => {
+    it('gathering_id / category 와 함께 join_gathering 이벤트를 발사한다', () => {
+      trackGatheringJoin({ gatheringId: '42', category: '스터디' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('join_gathering', {
+        gathering_id: '42',
+        category: '스터디',
       });
     });
   });

--- a/src/lib/analytics/gathering.ts
+++ b/src/lib/analytics/gathering.ts
@@ -22,6 +22,28 @@ export const trackGatheringView = ({ gatheringId, category, source }: TrackGathe
   trackEvent('view_gathering', { gathering_id: gatheringId, category, source });
 };
 
+export const trackGatheringCreateStart = () => {
+  trackEvent('create_gathering_start', {});
+};
+
+interface TrackGatheringCreateSubmitParams {
+  category: string;
+  memberCount: number;
+}
+
+export const trackGatheringCreateSubmit = ({ category, memberCount }: TrackGatheringCreateSubmitParams) => {
+  trackEvent('create_gathering_submit', { category, member_count: memberCount });
+};
+
+interface TrackGatheringJoinParams {
+  gatheringId: string;
+  category: string;
+}
+
+export const trackGatheringJoin = ({ gatheringId, category }: TrackGatheringJoinParams) => {
+  trackEvent('join_gathering', { gathering_id: gatheringId, category });
+};
+
 /**
  * URL searchParams 에서 모임 상세 진입 경로를 판정한다.
  * 판정 규칙은 events.ts 의 GatheringEntrySource JSDoc 참고.


### PR DESCRIPTION
## ❓ 이슈

- close #325

## ✍️ Description

GA4 Phase 2의 **마지막 PR**. 활성화 깔때기의 정점인 모임 생성·참여 이벤트를 구현해 **P0 이벤트 7개를 모두 완성**한다.

회의 확정 사항 "활성화 = 모임 1개 참여"에 따라 `join_gathering`이 본 깔때기의 핵심 종착 이벤트.

### 추가된 헬퍼 (`lib/analytics/gathering.ts`)

- `trackGatheringCreateStart()` — 모임 만들기 시작 (intent 기반)
- `trackGatheringCreateSubmit({ category, memberCount })` — 모임 생성 성공
- `trackGatheringJoin({ gatheringId, category })` — 모임 참여 신청 성공

### `create_gathering_start` — intent 기반 발사 (핵심 설계 결정)

처음엔 `/gatherings/new` 페이지 진입 시 발사하려 했으나, 헤더의 "모임 만들기" 버튼을 호기심에 눌러보고 나가는 사용자까지 포함돼 깔때기 노이즈가 큰 문제 발견. → **`react-hook-form`의 `formState.isDirty`가 true가 되는 순간**(사용자가 어느 필드든 처음으로 값을 변경한 시점)에 발사하도록 변경.

```tsx
const hasFiredStartRef = useRef(false);
useEffect(() => {
  if (isEditMode || !isDirty || hasFiredStartRef.current) return;
  hasFiredStartRef.current = true;
  trackGatheringCreateStart();
}, [isDirty, isEditMode]);
```

페이지 진입 카운트는 GA4 자동 `page_view`로 이미 잡히므로:
- 호기심 진입 비율 = `page_view - create_gathering_start`
- 의도 → 제출 전환율 = `create_gathering_submit / create_gathering_start`

→ 추가 이벤트 없이 두 깔때기 분석 모두 가능. GA4 표준 `form_start` 이벤트와 동일한 intent 기반 철학.

### 수정된 파일

| 파일 | 변경 |
|---|---|
| `lib/analytics/gathering.ts` | 헬퍼 3개 추가 |
| `lib/analytics/gathering.test.ts` | 3 케이스 추가 (총 14/14 통과) |
| `app/gatherings/new/CreateGatheringForm/index.tsx` | `isDirty` 기반 `create_gathering_start` 발사 + mutate onSuccess에 `create_gathering_submit`. **`isEditMode`면 둘 다 미발사** |
| `app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx` | 보유 중인 `useSuspenseQuery(detail)` 데이터로 mutate onSuccess에 `trackGatheringJoin` 발사 |
| `app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx` | `useQuery(detail)` 추가 (cache hit) + mutate onSuccess에 `trackGatheringJoin`. `detailData` null 가드 |

### 동작 매트릭스

| 시나리오 | page_view (자동) | `create_gathering_start` | `create_gathering_submit` | `join_gathering` |
|---|---|---|---|---|
| 헤더 호기심 클릭 → 즉시 이탈 | ✅ | ❌ | ❌ | ❌ |
| 진입 후 모임 유형만 선택하고 이탈 | ✅ | ✅ | ❌ | ❌ |
| 풀 제출 성공 | ✅ | ✅ | ✅ | ❌ |
| 수정 모드(`/edit`) 진입·작성·저장 | ✅ | ❌ | ❌ | ❌ |
| 다른 모임 참여 신청 성공 (PC/모바일) | - | ❌ | ❌ | ✅ |

### 핵심 설계 결정

- **`create_gathering_start` intent 기반** — `formState.isDirty` watch로 페이지 진입 노이즈 제거
- **`create_gathering_submit` mode 가드** — `isEditMode`면 발사 안 함 (수정은 새 모임 생성이 아님)
- **`category` 단일 대표값** — `categoryIds[0]` → 이름 매핑. `view_gathering`/`search`와 일관
- **두 join 호출 지점 동일 헬퍼** — PC/모바일 UI 다르지만 같은 비즈니스 액션. BottomSheet는 `useQuery(detail)` cache hit으로 비용 없이 카테고리 매핑
- **콜백 배치** — `mutate()` 호출 레벨 onSuccess (tanstack-query 규칙 준수)

### Phase 2 완성 ✅

본 PR 머지로 **P0 이벤트 7개 전부 활성화**:
`sign_up`, `login`, `search`, `view_gathering`, `create_gathering_start`, `create_gathering_submit`, `join_gathering`

### GA4 콘솔 (코드 외 작업, 본 PR과 무관)

- 주요 이벤트 마킹 (24~48h 후 가능): `join_gathering`, `create_gathering_submit`

### 후속 작업

- **Phase 3** — P1 이벤트 (실패 케이스, 회의/대시보드, 공유, `web_vitals`, `error_boundary`) + 가입 깔때기 / 검색→참여 깔때기 탐색 보고서

## 📸 스크린샷 (UI 변경 시)

해당 없음 (UI 변경 없음, 행동 추적 부착만).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-196`)
- [x] Base Branch 확인 (`dev`)
- [x] 적절한 Label 지정 (`feature`)
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (단위 테스트 26/26 통과 — `npx jest src/lib/analytics`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)