### PR TITLE
[SM-199] feat: GA4 도입 Phase 3 - 회의·대시보드·공유 이벤트(view_dashboard/enter_meeting/share_gathering)

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/FloatingActionBar/index.tsx
@@ -12,6 +12,7 @@ import { AuthModal } from '@/components/AuthModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useOverlay } from '@/hooks/useOverlay';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { trackGatheringShare } from '@/lib/analytics/gathering';
 
 import { GatheringApplyBottomSheet } from './GatheringApplyBottomSheet';
 
@@ -64,6 +65,8 @@ export function FloatingActionBar({ gatheringId }: FloatingActionBarProps) {
                 // 잘못된 source 로 분류되므로 origin + path 로 재구성해 깔끔한 URL 만 공유한다.
                 const shareUrl = `${window.location.origin}/gatherings/${gatheringId}`;
                 await navigator.clipboard.writeText(shareUrl);
+                // TODO: 카카오/트위터 공유 UI 추가 시 channel 분기 (현재는 link_copy 만 지원)
+                trackGatheringShare({ gatheringId: String(gatheringId), channel: 'link_copy' });
                 showToast({ variant: 'success', title: '링크가 복사되었습니다.' });
                 return;
               }

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -23,7 +23,7 @@ import { GatheringApplyForm } from '../GatheringApplyForm';
 import { GatheringApplySuccess } from '../GatheringApplySuccess';
 
 import { getGatheringDisplayStatus, getJoinButtonText } from '@/lib/gatheringStatus';
-import { trackGatheringJoin, trackGatheringJoinFailed } from '@/lib/analytics/gathering';
+import { trackGatheringJoin, trackGatheringJoinFailed, trackGatheringShare } from '@/lib/analytics/gathering';
 
 import type { GatheringType } from '@/api/gatherings/types';
 
@@ -172,6 +172,8 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
                   // 잘못된 source 로 분류되므로 origin + path 로 재구성해 깔끔한 URL 만 공유한다.
                   const shareUrl = `${window.location.origin}/gatherings/${gatheringId}`;
                   await navigator.clipboard.writeText(shareUrl);
+                  // TODO: 카카오/트위터 공유 UI 추가 시 channel 분기 (현재는 link_copy 만 지원)
+                  trackGatheringShare({ gatheringId: String(gatheringId), channel: 'link_copy' });
                   showToast({ variant: 'success', title: '링크가 복사되었습니다.' });
                   return;
                 }

--- a/src/app/gatherings/[id]/dashboard/_components/DashboardViewTracker/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/DashboardViewTracker/index.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { trackGatheringDashboardView } from '@/lib/analytics/gathering';
+
+import type { DashboardTab } from '../../_constants';
+
+interface DashboardViewTrackerProps {
+  gatheringId: number;
+  tab: DashboardTab;
+}
+
+// 페이지 진입(직접 URL/내부 navigation 모두) + 탭 변경 시마다 1회 발사.
+// 탭은 ?tab= 쿼리로만 바뀌고 page.tsx 가 re-render 되어 이 컴포넌트의 props 가 갱신되므로
+// deps 에 [tab, gatheringId] 만 두면 충분하다. 동일 tab 내 재마운트는 effect 가 같은 deps 로
+// 다시 실행되지만 view_dashboard 는 "탭별 활성도" 신호라 의도된 동작.
+export function DashboardViewTracker({ gatheringId, tab }: DashboardViewTrackerProps) {
+  useEffect(() => {
+    trackGatheringDashboardView({ gatheringId: String(gatheringId), tab });
+  }, [gatheringId, tab]);
+
+  return null;
+}

--- a/src/app/gatherings/[id]/dashboard/_components/MeetingSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MeetingSection/index.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState } from 'react';
 
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { trackMeetingEnter } from '@/lib/analytics/meeting';
 
 import { getTokenErrorMessage } from './getTokenErrorMessage';
 import { MeetingContent } from './MeetingContent';
@@ -37,6 +38,7 @@ export function MeetingSection({ gatheringId }: MeetingSectionProps) {
 
       const data = await resp.json();
       if (data.token) {
+        trackMeetingEnter({ gatheringId: String(gatheringId) });
         setToken(data.token);
         setStatus('joined');
       } else {

--- a/src/app/gatherings/[id]/dashboard/page.tsx
+++ b/src/app/gatherings/[id]/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { DashboardContent } from './_components/DashboardContent';
 import { DashboardHeader } from './_components/DashboardHeader';
 import { DashboardSkeleton } from './_components/DashboardSkeleton';
 import { DashboardTabNav } from './_components/DashboardTabNav';
+import { DashboardViewTracker } from './_components/DashboardViewTracker';
 import { DEFAULT_TAB } from './_constants';
 
 import type { Metadata } from 'next';
@@ -59,6 +60,7 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
 
       <DashboardTabNav activeTab={activeTab} gatheringId={gatheringId} />
       <DashboardContent activeTab={activeTab} gatheringId={gatheringId} />
+      <DashboardViewTracker gatheringId={gatheringId} tab={activeTab} />
     </main>
   );
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -3,6 +3,19 @@
 export type AuthMethod = 'kakao' | 'google' | 'email';
 
 /**
+ * 대시보드 탭 식별자.
+ * `app/gatherings/[id]/dashboard/_constants.ts` 의 `DashboardTab` 과 동기화.
+ */
+export type DashboardTab = 'summary' | 'weekly' | 'members' | 'meeting';
+
+/**
+ * 모임 공유 채널.
+ * - link_copy: 클립보드 복사 (현재 구현)
+ * - kakao / twitter: 향후 외부 공유 UI 추가 시 사용
+ */
+export type ShareChannel = 'kakao' | 'link_copy' | 'twitter';
+
+/**
  * 모임 상세 페이지로 진입한 경로.
  * - search: 검색 결과에서 클릭
  * - recommendation: 메인 페이지 추천 섹션에서 클릭
@@ -34,6 +47,9 @@ export interface AnalyticsEventMap {
   login_failed: { method: AuthMethod; reason: string };
   create_gathering_failed: { category: string; reason: string };
   join_gathering_failed: { gathering_id: string; category: string; reason: string };
+  view_dashboard: { gathering_id: string; tab: DashboardTab };
+  enter_meeting: { gathering_id: string };
+  share_gathering: { gathering_id: string; channel: ShareChannel };
 }
 
 export interface UserProperties {

--- a/src/lib/analytics/gathering.test.ts
+++ b/src/lib/analytics/gathering.test.ts
@@ -4,9 +4,11 @@ import {
   trackGatheringCreateFailed,
   trackGatheringCreateStart,
   trackGatheringCreateSubmit,
+  trackGatheringDashboardView,
   trackGatheringJoin,
   trackGatheringJoinFailed,
   trackGatheringSearch,
+  trackGatheringShare,
   trackGatheringView,
 } from './gathering';
 
@@ -110,6 +112,28 @@ describe('lib/analytics/gathering', () => {
         gathering_id: '42',
         category: '스터디',
         reason: 'ALREADY_APPLIED',
+      });
+    });
+  });
+
+  describe('trackGatheringDashboardView', () => {
+    it('gathering_id / tab 과 함께 view_dashboard 이벤트를 발사한다', () => {
+      trackGatheringDashboardView({ gatheringId: '42', tab: 'meeting' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('view_dashboard', {
+        gathering_id: '42',
+        tab: 'meeting',
+      });
+    });
+  });
+
+  describe('trackGatheringShare', () => {
+    it('gathering_id / channel 과 함께 share_gathering 이벤트를 발사한다', () => {
+      trackGatheringShare({ gatheringId: '42', channel: 'link_copy' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('share_gathering', {
+        gathering_id: '42',
+        channel: 'link_copy',
       });
     });
   });

--- a/src/lib/analytics/gathering.ts
+++ b/src/lib/analytics/gathering.ts
@@ -1,7 +1,7 @@
 import { extractFailureReason } from './extractFailureReason';
 import { trackEvent } from './index';
 
-import type { GatheringEntrySource } from './events';
+import type { DashboardTab, GatheringEntrySource, ShareChannel } from './events';
 
 interface TrackGatheringSearchParams {
   query: string;
@@ -66,6 +66,24 @@ export const trackGatheringJoinFailed = ({ gatheringId, category, error }: Track
     category,
     reason: extractFailureReason(error),
   });
+};
+
+interface TrackGatheringDashboardViewParams {
+  gatheringId: string;
+  tab: DashboardTab;
+}
+
+export const trackGatheringDashboardView = ({ gatheringId, tab }: TrackGatheringDashboardViewParams) => {
+  trackEvent('view_dashboard', { gathering_id: gatheringId, tab });
+};
+
+interface TrackGatheringShareParams {
+  gatheringId: string;
+  channel: ShareChannel;
+}
+
+export const trackGatheringShare = ({ gatheringId, channel }: TrackGatheringShareParams) => {
+  trackEvent('share_gathering', { gathering_id: gatheringId, channel });
 };
 
 /**

--- a/src/lib/analytics/meeting.test.ts
+++ b/src/lib/analytics/meeting.test.ts
@@ -1,0 +1,22 @@
+import { trackEvent } from './index';
+import { trackMeetingEnter } from './meeting';
+
+jest.mock('./index', () => ({
+  trackEvent: jest.fn(),
+}));
+
+describe('lib/analytics/meeting', () => {
+  const trackEventMock = trackEvent as jest.Mock;
+
+  beforeEach(() => {
+    trackEventMock.mockClear();
+  });
+
+  describe('trackMeetingEnter', () => {
+    it('gathering_id 와 함께 enter_meeting 이벤트를 발사한다', () => {
+      trackMeetingEnter({ gatheringId: '42' });
+
+      expect(trackEventMock).toHaveBeenCalledWith('enter_meeting', { gathering_id: '42' });
+    });
+  });
+});

--- a/src/lib/analytics/meeting.ts
+++ b/src/lib/analytics/meeting.ts
@@ -1,0 +1,11 @@
+import { trackEvent } from './index';
+
+interface TrackMeetingEnterParams {
+  gatheringId: string;
+}
+
+// LiveKit 토큰 발급 성공 직후 = 회의 실제 입장 시점 1회 발사.
+// 대시보드 "회의" 탭 진입(view_dashboard tab=meeting)과 회의 참석은 다른 의도이므로 별도 이벤트.
+export const trackMeetingEnter = ({ gatheringId }: TrackMeetingEnterParams) => {
+  trackEvent('enter_meeting', { gathering_id: gatheringId });
+};


### PR DESCRIPTION
## ❓ 이슈

- close #335

## ✍️ Description

GA4 Phase 3 두 번째 PR. 활성화 *이후* 동선(대시보드·회의)과 자발적 공유 시그널을 측정해 **리텐션·바이럴리티 지표를 정량화**한다.

### 추가된 이벤트 (`lib/analytics/events.ts`)

| 이벤트 | 파라미터 |
| --- | --- |
| `view_dashboard` | `gathering_id`, `tab` (`summary` \| `weekly` \| `members` \| `meeting`) |
| `enter_meeting` | `gathering_id` |
| `share_gathering` | `gathering_id`, `channel` (`kakao` \| `link_copy` \| `twitter`) |

### 발사 지점

| 이벤트 | 위치 | 시점 |
| --- | --- | --- |
| `view_dashboard` | `dashboard/_components/DashboardViewTracker` (신규 `'use client'`) | 대시보드 진입 + 탭 변경 시마다 `useEffect [tab, gatheringId]` 로 발사 |
| `enter_meeting` | `dashboard/_components/MeetingSection` | LiveKit 토큰 발급 성공 직후 (`setStatus('joined')` 직전) |
| `share_gathering` | `ApplySection/GatheringInfoAside` + `ApplySection/FloatingActionBar` | 모임장 "공유하기" 클릭 → `clipboard.writeText` 성공 직후 (channel=`link_copy`) |

### 핵심 설계 결정

- **`view_dashboard` 는 서버 컴포넌트 page.tsx 에 직접 못 박음** → 별도 `'use client'` tracker 컴포넌트(`DashboardViewTracker`)를 mount. 첫 진입(직접 URL/내부 navigation) + 탭 변경 모두 균일하게 잡음
- **`view_dashboard(tab=meeting)` 과 `enter_meeting` 둘 다 박는 이유** — 두 이벤트가 같이 있을 때 *회의 깔때기* 가 생긴다. `tab=meeting` 진입 → `enter_meeting` 전환율로 "회의 탭은 보지만 실제 참석 안 함" 양 측정. 회의 기능 개선 우선순위 판단 신호. GA4 표준 `form_view → form_submit` 과 동일 패턴
- **`enter_meeting` 위치** — LiveKit 토큰 발급 성공 직후. 회의 탭 호기심 클릭은 잡지 않고 *실제 입장 의도가 토큰까지 받은* 시점만 잡음
- **`share_gathering` 1:1 유입 매칭 의도적 제외** — SM-195 의 *깨끗한 공유 URL* 정책 유지 (`?utm_*` strip). 자발적 P2P 추천은 ROI 측정 대상이 아닌 정성 시그널이라 클릭 카운트로 충분. 외부 referrer 는 GA4 자동 `page_referrer` 가 부분 캡처. referral 프로그램 도입 시점에 재검토 거리
- **카카오/트위터 공유** — UI 가 아직 없어 현재는 `channel='link_copy'` 만. 두 호출 지점에 TODO 주석으로 채널 확장 지점 표시
- **`meeting.ts` 신규 도메인 파일** — `gathering.ts` 에 회의 헬퍼를 섞지 않고 새 파일. 헬퍼 위치 정착 패턴(`lib/analytics/<domain>.ts`) 유지

### 동작 매트릭스

| 시나리오 | view_dashboard | enter_meeting | share_gathering |
| --- | --- | --- | --- |
| 대시보드 진입 (summary) | ✅ tab=summary | ❌ | ❌ |
| 회의 탭 호기심 클릭 후 이탈 | ✅ tab=meeting | ❌ | ❌ |
| 회의 탭 클릭 → "참여" 버튼 → 토큰 발급 성공 | ✅ tab=meeting | ✅ | ❌ |
| LiveKit 토큰 발급 실패 (5xx 등) | ✅ tab=meeting | ❌ | ❌ |
| 모임장 "공유하기" 클릭 (PC/모바일) | - | - | ✅ channel=link_copy |

### 수정·신규 파일

| 파일 | 변경 |
| --- | --- |
| `lib/analytics/events.ts` | `DashboardTab` / `ShareChannel` 타입 + 3 이벤트 추가 |
| `lib/analytics/gathering.ts` | `trackGatheringDashboardView` / `trackGatheringShare` 추가 |
| `lib/analytics/gathering.test.ts` | 2 케이스 추가 |
| `lib/analytics/meeting.ts` | **신규** — `trackMeetingEnter` |
| `lib/analytics/meeting.test.ts` | **신규** — 1 케이스 |
| `dashboard/_components/DashboardViewTracker/index.tsx` | **신규** — `'use client'` tracker |
| `dashboard/page.tsx` | tracker mount |
| `dashboard/_components/MeetingSection/index.tsx` | 토큰 발급 직후 `enter_meeting` 발사 |
| `ApplySection/GatheringInfoAside/index.tsx` | 공유 클릭 시 `share_gathering` 발사 |
| `ApplySection/FloatingActionBar/index.tsx` | 동일 (모바일) |

### 후속 작업

- **GA4 콘솔 (코드 외, 머지 후 직접)** — 측정기준 등록: `tab`, `channel`. `enter_meeting` / `view_dashboard` 의 주요 이벤트 마킹 여부는 활성화 정의에 따라 별도 결정
- **Phase 3 PR 3** — 품질/시스템 (`web_vitals`, `error_boundary`)

## 📸 스크린샷 (UI 변경 시)

해당 없음 (UI 변경 없음, 행동 추적 부착만).

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-199`)
- [x] Base Branch 확인 (`dev`)
- [x] 적절한 Label 지정 (`feature`)
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (단위 테스트 41/41 통과 — `npx jest src/lib/analytics`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)