### PR TITLE
[SM-203] fix: sailmate.store 이미지 도메인 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'chukjibeob.store',
       },
+      {
+        protocol: 'https',
+        hostname: 'sailmate.store',
+      },
       // prod에 MSW용 호스트가 섞이지 않도록 NODE_ENV로 이중 가드.
       ...(process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true'
         ? [


### PR DESCRIPTION
## ❓ 이슈

- close #346

## ✍️ Description

백엔드가 이미지 URL을 절대경로(`https://sailmate.store/images/...`)로 변경한 뒤, Next.js 이미지 최적화기가 미등록 외부 호스트를 거부(`INVALID_IMAGE_OPTIMIZE_REQUEST`)하여 프로필 이미지 등이 표시되지 않던 문제를 수정합니다.

- `next.config.ts`의 `images.remotePatterns`에 `{ protocol: 'https', hostname: 'sailmate.store' }` 추가

## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`fix/*`)
- [x] Base Branch 확인 (`dev`)
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)