### PR TITLE
[SM-197] style: 모임 만들기 페이지 2차 디자인 QA

### DIFF
--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -96,7 +96,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         <div
           className={cn(
             'flex w-full cursor-pointer flex-col items-center justify-center gap-4 bg-gray-100',
-            'h-[343px] md:h-[688px] lg:h-[408px]',
+            'h-[188px] md:h-[604px] lg:h-[408px]',
             isDragging ? 'rounded-lg border border-blue-300' : 'dashed-border-gray',
           )}
           onClick={openFilePicker}
@@ -129,7 +129,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         <div
           className={cn(
             'flex flex-row items-center gap-2.5 overflow-x-auto bg-gray-100 px-2 py-3 md:flex-wrap md:justify-center md:overflow-x-visible md:overflow-y-auto',
-            'h-[343px] md:h-[688px] lg:h-[408px]',
+            'h-[188px] md:h-[604px] lg:h-[408px]',
             isDragging ? 'rounded-lg border border-blue-300' : 'dashed-border-gray',
           )}
           onDragOver={handleDragOver}
@@ -143,7 +143,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
             return (
               <div
                 key={index}
-                className='relative aspect-3/4 w-[200px] shrink-0 overflow-hidden rounded-lg md:w-[calc((100%-1rem)/3)] lg:w-[264px]'
+                className='relative aspect-3/4 w-[111px] shrink-0 overflow-hidden rounded-lg md:w-[208px] lg:w-[264px]'
               >
                 {isPdf ? (
                   <div className='flex h-full w-full flex-col items-center justify-center gap-2 bg-gray-100'>
@@ -159,9 +159,10 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
                 <button
                   type='button'
                   onClick={() => handleRemove(index)}
-                  className='absolute top-1.5 right-1.5 flex h-7 w-7 items-center justify-center rounded-full bg-white/[0.28] transition-colors hover:bg-white/50'
+                  className='absolute top-1.5 right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-white/[0.28] transition-colors hover:bg-white/50 md:h-7 md:w-7'
                 >
-                  <CloseIcon size={20} className='text-white' />
+                  <CloseIcon size={14} className='text-white md:hidden' />
+                  <CloseIcon size={20} className='hidden text-white md:block' />
                 </button>
               </div>
             );
@@ -173,7 +174,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
               key={`empty-${i}`}
               type='button'
               onClick={openFilePicker}
-              className='bg-gray-150 dashed-border-gray flex aspect-3/4 w-[200px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 md:w-[calc((100%-1rem)/3)] md:flex-row lg:w-[264px]'
+              className='bg-gray-150 dashed-border-gray flex aspect-3/4 w-[111px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 md:w-[208px] md:flex-row lg:w-[264px]'
             >
               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>+</span>
               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>이미지 추가</span>

--- a/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/ImageUpload/index.tsx
@@ -128,7 +128,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
         /* ── 1장 이상: 썸네일 + 빈 슬롯 ── */
         <div
           className={cn(
-            'flex flex-row gap-2 overflow-x-auto bg-gray-100 px-1 py-3 md:flex-wrap md:overflow-x-visible md:overflow-y-auto',
+            'flex flex-row items-center gap-2.5 overflow-x-auto bg-gray-100 px-2 py-3 md:flex-wrap md:justify-center md:overflow-x-visible md:overflow-y-auto',
             'h-[343px] md:h-[688px] lg:h-[408px]',
             isDragging ? 'rounded-lg border border-blue-300' : 'dashed-border-gray',
           )}
@@ -173,7 +173,7 @@ export function ImageUpload({ value, onChange, error }: ImageUploadProps) {
               key={`empty-${i}`}
               type='button'
               onClick={openFilePicker}
-              className='bg-gray-150 flex aspect-3/4 w-[200px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-gray-300 md:w-[calc((100%-1rem)/3)] md:flex-row lg:w-[264px]'
+              className='bg-gray-150 dashed-border-gray flex aspect-3/4 w-[200px] shrink-0 cursor-pointer flex-col items-center justify-center gap-1 md:w-[calc((100%-1rem)/3)] md:flex-row lg:w-[264px]'
             >
               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>+</span>
               <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-600'>이미지 추가</span>

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -192,7 +192,7 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
   };
 
   return (
-    <section className='mt-8 flex flex-col'>
+    <section className='mt-2 flex flex-col md:mt-4'>
       <button
         type='button'
         onClick={() => setIsOpenOverride((prev) => !(prev ?? totalWeeks > 0))}

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.tsx
@@ -92,37 +92,37 @@ function WeekDetailInputs({ control, index, error }: WeekDetailInputsProps) {
                 <CloseIcon className='size-4 md:size-5 lg:size-5' />
               </button>
             </div>
-            {canAddDetail && (
-              <Button
-                type='button'
-                variant='add-detail'
-                size='add-detail'
-                className='text-small-02-m md:text-body-02-m lg:text-body-01-m hidden h-[43px] w-full md:h-[58px] lg:block lg:h-[72px] lg:w-1/2'
-                onClick={handleAddDetail}
-              >
-                + 세부 계획 추가
-              </Button>
+            {details.length > 1 ? (
+              <div className='relative w-full lg:w-1/2'>
+                <Input
+                  placeholder='세부 계획을 적어주세요'
+                  value={details[1] ?? ''}
+                  onBlur={field.onBlur}
+                  onChange={(event) => updateDetail(1, event.target.value)}
+                  className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-10 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-10'
+                />
+                <button
+                  type='button'
+                  onClick={() => handleRemoveDetail(1)}
+                  className='absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600'
+                >
+                  <CloseIcon className='size-4 md:size-5 lg:size-5' />
+                </button>
+              </div>
+            ) : (
+              canAddDetail && (
+                <Button
+                  type='button'
+                  variant='add-detail'
+                  size='add-detail'
+                  className='text-small-02-m md:text-body-02-m lg:text-body-01-m hidden h-[43px] w-full md:h-[58px] lg:block lg:h-[72px] lg:w-1/2'
+                  onClick={handleAddDetail}
+                >
+                  + 세부 계획 추가
+                </Button>
+              )
             )}
           </div>
-
-          {details.length > 1 && (
-            <div className='relative w-full lg:w-1/2'>
-              <Input
-                placeholder='세부 계획을 적어주세요'
-                value={details[1] ?? ''}
-                onBlur={field.onBlur}
-                onChange={(event) => updateDetail(1, event.target.value)}
-                className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-10 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-10'
-              />
-              <button
-                type='button'
-                onClick={() => handleRemoveDetail(1)}
-                className='absolute top-1/2 right-3 -translate-y-1/2 text-gray-400 hover:text-gray-600'
-              >
-                <CloseIcon className='size-4 md:size-5 lg:size-5' />
-              </button>
-            </div>
-          )}
 
           {canAddDetail && (
             <Button
@@ -204,7 +204,12 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
         <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
           주차별 계획 <span className='text-blue-400'>*</span>
         </span>
-        <ArrowIcon className={cn('size-4 rotate-90 text-gray-800 transition-transform', isOpen && '-rotate-90')} />
+        <ArrowIcon
+          className={cn(
+            'size-4 rotate-90 text-gray-800 transition-transform md:size-5 lg:size-6',
+            isOpen && '-rotate-90',
+          )}
+        />
       </button>
 
       <AnimatePresence>
@@ -229,7 +234,7 @@ export function WeeklyPlanForm({ control, register, errors, totalWeeks }: Weekly
               {fields.map((field, index) => (
                 <div
                   key={field.id}
-                  className='border-gray-150 flex flex-col gap-3 border-b pb-5 last:border-b-0 last:pb-0'
+                  className='border-gray-150 flex flex-col gap-6 border-b pb-5 last:border-b-0 last:pb-0'
                 >
                   <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
                     {index + 1}주차

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -304,7 +304,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                           disabled={selected.length >= MAX_CATEGORIES && !selected.includes(cat.id)}
                           onClick={() => toggleCategory(cat.id)}
                           className={cn(
-                            'text-small-02-m md:text-body-02-m lg:text-body-01-m flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-gray-700 hover:bg-blue-100 hover:text-blue-400',
+                            'text-small-02-m md:text-body-02-m lg:text-body-01-m mb-[2px] flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-gray-700 hover:bg-blue-100 hover:text-blue-400',
                             selected.includes(cat.id) && 'bg-blue-100 text-blue-400',
                           )}
                         >

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -46,7 +46,7 @@ const CategoryTriggerBorder = ({ children }: { children: ReactNode }) => {
   return (
     <div
       className={cn(
-        'flex h-[43px] w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3 transition-colors duration-200 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5',
+        'flex h-[47px] w-full cursor-pointer items-center justify-between rounded-lg bg-white px-4 py-3 transition-colors duration-200 md:h-[62px] lg:h-[76px] lg:px-7 lg:py-5',
         isOpen ? 'border-gradient-primary' : 'border border-gray-200',
       )}
     >
@@ -236,7 +236,10 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                 error={errors.title?.message}
                 hideErrorMessage
                 {...register('title')}
-                className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-[43px] pr-12 md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5 lg:pr-20'
+                className={cn(
+                  'text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 pr-12 lg:px-7 lg:py-5 lg:pr-20',
+                  errors.title?.message ? 'h-[47px] md:h-[62px] lg:h-[76px]' : 'h-[43px] md:h-[58px] lg:h-[72px]',
+                )}
               />
               <span className='md:text-small-02-r pointer-events-none absolute right-3 bottom-1 text-[8px] text-gray-400 lg:right-5 lg:bottom-4'>
                 {titleValue.length}/30
@@ -268,7 +271,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
               };
 
               return (
-                <div className='flex w-full flex-col gap-1 lg:flex-1'>
+                <div className='flex w-full flex-col gap-1.5 lg:flex-1'>
                   <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>카테고리</p>
                   <Dropdown className='flex w-full flex-col'>
                     <Dropdown.Trigger>

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -177,7 +177,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   <Card
                     key={type}
                     className={cn(
-                      'flex h-40 cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none',
+                      'flex h-40 cursor-pointer items-center gap-6 rounded-lg px-8 shadow-none hover:shadow-none',
                       'h-[85px]',
                       'md:h-40 md:w-auto md:flex-1 md:gap-6 md:px-8',
                       isSelected ? 'border-focus-100 bg-blue-50' : 'border-gray-300 bg-gray-100',
@@ -220,7 +220,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
       </section>
 
       {/* 기본 정보 */}
-      <section className='flex flex-col gap-6'>
+      <section className='flex flex-col gap-6 md:gap-8'>
         <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-b text-gray-800'>
           기본 정보 <span className='text-blue-400'>*</span>
         </p>
@@ -535,7 +535,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
           />
         </div>
 
-        <div className='mt-8 flex h-[43px] items-center justify-between rounded-lg bg-gray-100 px-7 py-5 md:h-[58px] lg:h-[72px]'>
+        <div className='mt-2 flex h-[43px] items-center justify-between rounded-lg bg-gray-100 px-7 py-5 md:mt-4 md:h-[58px] lg:h-[72px]'>
           <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>모임 기간</p>
           <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
             <span className='text-blue-400'>{totalWeeks}</span> 주

--- a/src/app/gatherings/new/page.tsx
+++ b/src/app/gatherings/new/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function CreateGatheringPage() {
   return (
-    <main className='mx-auto max-w-[1680px] px-5 pt-20 pb-40'>
+    <main className='mx-auto max-w-[1720px] px-5 pt-20 pb-40'>
       <h1 className='text-body-01-b md:text-h4-b lg:text-h3-b mb-8 text-gray-900'>모임 만들기</h1>
       <SuspenseBoundary
         pendingFallback={


### PR DESCRIPTION
## ❓ 이슈

- close #331 

## ✍️ Description

모임 만들기 페이지 디자인 QA — 레이아웃·반응형·세부 간격 수정

- 페이지 콘텐츠 최대 너비 1680px로 조정
- 카테고리 드롭다운 아이템 간격 추가
- 이미지 업로드 썸네일 컨테이너 간격·정렬 조정 및 빈 슬롯 점선 테두리 통일
- 이미지 업로드 모바일·태블릿 반응형 추가
- 주차별 계획 폼 lg 반응형 레이아웃 개선
- 모임 만들기 폼 간격 반응형 적용 및 카드 hover 그림자 제거
- 모임 제목 input과 카테고리 드롭다운 높이·간격 불일치 수정 (Input 래퍼 p-px + border 포함 실제 높이 기준, 에러 상태 높이 축소 보정)


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


