### PR TITLE
[SM-198] feat: GA4 도입 Phase 3 - 실패 이벤트 4개(sign_up/login/create_gathering/join_gathering)

### DIFF
--- a/src/app/(auth)/login/EmailLoginForm/index.tsx
+++ b/src/app/(auth)/login/EmailLoginForm/index.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { VisibilityIcon } from '@/components/ui/Icon';
 import { useLogin } from '@/api/auth/queries';
-import { trackAuthLogin } from '@/lib/analytics/auth';
+import { trackAuthLogin, trackAuthLoginFailed } from '@/lib/analytics/auth';
 
 import type { LoginForm } from '@/api/auth/types';
 
@@ -34,7 +34,10 @@ export function EmailLoginForm() {
       trackAuthLogin({ userId: String(data.user.id), method: 'email' });
       router.push('/main');
     },
-    onError: () => setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' }),
+    onError: (error) => {
+      trackAuthLoginFailed({ method: 'email', error });
+      setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' });
+    },
   });
 
   const onSubmit = (data: LoginForm) => loginMutate(data);

--- a/src/app/(auth)/login/EmailLoginForm/index.tsx
+++ b/src/app/(auth)/login/EmailLoginForm/index.tsx
@@ -29,18 +29,19 @@ export function EmailLoginForm() {
     mode: 'onChange',
   });
 
-  const { mutate: loginMutate, isPending } = useLogin({
-    onSuccess: (data) => {
-      trackAuthLogin({ userId: String(data.user.id), method: 'email' });
-      router.push('/main');
-    },
-    onError: (error) => {
-      trackAuthLoginFailed({ method: 'email', error });
-      setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' });
-    },
-  });
+  const { mutate: loginMutate, isPending } = useLogin();
 
-  const onSubmit = (data: LoginForm) => loginMutate(data);
+  const onSubmit = (data: LoginForm) =>
+    loginMutate(data, {
+      onSuccess: (response) => {
+        trackAuthLogin({ userId: String(response.user.id), method: 'email' });
+        router.push('/main');
+      },
+      onError: (error) => {
+        trackAuthLoginFailed({ method: 'email', error });
+        setError('root', { message: '이메일 또는 비밀번호가 올바르지 않습니다.' });
+      },
+    });
   const showEmailError = !!touchedFields.email || submitCount > 0;
   const showPasswordError = !!touchedFields.password || submitCount > 0;
 

--- a/src/app/(auth)/register/EmailRegisterForm/index.tsx
+++ b/src/app/(auth)/register/EmailRegisterForm/index.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { CheckIcon, VisibilityIcon } from '@/components/ui/Icon';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
-import { trackAuthSignUp } from '@/lib/analytics/auth';
+import { trackAuthSignUp, trackAuthSignUpFailed } from '@/lib/analytics/auth';
 
 import { useEmailRegister } from './useEmailRegister';
 
@@ -31,7 +31,8 @@ export function EmailRegisterForm() {
         showToast({ title: '회원가입이 완료되었습니다.', variant: 'success' });
         router.push('/main');
       },
-      onError: () => {
+      onError: (error) => {
+        trackAuthSignUpFailed({ method: 'email', error });
         showToast({ title: '회원가입 중 오류가 발생했습니다.', variant: 'error' });
       },
     });

--- a/src/app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx
+++ b/src/app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useSocialLoginCallback } from '@/api/auth/queries';
 import { userQueries } from '@/api/users/queries';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
-import { trackAuthLogin, trackAuthSignUp } from '@/lib/analytics/auth';
+import { trackAuthLogin, trackAuthLoginFailed, trackAuthSignUp } from '@/lib/analytics/auth';
 
 import type { AuthMethod } from '@/lib/analytics/events';
 
@@ -59,6 +59,9 @@ export function OAuthCallbackClient() {
     },
     onError: (error) => {
       console.error('[OAuth 실패 에러]:', error);
+      const method = toAuthMethod(provider);
+      // 신규/기존 유저 구분이 불가능한 시점이라 sign_up_failed 분기 없이 login_failed 로 통합한다.
+      if (method) trackAuthLoginFailed({ method, error });
       showToast({
         variant: 'error',
         title: '로그인에 실패했습니다.',
@@ -69,9 +72,19 @@ export function OAuthCallbackClient() {
   });
 
   const hasCalled = useRef(false);
+  const hasFiredCancelRef = useRef(false);
 
   useEffect(() => {
-    if (!code || !provider || hasCalled.current) return;
+    if (!provider || hasCalled.current) return;
+
+    // 인가 코드 누락 = provider 화면에서 사용자가 "취소" 한 케이스. 깔때기 누락으로 기록한다.
+    if (!code) {
+      if (hasFiredCancelRef.current) return;
+      hasFiredCancelRef.current = true;
+      const method = toAuthMethod(provider);
+      if (method) trackAuthLoginFailed({ method, error: 'OAUTH_CANCELLED' });
+      return;
+    }
 
     // React 18 StrictMode의 더블 마운트로 인한 중복 호출 방지를 위해 sessionStorage 사용
     const processedCodeKey = `processed_code_${code}`;

--- a/src/app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx
+++ b/src/app/auth/[provider]/callback/_components/OAuthCallbackClient.tsx
@@ -24,52 +24,7 @@ export function OAuthCallbackClient() {
   const code = searchParams.get('code');
   const { showToast } = useToastStore();
 
-  const { mutate: loginCallback, isPending } = useSocialLoginCallback({
-    onSuccess: (data) => {
-      console.log('[OAuth 성공 응답 데이터]:', data);
-      // OAuth 응답에는 user.id가 없어 /users/me 를 보강 호출해 GA identifyUser 에 전달.
-      // GA 발사 실패가 로그인 흐름을 막지 않도록 fire-and-forget.
-      const method = toAuthMethod(provider);
-      if (method) {
-        queryClient
-          .fetchQuery(userQueries.me())
-          .then((me) => {
-            const userId = String(me.id);
-            if (data.newUser) trackAuthSignUp({ userId, method });
-            else trackAuthLogin({ userId, method });
-          })
-          .catch((error) => {
-            console.warn('[GA] OAuth tracking 실패 (로그인은 정상 진행):', error);
-          });
-      }
-
-      // 신규 유저인 경우 무조건 메인으로 이동
-      if (data.newUser) {
-        router.replace('/main');
-      } else {
-        // 기존 유저인 경우 이전 페이지(returnTo)가 있다면 해당 페이지로, 없다면 메인으로 이동
-        const returnTo = sessionStorage.getItem('returnTo');
-        if (returnTo) {
-          router.replace(returnTo);
-          sessionStorage.removeItem('returnTo');
-        } else {
-          router.replace('/main');
-        }
-      }
-    },
-    onError: (error) => {
-      console.error('[OAuth 실패 에러]:', error);
-      const method = toAuthMethod(provider);
-      // 신규/기존 유저 구분이 불가능한 시점이라 sign_up_failed 분기 없이 login_failed 로 통합한다.
-      if (method) trackAuthLoginFailed({ method, error });
-      showToast({
-        variant: 'error',
-        title: '로그인에 실패했습니다.',
-        description: '다시 시도해 주세요.',
-      });
-      router.replace('/login');
-    },
-  });
+  const { mutate: loginCallback, isPending } = useSocialLoginCallback();
 
   const hasCalled = useRef(false);
   const hasFiredCancelRef = useRef(false);
@@ -95,8 +50,56 @@ export function OAuthCallbackClient() {
 
     const redirectUri = `${window.location.origin}${window.location.pathname}`;
 
-    loginCallback({ provider, code, redirectUri });
-  }, [code, provider, loginCallback]);
+    loginCallback(
+      { provider, code, redirectUri },
+      {
+        onSuccess: (data) => {
+          console.log('[OAuth 성공 응답 데이터]:', data);
+          // OAuth 응답에는 user.id가 없어 /users/me 를 보강 호출해 GA identifyUser 에 전달.
+          // GA 발사 실패가 로그인 흐름을 막지 않도록 fire-and-forget.
+          const method = toAuthMethod(provider);
+          if (method) {
+            queryClient
+              .fetchQuery(userQueries.me())
+              .then((me) => {
+                const userId = String(me.id);
+                if (data.newUser) trackAuthSignUp({ userId, method });
+                else trackAuthLogin({ userId, method });
+              })
+              .catch((error) => {
+                console.warn('[GA] OAuth tracking 실패 (로그인은 정상 진행):', error);
+              });
+          }
+
+          // 신규 유저인 경우 무조건 메인으로 이동
+          if (data.newUser) {
+            router.replace('/main');
+          } else {
+            // 기존 유저인 경우 이전 페이지(returnTo)가 있다면 해당 페이지로, 없다면 메인으로 이동
+            const returnTo = sessionStorage.getItem('returnTo');
+            if (returnTo) {
+              router.replace(returnTo);
+              sessionStorage.removeItem('returnTo');
+            } else {
+              router.replace('/main');
+            }
+          }
+        },
+        onError: (error) => {
+          console.error('[OAuth 실패 에러]:', error);
+          const method = toAuthMethod(provider);
+          // 신규/기존 유저 구분이 불가능한 시점이라 sign_up_failed 분기 없이 login_failed 로 통합한다.
+          if (method) trackAuthLoginFailed({ method, error });
+          showToast({
+            variant: 'error',
+            title: '로그인에 실패했습니다.',
+            description: '다시 시도해 주세요.',
+          });
+          router.replace('/login');
+        },
+      },
+    );
+  }, [code, provider, loginCallback, queryClient, router, showToast]);
 
   return (
     <div className='flex min-h-screen flex-col items-center justify-center p-4 text-center'>

--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/GatheringApplyBottomSheet/index.tsx
@@ -5,7 +5,7 @@ import { useCreateApplication } from '@/api/applications/queries';
 import { BottomSheet } from '@/components/ui/BottomSheet';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { useFunnel } from '@/hooks/useFunnel';
-import { trackGatheringJoin } from '@/lib/analytics/gathering';
+import { trackGatheringJoin, trackGatheringJoinFailed } from '@/lib/analytics/gathering';
 import { GatheringApplyForm } from '../../GatheringApplyForm';
 import { GatheringApplySuccess } from '../../GatheringApplySuccess';
 
@@ -33,6 +33,7 @@ export function GatheringApplyBottomSheet({
       setStep('SUCCESS');
     },
     onError: (error) => {
+      trackGatheringJoinFailed({ gatheringId: String(gatheringId), category, error });
       if (axios.isAxiosError(error) && error.response?.data?.message) {
         showToast({ variant: 'error', title: error.response.data.message });
         return;

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -23,7 +23,7 @@ import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
 
 import { getGatheringDisplayStatus, getJoinButtonText } from '@/lib/gatheringStatus';
-import { trackGatheringJoin } from '@/lib/analytics/gathering';
+import { trackGatheringJoin, trackGatheringJoinFailed } from '@/lib/analytics/gathering';
 
 import type { GatheringType } from '@/api/gatherings/types';
 
@@ -59,6 +59,11 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
       setStep('SUCCESS');
     },
     onError: (error) => {
+      trackGatheringJoinFailed({
+        gatheringId: String(gatheringId),
+        category: data.categories[0] ?? 'unknown',
+        error,
+      });
       if (axios.isAxiosError(error) && error.response?.data?.message) {
         showToast({ variant: 'error', title: error.response.data.message });
         return;

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -21,7 +21,11 @@ import { gatheringQueries, useCreateGathering, useUpdateGathering } from '@/api/
 import { gatheringFormSchema } from '@/api/gatherings/schemas';
 import { GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
-import { trackGatheringCreateStart, trackGatheringCreateSubmit } from '@/lib/analytics/gathering';
+import {
+  trackGatheringCreateFailed,
+  trackGatheringCreateStart,
+  trackGatheringCreateSubmit,
+} from '@/lib/analytics/gathering';
 
 import { ImageUpload } from './ImageUpload';
 import { TagInput } from './TagInput';
@@ -167,7 +171,11 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
           router.push('/main');
         }
       },
-      onError: () => {
+      onError: (error) => {
+        if (!isEditMode) {
+          const category = categories.find((c) => c.id === data.categoryIds[0])?.name ?? 'unknown';
+          trackGatheringCreateFailed({ category, error });
+        }
         showToast({ variant: 'error', title: isEditMode ? '모임 수정에 실패했습니다.' : '모임 생성에 실패했습니다.' });
       },
     });

--- a/src/lib/analytics/auth.test.ts
+++ b/src/lib/analytics/auth.test.ts
@@ -1,5 +1,5 @@
 import { identifyUser, setUserProperties, trackEvent } from './index';
-import { trackAuthLogin, trackAuthSignUp } from './auth';
+import { trackAuthLogin, trackAuthLoginFailed, trackAuthSignUp, trackAuthSignUpFailed } from './auth';
 
 jest.mock('./index', () => ({
   trackEvent: jest.fn(),
@@ -58,6 +58,44 @@ describe('lib/analytics/auth', () => {
 
       const properties = setUserPropertiesMock.mock.calls[0][0];
       expect(properties.signup_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('trackAuthLoginFailed', () => {
+    it('login_failed 이벤트를 method/reason 과 함께 발사한다', () => {
+      trackAuthLoginFailed({ method: 'email', error: new Error('INVALID_CREDENTIALS') });
+
+      expect(trackEventMock).toHaveBeenCalledWith('login_failed', {
+        method: 'email',
+        reason: 'INVALID_CREDENTIALS',
+      });
+    });
+
+    it('명시 string 사유(OAUTH_CANCELLED) 도 그대로 전달한다', () => {
+      trackAuthLoginFailed({ method: 'kakao', error: 'OAUTH_CANCELLED' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('login_failed', {
+        method: 'kakao',
+        reason: 'OAUTH_CANCELLED',
+      });
+    });
+
+    it('identifyUser / setUserProperties 는 호출하지 않는다 (실패는 식별 안 됨)', () => {
+      trackAuthLoginFailed({ method: 'email', error: new Error('x') });
+
+      expect(identifyUserMock).not.toHaveBeenCalled();
+      expect(setUserPropertiesMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trackAuthSignUpFailed', () => {
+    it('sign_up_failed 이벤트를 method/reason 과 함께 발사한다', () => {
+      trackAuthSignUpFailed({ method: 'email', error: new Error('EMAIL_DUPLICATE') });
+
+      expect(trackEventMock).toHaveBeenCalledWith('sign_up_failed', {
+        method: 'email',
+        reason: 'EMAIL_DUPLICATE',
+      });
     });
   });
 });

--- a/src/lib/analytics/auth.ts
+++ b/src/lib/analytics/auth.ts
@@ -1,3 +1,4 @@
+import { extractFailureReason } from './extractFailureReason';
 import { identifyUser, setUserProperties, trackEvent } from './index';
 
 import type { AuthMethod } from './events';
@@ -5,6 +6,11 @@ import type { AuthMethod } from './events';
 interface AuthTrackingParams {
   userId: string;
   method: AuthMethod;
+}
+
+interface AuthFailureParams {
+  method: AuthMethod;
+  error: unknown;
 }
 
 const getTodayIsoDate = () => new Date().toISOString().slice(0, 10);
@@ -19,4 +25,12 @@ export const trackAuthSignUp = ({ userId, method }: AuthTrackingParams) => {
   trackEvent('sign_up', { method });
   identifyUser(userId);
   setUserProperties({ signup_date: getTodayIsoDate(), auth_method: method });
+};
+
+export const trackAuthLoginFailed = ({ method, error }: AuthFailureParams) => {
+  trackEvent('login_failed', { method, reason: extractFailureReason(error) });
+};
+
+export const trackAuthSignUpFailed = ({ method, error }: AuthFailureParams) => {
+  trackEvent('sign_up_failed', { method, reason: extractFailureReason(error) });
 };

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -30,6 +30,10 @@ export interface AnalyticsEventMap {
   create_gathering_start: Record<string, never>;
   create_gathering_submit: { category: string; member_count: number };
   join_gathering: { gathering_id: string; category: string };
+  sign_up_failed: { method: AuthMethod; reason: string };
+  login_failed: { method: AuthMethod; reason: string };
+  create_gathering_failed: { category: string; reason: string };
+  join_gathering_failed: { gathering_id: string; category: string; reason: string };
 }
 
 export interface UserProperties {

--- a/src/lib/analytics/extractFailureReason.test.ts
+++ b/src/lib/analytics/extractFailureReason.test.ts
@@ -1,0 +1,55 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+
+import { extractFailureReason } from './extractFailureReason';
+
+const createAxiosError = (data: unknown, message = 'Request failed') => {
+  const headers = new AxiosHeaders();
+  return new AxiosError(message, 'ERR_BAD_RESPONSE', undefined, undefined, {
+    data,
+    status: 400,
+    statusText: 'Bad Request',
+    headers,
+    config: { headers },
+  });
+};
+
+describe('lib/analytics/extractFailureReason', () => {
+  it('axios 에러의 response.data.errorCode 가 있으면 그 값을 우선 사용한다', () => {
+    const error = createAxiosError({ errorCode: 'EMAIL_ALREADY_EXISTS' });
+
+    expect(extractFailureReason(error)).toBe('EMAIL_ALREADY_EXISTS');
+  });
+
+  it('axios 에러에 errorCode 가 없으면 message 를 사용한다', () => {
+    const error = createAxiosError(undefined, 'Network Error');
+
+    expect(extractFailureReason(error)).toBe('Network Error');
+  });
+
+  it('일반 Error 인스턴스는 message 를 사용한다', () => {
+    expect(extractFailureReason(new Error('boom'))).toBe('boom');
+  });
+
+  it('string 을 그대로 전달하면 사유로 사용한다 (명시 reason 예: OAUTH_CANCELLED)', () => {
+    expect(extractFailureReason('OAUTH_CANCELLED')).toBe('OAUTH_CANCELLED');
+  });
+
+  it('알 수 없는 형태의 에러는 "unknown" 으로 폴백한다', () => {
+    expect(extractFailureReason(null)).toBe('unknown');
+    expect(extractFailureReason(undefined)).toBe('unknown');
+    expect(extractFailureReason(42)).toBe('unknown');
+    expect(extractFailureReason({})).toBe('unknown');
+  });
+
+  it('reason 은 100자를 초과하지 않는다', () => {
+    const longMessage = 'x'.repeat(500);
+
+    const fromString = extractFailureReason(longMessage);
+    const fromError = extractFailureReason(new Error(longMessage));
+    const fromAxios = extractFailureReason(createAxiosError({ errorCode: longMessage }));
+
+    expect(fromString).toHaveLength(100);
+    expect(fromError).toHaveLength(100);
+    expect(fromAxios).toHaveLength(100);
+  });
+});

--- a/src/lib/analytics/extractFailureReason.ts
+++ b/src/lib/analytics/extractFailureReason.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const MAX_REASON_LENGTH = 100;
+
+// GA4 의 `*_failed` 이벤트는 reason 파라미터를 카디널리티 안전한 짧은 문자열로 받는다.
+// 호출처에서 매번 분기/슬라이스하지 않도록 추출 로직을 한 곳에 모은다.
+export const extractFailureReason = (error: unknown): string => {
+  if (typeof error === 'string') return error.slice(0, MAX_REASON_LENGTH);
+
+  if (axios.isAxiosError(error)) {
+    const errorCode = error.response?.data?.errorCode;
+    if (typeof errorCode === 'string' && errorCode.length > 0) return errorCode.slice(0, MAX_REASON_LENGTH);
+    if (error.message) return error.message.slice(0, MAX_REASON_LENGTH);
+  }
+
+  if (error instanceof Error && error.message) return error.message.slice(0, MAX_REASON_LENGTH);
+
+  return 'unknown';
+};

--- a/src/lib/analytics/gathering.test.ts
+++ b/src/lib/analytics/gathering.test.ts
@@ -1,9 +1,11 @@
 import { trackEvent } from './index';
 import {
   resolveGatheringEntrySource,
+  trackGatheringCreateFailed,
   trackGatheringCreateStart,
   trackGatheringCreateSubmit,
   trackGatheringJoin,
+  trackGatheringJoinFailed,
   trackGatheringSearch,
   trackGatheringView,
 } from './gathering';
@@ -81,6 +83,33 @@ describe('lib/analytics/gathering', () => {
       expect(trackEventMock).toHaveBeenCalledWith('join_gathering', {
         gathering_id: '42',
         category: '스터디',
+      });
+    });
+  });
+
+  describe('trackGatheringCreateFailed', () => {
+    it('category / reason 과 함께 create_gathering_failed 이벤트를 발사한다', () => {
+      trackGatheringCreateFailed({ category: '프로그래밍', error: new Error('VALIDATION_FAILED') });
+
+      expect(trackEventMock).toHaveBeenCalledWith('create_gathering_failed', {
+        category: '프로그래밍',
+        reason: 'VALIDATION_FAILED',
+      });
+    });
+  });
+
+  describe('trackGatheringJoinFailed', () => {
+    it('gathering_id / category / reason 과 함께 join_gathering_failed 이벤트를 발사한다', () => {
+      trackGatheringJoinFailed({
+        gatheringId: '42',
+        category: '스터디',
+        error: new Error('ALREADY_APPLIED'),
+      });
+
+      expect(trackEventMock).toHaveBeenCalledWith('join_gathering_failed', {
+        gathering_id: '42',
+        category: '스터디',
+        reason: 'ALREADY_APPLIED',
       });
     });
   });

--- a/src/lib/analytics/gathering.ts
+++ b/src/lib/analytics/gathering.ts
@@ -1,3 +1,4 @@
+import { extractFailureReason } from './extractFailureReason';
 import { trackEvent } from './index';
 
 import type { GatheringEntrySource } from './events';
@@ -42,6 +43,29 @@ interface TrackGatheringJoinParams {
 
 export const trackGatheringJoin = ({ gatheringId, category }: TrackGatheringJoinParams) => {
   trackEvent('join_gathering', { gathering_id: gatheringId, category });
+};
+
+interface TrackGatheringCreateFailedParams {
+  category: string;
+  error: unknown;
+}
+
+export const trackGatheringCreateFailed = ({ category, error }: TrackGatheringCreateFailedParams) => {
+  trackEvent('create_gathering_failed', { category, reason: extractFailureReason(error) });
+};
+
+interface TrackGatheringJoinFailedParams {
+  gatheringId: string;
+  category: string;
+  error: unknown;
+}
+
+export const trackGatheringJoinFailed = ({ gatheringId, category, error }: TrackGatheringJoinFailedParams) => {
+  trackEvent('join_gathering_failed', {
+    gathering_id: gatheringId,
+    category,
+    reason: extractFailureReason(error),
+  });
 };
 
 /**


### PR DESCRIPTION
## ❓ 이슈

- close #333

## ✍️ Description

GA4 Phase 3의 첫 PR. **활성화 깔때기에서 "어디서 빠지나"를 정량화**하기 위해 실패 이벤트 4종을 도입한다. Phase 2 에서 정착한 성공 경로(`sign_up`/`login`/`create_gathering_submit`/`join_gathering`)에 대응하는 `*_failed` 이벤트를 동일 mutation 의 onError 경로에 대칭 배치.

Sentry 와의 역할 분리는 유지한다 — **Sentry = 스택·replay 기반 디버깅, GA = 깔때기 누락 측정**.

### 추가된 이벤트 (`lib/analytics/events.ts`)

| 이벤트 | 파라미터 |
| --- | --- |
| `sign_up_failed` | `method`, `reason` |
| `login_failed` | `method`, `reason` |
| `create_gathering_failed` | `category`, `reason` |
| `join_gathering_failed` | `gathering_id`, `category`, `reason` |

### 신규 헬퍼

- `lib/analytics/extractFailureReason.ts` — `error: unknown → reason: string`
  - axios errorCode 우선 → message 슬라이스 → `'unknown'` 폴백, 100자 컷
  - 명시 string(`'OAUTH_CANCELLED'` 등) 도 그대로 통과
  - `lib/analytics/index.ts` 에는 재export 안 함 (circular import 회피, Phase 2 정착 패턴)
- `lib/analytics/auth.ts` — `trackAuthLoginFailed` / `trackAuthSignUpFailed`
- `lib/analytics/gathering.ts` — `trackGatheringCreateFailed` / `trackGatheringJoinFailed`

도메인 헬퍼 시그니처는 모두 **`error: unknown` 을 받는다**. 호출처에서 reason 추출을 누락하는 실수를 막기 위해 추출 책임을 헬퍼 안에 캡슐화.

### 호출처 7곳 (mutate onError 레벨)

| # | 위치 | 이벤트 |
| --- | --- | --- |
| 1 | `app/(auth)/register/EmailRegisterForm` onError | `sign_up_failed` (method=email) |
| 2 | `app/(auth)/login/EmailLoginForm` onError | `login_failed` (method=email) |
| 3 | `app/gatherings/new/CreateGatheringForm` onError | `create_gathering_failed` (수정 모드는 발사 안 함) |
| 4 | `app/gatherings/[id]/.../GatheringInfoAside` onError | `join_gathering_failed` |
| 5 | `app/gatherings/[id]/.../GatheringApplyBottomSheet` onError | `join_gathering_failed` |
| 6 | `app/auth/[provider]/callback/.../OAuthCallbackClient` mutation onError | `login_failed` (method=kakao/google) |
| 7 | 같은 파일, `code` 누락 분기 | `login_failed` (reason=`OAUTH_CANCELLED`) |

CLAUDE.md `tanstack-query.md` 규칙에 따라 모두 **`mutate()` 호출 레벨**에 배치(훅 내부 onSuccess 는 캐시 무효화 전용).

### 핵심 설계 결정

- **`category` 양쪽 다 포함** — `create_gathering_failed` / `join_gathering_failed` 모두 category 동봉. 일관성 + 카테고리별 실패율 분석 가치. 호출처에 이미 category 데이터 있음
- **OAuth 콜백 sign_up/login 분기 없음** — 신규/기존 유저 구분 불가능한 시점이라 `login_failed` 로 통합
- **OAuth 사용자 취소** — provider 화면에서 "취소" 시 redirect 로 돌아오면서 `code` 누락. `error: 'OAUTH_CANCELLED'` 로 발사 + ref 가드로 1회만
- **OAuth `/users/me` 보강 실패 제외** — OAuth 자체는 성공, 식별 누락 → Sentry 영역. 깔때기 통계 왜곡 방지 (코드 그대로 둠)
- **`create_gathering_failed` 수정 모드 제외** — 성공 경로(`create_gathering_submit`)와 대칭. 수정은 새 모임 생성이 아님
- **reason 100자 컷** — GA4 카디널리티 안전. 긴 stacktrace/HTML body 가 묻어 들어가도 잘림

### 동작 매트릭스

| 시나리오 | 발사되는 이벤트 |
| --- | --- |
| 이메일 회원가입 실패 (닉네임/이메일 중복 등) | `sign_up_failed` (method=email, reason=서버 errorCode) |
| 이메일 로그인 실패 (자격증명 불일치) | `login_failed` (method=email, reason=서버 errorCode) |
| 카카오/구글 OAuth 콜백 실패 (서버 5xx 등) | `login_failed` (method=kakao\|google, reason=서버 errorCode 또는 message) |
| 카카오/구글 동의 화면에서 "취소" | `login_failed` (method=…, reason=`OAUTH_CANCELLED`) |
| 모임 생성 제출 실패 | `create_gathering_failed` (category, reason) |
| 모임 수정 실패 | (발사 안 함) |
| 모임 참여 신청 실패 (PC/모바일 양쪽) | `join_gathering_failed` (gathering_id, category, reason) |

### 후속 작업

- **GA4 콘솔 (코드 외, 머지 후 직접)** — 측정기준(이벤트 범위) `reason` 등록. 실패 이벤트는 **주요 이벤트 마킹 안 함** (전환 아님)
- **Phase 3 PR 2** — 회의·대시보드·공유 이벤트 (view_dashboard / enter_meeting / share_gathering)

## 📸 스크린샷 (UI 변경 시)

해당 없음 (UI 변경 없음, 행동 추적 부착만).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-198`)
- [x] Base Branch 확인 (`dev`)
- [x] 적절한 Label 지정 (`feature`)
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (단위 테스트 38/38 통과 — `npx jest src/lib/analytics`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)