### PR TITLE
[SM-200] feat: 메인/탐색 페이지 빈 모임 섹션 EmptyState 도입

### DIFF
--- a/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
+++ b/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
 import { Pagination } from '@/components/ui/Pagination';
 
@@ -11,6 +12,7 @@ import { useDeadlineGatherings } from './useDeadlineGatherings';
 export function DeadlineGatheringList() {
   const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings } = useDeadlineGatherings();
+  const isEmpty = visibleGatherings.length === 0;
 
   const handleJoin = (id: number) => {
     router.push(`/gatherings/${id}?source=recommendation`);
@@ -24,23 +26,34 @@ export function DeadlineGatheringList() {
           <Link href='/gatherings?sort=deadline' className='text-body-02-m text-gray-600'>
             더보기
           </Link>
-          <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          {!isEmpty && (
+            <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          )}
         </div>
       </div>
-      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
-        {visibleGatherings.map((gathering) => (
-          <MainGatheringCard
-            key={gathering.id}
-            gathering={gathering}
-            joinButtonLabel='참여하기'
-            joinButtonClassName=''
-            isJoinDisabled={false}
-            initialFavorite={false}
-            onJoin={() => handleJoin(gathering.id)}
-            className=''
-          />
-        ))}
-      </div>
+      {isEmpty ? (
+        <EmptyState
+          emoji='⏰'
+          title='마감 임박 모임이 없어요'
+          description='마감까지 같이 갈 동료, 직접 모아 보세요'
+          action={{ label: '모임 만들기', href: '/gatherings/new' }}
+        />
+      ) : (
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
+          {visibleGatherings.map((gathering) => (
+            <MainGatheringCard
+              key={gathering.id}
+              gathering={gathering}
+              joinButtonLabel='참여하기'
+              joinButtonClassName=''
+              isJoinDisabled={false}
+              initialFavorite={false}
+              onJoin={() => handleJoin(gathering.id)}
+              className=''
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
+++ b/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
@@ -22,14 +22,14 @@ export function DeadlineGatheringList() {
     <div>
       <div className='mb-4 flex items-center justify-between'>
         <h2 className='text-body-01-b md:text-h4-b lg:text-h3-b text-gray-900'>마감 임박 모임⏰</h2>
-        <div className='flex items-center gap-3 md:gap-6'>
-          <Link href='/gatherings?sort=deadline' className='text-body-02-m text-gray-600'>
-            더보기
-          </Link>
-          {!isEmpty && (
+        {!isEmpty && (
+          <div className='flex items-center gap-3 md:gap-6'>
+            <Link href='/gatherings?sort=deadline' className='text-body-02-m text-gray-600'>
+              더보기
+            </Link>
             <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
-          )}
-        </div>
+          </div>
+        )}
       </div>
       {isEmpty ? (
         <EmptyState

--- a/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
+++ b/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
@@ -22,14 +22,14 @@ export function LatestGatheringList() {
     <div>
       <div className='mb-4 flex items-center justify-between'>
         <h2 className='text-body-01-b md:text-h4-b lg:text-h3-b text-gray-900'>최신 모임👀</h2>
-        <div className='flex items-center gap-3 md:gap-6'>
-          <Link href='/gatherings' className='text-body-02-b text-gray-500'>
-            더보기
-          </Link>
-          {!isEmpty && (
+        {!isEmpty && (
+          <div className='flex items-center gap-3 md:gap-6'>
+            <Link href='/gatherings' className='text-body-02-b text-gray-500'>
+              더보기
+            </Link>
             <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
-          )}
-        </div>
+          </div>
+        )}
       </div>
       {isEmpty ? (
         <EmptyState

--- a/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
+++ b/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
 import { Pagination } from '@/components/ui/Pagination';
 
@@ -11,6 +12,7 @@ import { useLatestGatherings } from './useLatestGatherings';
 export function LatestGatheringList() {
   const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings } = useLatestGatherings();
+  const isEmpty = visibleGatherings.length === 0;
 
   const handleJoin = (id: number) => {
     router.push(`/gatherings/${id}?source=recommendation`);
@@ -24,23 +26,34 @@ export function LatestGatheringList() {
           <Link href='/gatherings' className='text-body-02-b text-gray-500'>
             더보기
           </Link>
-          <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          {!isEmpty && (
+            <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          )}
         </div>
       </div>
-      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
-        {visibleGatherings.map((gathering) => (
-          <MainGatheringCard
-            key={gathering.id}
-            gathering={gathering}
-            joinButtonLabel='참여하기'
-            joinButtonClassName=''
-            isJoinDisabled={false}
-            initialFavorite={false}
-            onJoin={() => handleJoin(gathering.id)}
-            className=''
-          />
-        ))}
-      </div>
+      {isEmpty ? (
+        <EmptyState
+          emoji='👀'
+          title='새로 올라온 모임이 없어요'
+          description='오늘 시작하는 모임이 다음 완성의 출발점이 됩니다'
+          action={{ label: '모임 만들기', href: '/gatherings/new' }}
+        />
+      ) : (
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
+          {visibleGatherings.map((gathering) => (
+            <MainGatheringCard
+              key={gathering.id}
+              gathering={gathering}
+              joinButtonLabel='참여하기'
+              joinButtonClassName=''
+              isJoinDisabled={false}
+              initialFavorite={false}
+              onJoin={() => handleJoin(gathering.id)}
+              className=''
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/main/components/MyGatheringSection/MyGatheringList/index.tsx
+++ b/src/app/main/components/MyGatheringSection/MyGatheringList/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { MembershipGathering } from '@/api/memberships/types';
 import { EmptyState } from '@/components/EmptyState';
 import { Pagination } from '@/components/ui/Pagination';
+
 import { MyGatheringCard } from '../MyGatheringCard';
 import { useMyGatheringList } from './useMyGatheringList';
 
@@ -22,14 +23,14 @@ export function MyGatheringList() {
     <div>
       <div className='mb-4 flex items-center justify-between'>
         <h2 className='text-body-01-b md:text-h4-b lg:text-h3-b text-gray-900'>내 모임💡</h2>
-        <div className='flex items-center gap-3 md:gap-6'>
-          <Link href='/gatherings' className='text-body-02-b text-gray-500'>
-            더보기
-          </Link>
-          {!isEmpty && (
+        {!isEmpty && (
+          <div className='flex items-center gap-3 md:gap-6'>
+            <Link href='/gatherings' className='text-body-02-b text-gray-500'>
+              더보기
+            </Link>
             <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
-          )}
-        </div>
+          </div>
+        )}
       </div>
       {isEmpty ? (
         <EmptyState

--- a/src/app/main/components/MyGatheringSection/MyGatheringList/index.tsx
+++ b/src/app/main/components/MyGatheringSection/MyGatheringList/index.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { MembershipGathering } from '@/api/memberships/types';
+import { EmptyState } from '@/components/EmptyState';
 import { Pagination } from '@/components/ui/Pagination';
 import { MyGatheringCard } from '../MyGatheringCard';
 import { useMyGatheringList } from './useMyGatheringList';
@@ -11,6 +12,7 @@ import { useMyGatheringList } from './useMyGatheringList';
 export function MyGatheringList() {
   const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings, memberQueries } = useMyGatheringList();
+  const isEmpty = visibleGatherings.length === 0;
 
   const handleCardClick = (id: number) => {
     router.push(`/gatherings/${id}/dashboard`);
@@ -24,19 +26,30 @@ export function MyGatheringList() {
           <Link href='/gatherings' className='text-body-02-b text-gray-500'>
             더보기
           </Link>
-          <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          {!isEmpty && (
+            <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          )}
         </div>
       </div>
-      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
-        {visibleGatherings.map((gathering: MembershipGathering, index) => (
-          <MyGatheringCard
-            key={gathering.id}
-            gathering={gathering}
-            members={memberQueries[index].data.members}
-            onClick={() => handleCardClick(gathering.id)}
-          />
-        ))}
-      </div>
+      {isEmpty ? (
+        <EmptyState
+          emoji='💡'
+          title='아직 참여 중인 모임이 없어요'
+          description='관심 있는 분야의 모임을 찾아, 동료와 함께 완성해 봐요'
+          action={{ label: '모임 탐색하기', href: '/gatherings' }}
+        />
+      ) : (
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
+          {visibleGatherings.map((gathering: MembershipGathering, index) => (
+            <MyGatheringCard
+              key={gathering.id}
+              gathering={gathering}
+              members={memberQueries[index].data.members}
+              onClick={() => handleCardClick(gathering.id)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
+++ b/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
 import { Pagination } from '@/components/ui/Pagination';
 
@@ -11,6 +12,7 @@ import { usePopularGatherings } from './usePopularGatherings';
 export function PopularGatheringList() {
   const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings } = usePopularGatherings();
+  const isEmpty = visibleGatherings.length === 0;
 
   const handleJoin = (id: number) => {
     router.push(`/gatherings/${id}?source=recommendation`);
@@ -24,23 +26,34 @@ export function PopularGatheringList() {
           <Link href='/gatherings?sort=popular' className='text-body-02-b text-gray-500'>
             더보기
           </Link>
-          <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          {!isEmpty && (
+            <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+          )}
         </div>
       </div>
-      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
-        {visibleGatherings.map((gathering) => (
-          <MainGatheringCard
-            key={gathering.id}
-            gathering={gathering}
-            joinButtonLabel='참여하기'
-            joinButtonClassName=''
-            isJoinDisabled={false}
-            initialFavorite={false}
-            onJoin={() => handleJoin(gathering.id)}
-            className=''
-          />
-        ))}
-      </div>
+      {isEmpty ? (
+        <EmptyState
+          emoji='🔥'
+          title='아직 모이고 있는 모임이 없어요'
+          description='혼자 마무리하기 어려운 일, 완성도와 끝까지 가봐요'
+          action={{ label: '모임 만들기', href: '/gatherings/new' }}
+        />
+      ) : (
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-6'>
+          {visibleGatherings.map((gathering) => (
+            <MainGatheringCard
+              key={gathering.id}
+              gathering={gathering}
+              joinButtonLabel='참여하기'
+              joinButtonClassName=''
+              isJoinDisabled={false}
+              initialFavorite={false}
+              onJoin={() => handleJoin(gathering.id)}
+              className=''
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
+++ b/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
@@ -22,14 +22,14 @@ export function PopularGatheringList() {
     <div>
       <div className='mb-4 flex items-center justify-between'>
         <h2 className='text-body-01-b md:text-h4-b lg:text-h3-b text-gray-900'>인기 모임🔥</h2>
-        <div className='flex items-center gap-3 md:gap-6'>
-          <Link href='/gatherings?sort=popular' className='text-body-02-b text-gray-500'>
-            더보기
-          </Link>
-          {!isEmpty && (
+        {!isEmpty && (
+          <div className='flex items-center gap-3 md:gap-6'>
+            <Link href='/gatherings?sort=popular' className='text-body-02-b text-gray-500'>
+              더보기
+            </Link>
             <Pagination variant='simple' currentPage={page} totalPages={totalPages} onPageChange={setPage} />
-          )}
-        </div>
+          </div>
+        )}
       </div>
       {isEmpty ? (
         <EmptyState

--- a/src/components/EmptyState/index.stories.tsx
+++ b/src/components/EmptyState/index.stories.tsx
@@ -56,6 +56,16 @@ export const Search: Story = {
   },
 };
 
+export const My: Story = {
+  name: '내 모임 빈 상태',
+  args: {
+    emoji: '💡',
+    title: '아직 참여 중인 모임이 없어요',
+    description: '관심 있는 분야의 모임을 찾아, 동료와 함께 완성해 봐요',
+    action: { label: '모임 탐색하기', href: '/gatherings' },
+  },
+};
+
 export const TitleOnly: Story = {
   name: '제목만 (description/action 없음)',
   args: {

--- a/src/components/EmptyState/index.stories.tsx
+++ b/src/components/EmptyState/index.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { EmptyState } from '.';
+
+const meta = {
+  title: 'components/EmptyState',
+  component: EmptyState,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const CTA = { label: '모임 만들기', href: '/gatherings/new' };
+
+export const Popular: Story = {
+  name: '인기 모임 빈 상태',
+  args: {
+    emoji: '🔥',
+    title: '아직 모이고 있는 모임이 없어요',
+    description: '혼자 마무리하기 어려운 일, 완성도와 끝까지 가봐요',
+    action: CTA,
+  },
+};
+
+export const Deadline: Story = {
+  name: '마감 임박 모임 빈 상태',
+  args: {
+    emoji: '⏰',
+    title: '마감 임박 모임이 없어요',
+    description: '마감까지 같이 갈 동료, 직접 모아 보세요',
+    action: CTA,
+  },
+};
+
+export const Latest: Story = {
+  name: '최신 모임 빈 상태',
+  args: {
+    emoji: '👀',
+    title: '새로 올라온 모임이 없어요',
+    description: '오늘 시작하는 모임이 다음 완성의 출발점이 됩니다',
+    action: CTA,
+  },
+};
+
+export const Search: Story = {
+  name: '탐색 검색 결과 없음',
+  args: {
+    title: '조건에 맞는 모임이 없어요',
+    description: '검색 조건을 바꾸거나, 직접 모임을 열어 동료를 모아 보세요',
+    action: CTA,
+  },
+};
+
+export const TitleOnly: Story = {
+  name: '제목만 (description/action 없음)',
+  args: {
+    title: '데이터가 없어요',
+  },
+};

--- a/src/components/EmptyState/index.test.tsx
+++ b/src/components/EmptyState/index.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+
+import { EmptyState } from '.';
+
+describe('EmptyState', () => {
+  describe('렌더링', () => {
+    it('title을 렌더링한다', () => {
+      render(<EmptyState title='모임이 없어요' />);
+
+      expect(screen.getByText('모임이 없어요')).toBeInTheDocument();
+    });
+
+    it('emoji가 있으면 렌더링한다', () => {
+      render(<EmptyState emoji='🔥' title='모임이 없어요' />);
+
+      expect(screen.getByText('🔥')).toBeInTheDocument();
+    });
+
+    it('emoji가 없으면 렌더링하지 않는다', () => {
+      render(<EmptyState title='모임이 없어요' />);
+
+      expect(screen.queryByText('🔥')).not.toBeInTheDocument();
+    });
+
+    it('description이 있으면 렌더링한다', () => {
+      render(<EmptyState title='모임이 없어요' description='새로 만들어 보세요' />);
+
+      expect(screen.getByText('새로 만들어 보세요')).toBeInTheDocument();
+    });
+
+    it('description이 없으면 렌더링하지 않는다', () => {
+      render(<EmptyState title='모임이 없어요' />);
+
+      expect(screen.queryByText('새로 만들어 보세요')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('action', () => {
+    it('action이 있으면 label과 href가 링크로 렌더링된다', () => {
+      render(<EmptyState title='모임이 없어요' action={{ label: '모임 만들기', href: '/gatherings/new' }} />);
+
+      const link = screen.getByRole('link', { name: '모임 만들기' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '/gatherings/new');
+    });
+
+    it('action이 없으면 링크를 렌더링하지 않는다', () => {
+      render(<EmptyState title='모임이 없어요' />);
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -15,7 +15,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ emoji, title, description, action, className }: EmptyStateProps) {
   return (
-    <div className={cn('flex flex-col items-center gap-3 px-4 py-16 text-center', className)}>
+    <div className={cn('flex flex-col items-center gap-3 px-4 py-16 text-center break-keep', className)}>
       {emoji && (
         <span aria-hidden='true' className='text-[40px] leading-none'>
           {emoji}

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+import { cn } from '@/lib/cn';
+
+interface EmptyStateProps {
+  emoji?: string;
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    href: string;
+  };
+  className?: string;
+}
+
+export function EmptyState({ emoji, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center gap-3 px-4 py-16 text-center', className)}>
+      {emoji && (
+        <span aria-hidden='true' className='text-[40px] leading-none'>
+          {emoji}
+        </span>
+      )}
+      <p className='text-body-01-b text-gray-900'>{title}</p>
+      {description && <p className='text-body-02-r text-gray-600'>{description}</p>}
+      {action && (
+        <Link
+          href={action.href}
+          className='bg-gradient-primary text-body-02-sb mt-2 inline-flex h-12 items-center justify-center rounded-lg px-6 text-white transition-colors'
+        >
+          {action.label}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
+import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
 import { GatheringFilterBar } from '@/components/Search/GatheringFilterBar';
 import { Pagination } from '@/components/ui/Pagination';
@@ -71,7 +72,11 @@ export function GatheringList() {
     return (
       <>
         <GatheringFilterBar totalCount={0} />
-        <p className='text-body-02-r py-20 text-center text-gray-500'>검색 결과가 없습니다.</p>
+        <EmptyState
+          title='조건에 맞는 모임이 없어요'
+          description='검색 조건을 바꾸거나, 직접 모임을 열어 동료를 모아 보세요'
+          action={{ label: '모임 만들기', href: '/gatherings/new' }}
+        />
       </>
     );
   }


### PR DESCRIPTION
## ❓ 이슈

- close #337

## ✍️ Description

메인페이지의 모든 모임 섹션(인기·마감임박·최신·**내 모임**)과 탐색 페이지 검색 결과 0건 케이스에 공통 `EmptyState` 컴포넌트를 도입했습니다. 빈 응답일 때 휑한 본문 대신 안내 문구와 CTA를 노출해, 사용자가 "왜 비어있지?"라는 혼란 대신 다음 행동으로 자연스럽게 이어지도록 합니다.

- 신규: `src/components/EmptyState/` (index.tsx · index.stories.tsx · index.test.tsx)
- 메인 4개 섹션은 빈 상태에서 **"더보기" 링크와 Pagination 화살표 모두 숨김**, 제목만 유지
- CTA는 섹션 의도에 맞게 분기:
  - 공개 섹션(인기/마감임박/최신) + 탐색 → "모임 만들기" → `/gatherings/new`
  - 내 모임 → "모임 탐색하기" → `/gatherings` (참여 모임이 없는 사용자의 자연스러운 첫 동선은 만들기보다 둘러보고 합류)
- 카피는 서비스명 "완성도" 톤을 직접 반영
- EmptyState 컨테이너에 `break-keep` 적용해 모바일에서 한국어를 어절 단위로 줄바꿈
- 새 아이콘 라이브러리 도입 없이 기존 제목 이모지(🔥⏰👀💡) 재사용, 탐색은 이모지 없이 적용

### 섹션별 카피
| 섹션 | emoji | title | description | CTA |
| --- | --- | --- | --- | --- |
| Popular | 🔥 | 아직 모이고 있는 모임이 없어요 | 혼자 마무리하기 어려운 일, 완성도와 끝까지 가봐요 | 모임 만들기 |
| Deadline | ⏰ | 마감 임박 모임이 없어요 | 마감까지 같이 갈 동료, 직접 모아 보세요 | 모임 만들기 |
| Latest | 👀 | 새로 올라온 모임이 없어요 | 오늘 시작하는 모임이 다음 완성의 출발점이 됩니다 | 모임 만들기 |
| My | 💡 | 아직 참여 중인 모임이 없어요 | 관심 있는 분야의 모임을 찾아, 동료와 함께 완성해 봐요 | 모임 탐색하기 |
| Search | (없음) | 조건에 맞는 모임이 없어요 | 검색 조건을 바꾸거나, 직접 모임을 열어 동료를 모아 보세요 | 모임 만들기 |

## 📸 스크린샷 (UI 변경 시)

<!-- 빈 응답 시뮬레이션 스크린샷 첨부 예정 -->

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [x] 빈 응답 mock으로 메인 4개 섹션·탐색 페이지 시각 검증 + 스크린샷 첨부
- [x] 반응형 mobile / tablet / desktop 어절 단위 줄바꿈·중앙 정렬 확인
- [x] CTA 라우팅 확인: "모임 만들기" → `/gatherings/new`, "모임 탐색하기" → `/gatherings`
- [x] Storybook 6개 variant 시각 확인 (Popular / Deadline / Latest / Search / My / TitleOnly)