### PR TITLE
[SM-205] refactor: 모임 대시보드 연속달성일수·주의 배지 개선

### DIFF
--- a/src/api/achievements/types.ts
+++ b/src/api/achievements/types.ts
@@ -10,6 +10,7 @@ export interface MemberAchievement {
   nickname: string;
   weeklyRates: WeeklyRate[];
   overallRate: number;
+  streakDays: number;
 }
 
 // GET /gatherings/:gatheringId/achievements 응답

--- a/src/app/gatherings/[id]/dashboard/_components/MemberBadge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberBadge/index.tsx
@@ -1,0 +1,22 @@
+import { StateIcon } from '@/components/ui/Icon';
+import { Tag } from '@/components/ui/Tag';
+
+interface MemberBadgeProps {
+  type: 'streak' | 'warning';
+  label: string;
+}
+
+export function MemberBadge({ type, label }: MemberBadgeProps) {
+  const isStreak = type === 'streak';
+
+  return (
+    <Tag
+      variant='info'
+      state={isStreak ? 'good' : 'bad'}
+      className='md:text-small-02-m text-small-03-r h-4.25 rounded px-1.5 py-0 leading-none md:h-6.75 md:rounded-lg md:px-3 md:py-1'
+    >
+      <StateIcon variant={isStreak ? 'active' : 'warning'} className='h-3 w-3 md:h-4 md:w-4' />
+      <span className='translate-y-px'>{label}</span>
+    </Tag>
+  );
+}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberBadge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberBadge/index.tsx
@@ -1,6 +1,9 @@
 import { StateIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 
+export const WARNING_THRESHOLD = 50;
+export const MIN_WEEKS_FOR_WARNING = 2;
+
 interface MemberBadgeProps {
   type: 'streak' | 'warning';
   label: string;

--- a/src/app/gatherings/[id]/dashboard/_components/MemberListSection/MemberCard/Badge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberListSection/MemberCard/Badge/index.tsx
@@ -1,22 +1,3 @@
-import { StateIcon } from '@/components/ui/Icon';
-import { Tag } from '@/components/ui/Tag';
-
-interface MemberBadgeProps {
-  type: 'streak' | 'warning';
-  label: string;
-}
-
-export function MemberBadge({ type, label }: MemberBadgeProps) {
-  const isStreak = type === 'streak';
-
-  return (
-    <Tag variant='info' state={isStreak ? 'good' : 'bad'}>
-      <StateIcon variant={isStreak ? 'active' : 'warning'} size={14} />
-      {label}
-    </Tag>
-  );
-}
-
 export function MeBadge() {
   return (
     <span className='text-small-02-sb md:text-body-02-sb inline-flex size-8 items-center justify-center rounded-[12px] bg-blue-100 text-blue-300 md:size-12'>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberListSection/MemberCard/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberListSection/MemberCard/index.tsx
@@ -4,7 +4,8 @@ import { HandIcon } from '@/components/ui/Icon';
 import { Button } from '@/components/ui/Button';
 
 import { ReviewButton } from '../ReviewButton';
-import { MemberBadge, MeBadge } from './Badge';
+import { MemberBadge } from '../../MemberBadge';
+import { MeBadge } from './Badge';
 
 import type { Member } from '@/api/memberships/types';
 

--- a/src/app/gatherings/[id]/dashboard/_components/MemberListSection/useMemberList.ts
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberListSection/useMemberList.ts
@@ -15,7 +15,6 @@ import type { Member } from '@/api/memberships/types';
 const MEMBERS_PER_PAGE = 10;
 const WARNING_ACHIEVEMENT_THRESHOLD = 0.5; // 50% 이하면 주의 배지 (현재 주차 기준)
 const MIN_WEEKS_FOR_WARNING = 2;
-const DAYS_PER_WEEK = 7;
 
 export const useMemberList = (gatheringId: number) => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -57,21 +56,9 @@ export const useMemberList = (gatheringId: number) => {
       return { type: 'warning', label: '주의' };
     }
 
-    const STREAK_WEEKS_THRESHOLD = 2;
     const memberAchievement = achievementData.members.find((m: MemberAchievement) => m.userId === member.userId);
-    if (memberAchievement) {
-      let streak = 0;
-      for (let w = currentWeek; w >= 1; w--) {
-        const weekRate = memberAchievement.weeklyRates.find((wr) => wr.week === w);
-        if (weekRate && weekRate.rate > 0) {
-          streak++;
-        } else {
-          break;
-        }
-      }
-      if (streak >= STREAK_WEEKS_THRESHOLD) {
-        return { type: 'streak', label: `${streak * DAYS_PER_WEEK}일` };
-      }
+    if (memberAchievement && memberAchievement.streakDays > 0) {
+      return { type: 'streak', label: `${memberAchievement.streakDays}일` };
     }
 
     return { type: null, label: '' };

--- a/src/app/gatherings/[id]/dashboard/_components/MemberListSection/useMemberList.ts
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberListSection/useMemberList.ts
@@ -9,12 +9,12 @@ import { reviewQueries } from '@/api/reviews/queries';
 import { useAuth } from '@/hooks/useAuth';
 import { getCurrentWeek, getRemainingDays } from '@/lib/formatGatheringDate';
 
+import { MIN_WEEKS_FOR_WARNING, WARNING_THRESHOLD } from '../MemberBadge';
+
 import type { MemberAchievement } from '@/api/achievements/types';
 import type { Member } from '@/api/memberships/types';
 
 const MEMBERS_PER_PAGE = 10;
-const WARNING_ACHIEVEMENT_THRESHOLD = 50;
-const MIN_WEEKS_FOR_WARNING = 2;
 
 export const useMemberList = (gatheringId: number) => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -49,7 +49,7 @@ export const useMemberList = (gatheringId: number) => {
   };
 
   const getBadgeInfo = (member: Member): { type: 'streak' | 'warning' | null; label: string } => {
-    if (member.overallAchievementRate < WARNING_ACHIEVEMENT_THRESHOLD && currentWeek >= MIN_WEEKS_FOR_WARNING) {
+    if (member.overallAchievementRate < WARNING_THRESHOLD && currentWeek >= MIN_WEEKS_FOR_WARNING) {
       return { type: 'warning', label: '주의' };
     }
 

--- a/src/app/gatherings/[id]/dashboard/_components/MemberListSection/useMemberList.ts
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberListSection/useMemberList.ts
@@ -13,7 +13,7 @@ import type { MemberAchievement } from '@/api/achievements/types';
 import type { Member } from '@/api/memberships/types';
 
 const MEMBERS_PER_PAGE = 10;
-const WARNING_ACHIEVEMENT_THRESHOLD = 0.5; // 50% 이하면 주의 배지 (현재 주차 기준)
+const WARNING_ACHIEVEMENT_THRESHOLD = 50;
 const MIN_WEEKS_FOR_WARNING = 2;
 
 export const useMemberList = (gatheringId: number) => {
@@ -49,10 +49,7 @@ export const useMemberList = (gatheringId: number) => {
   };
 
   const getBadgeInfo = (member: Member): { type: 'streak' | 'warning' | null; label: string } => {
-    const achievedWeeks = getAchievedWeeks(member.userId);
-    const achievementRatio = currentWeek > 0 ? achievedWeeks / currentWeek : 0;
-
-    if (achievementRatio <= WARNING_ACHIEVEMENT_THRESHOLD && currentWeek >= MIN_WEEKS_FOR_WARNING) {
+    if (member.overallAchievementRate < WARNING_ACHIEVEMENT_THRESHOLD && currentWeek >= MIN_WEEKS_FOR_WARNING) {
       return { type: 'warning', label: '주의' };
     }
 

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
@@ -7,7 +7,7 @@ import { HandIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { useFallbackImage } from '@/hooks/useFallbackImage';
 
-import { MemberBadge } from '../../MemberBadge';
+import { MemberBadge, MIN_WEEKS_FOR_WARNING, WARNING_THRESHOLD } from '../../MemberBadge';
 import { RankBadge } from '../RankBadge';
 
 import type { AchievementRankingItem } from '@/api/achievements/types';
@@ -18,9 +18,6 @@ interface RankingItemProps {
   streakDays: number;
   currentWeek: number;
 }
-
-const WARNING_THRESHOLD = 50;
-const MIN_WEEKS_FOR_WARNING = 2;
 
 export function RankingItem({ item, isMe, streakDays, currentWeek }: RankingItemProps) {
   const { imgSrc, onError } = useFallbackImage(item.profileImage);

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
@@ -15,11 +15,12 @@ import type { AchievementRankingItem } from '@/api/achievements/types';
 interface RankingItemProps {
   item: AchievementRankingItem;
   isMe: boolean;
+  streakDays: number;
 }
 
 const WARNING_THRESHOLD = 50;
 
-export function RankingItem({ item, isMe }: RankingItemProps) {
+export function RankingItem({ item, isMe, streakDays }: RankingItemProps) {
   const { imgSrc, onError } = useFallbackImage(item.profileImage);
   const isWarning = item.overallRate < WARNING_THRESHOLD;
 
@@ -38,7 +39,7 @@ export function RankingItem({ item, isMe }: RankingItemProps) {
           <div className='flex items-center justify-between'>
             <div className='flex items-center gap-1 md:gap-2'>
               <span className='text-small-02-m md:text-body-01-m text-gray-900'>{item.nickname}</span>
-              {isWarning ? (
+              {isWarning && (
                 <Tag
                   variant='deadline'
                   state='warning'
@@ -47,14 +48,15 @@ export function RankingItem({ item, isMe }: RankingItemProps) {
                   <StateIcon variant='warning' className='h-3 w-3 md:h-4 md:w-4' />
                   주의
                 </Tag>
-              ) : (
+              )}
+              {!isWarning && streakDays > 0 && (
                 <Tag
                   variant='deadline'
                   state='goal'
                   className='md:text-small-02-m gap-0.3 flex h-[17px] w-10 px-1.5 py-0 text-[10px] md:h-[27px] md:w-[66px] md:gap-1 md:px-3 md:py-1'
                 >
                   <StateIcon variant='active' className='h-3 w-3 md:h-4 md:w-4' />
-                  14일
+                  {streakDays}일
                 </Tag>
               )}
             </div>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
@@ -3,11 +3,11 @@
 import Image from 'next/image';
 
 import { Button } from '@/components/ui/Button';
-import { HandIcon, StateIcon } from '@/components/ui/Icon';
+import { HandIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
-import { Tag } from '@/components/ui/Tag';
 import { useFallbackImage } from '@/hooks/useFallbackImage';
 
+import { MemberBadge } from '../../MemberBadge';
 import { RankBadge } from '../RankBadge';
 
 import type { AchievementRankingItem } from '@/api/achievements/types';
@@ -39,26 +39,8 @@ export function RankingItem({ item, isMe, streakDays }: RankingItemProps) {
           <div className='flex items-center justify-between'>
             <div className='flex items-center gap-1 md:gap-2'>
               <span className='text-small-02-m md:text-body-01-m text-gray-900'>{item.nickname}</span>
-              {isWarning && (
-                <Tag
-                  variant='deadline'
-                  state='warning'
-                  className='md:text-small-02-m h-[17px] w-[40px] px-1.5 py-0 text-[10px] md:h-[27px] md:w-[66px] md:px-3 md:py-1'
-                >
-                  <StateIcon variant='warning' className='h-3 w-3 md:h-4 md:w-4' />
-                  주의
-                </Tag>
-              )}
-              {!isWarning && streakDays > 0 && (
-                <Tag
-                  variant='deadline'
-                  state='goal'
-                  className='md:text-small-02-m gap-0.3 flex h-[17px] w-10 px-1.5 py-0 text-[10px] md:h-[27px] md:w-[66px] md:gap-1 md:px-3 md:py-1'
-                >
-                  <StateIcon variant='active' className='h-3 w-3 md:h-4 md:w-4' />
-                  {streakDays}일
-                </Tag>
-              )}
+              {isWarning && <MemberBadge type='warning' label='주의' />}
+              {!isWarning && streakDays > 0 && <MemberBadge type='streak' label={`${streakDays}일`} />}
             </div>
             <div className='flex shrink-0 items-center gap-1'>
               <span className='text-small-02-r md:text-body-01-r text-gray-900'>달성률</span>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
@@ -16,13 +16,15 @@ interface RankingItemProps {
   item: AchievementRankingItem;
   isMe: boolean;
   streakDays: number;
+  currentWeek: number;
 }
 
 const WARNING_THRESHOLD = 50;
+const MIN_WEEKS_FOR_WARNING = 2;
 
-export function RankingItem({ item, isMe, streakDays }: RankingItemProps) {
+export function RankingItem({ item, isMe, streakDays, currentWeek }: RankingItemProps) {
   const { imgSrc, onError } = useFallbackImage(item.profileImage);
-  const isWarning = item.overallRate < WARNING_THRESHOLD;
+  const isWarning = item.overallRate < WARNING_THRESHOLD && currentWeek >= MIN_WEEKS_FOR_WARNING;
 
   return (
     <div

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/index.tsx
@@ -5,9 +5,11 @@ import { useState } from 'react';
 import { useSuspenseQueries } from '@tanstack/react-query';
 
 import { achievementQueries } from '@/api/achievements/queries';
+import { gatheringQueries } from '@/api/gatherings/queries';
 import { Pagination } from '@/components/ui/Pagination';
 import { useAuth } from '@/hooks/useAuth';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { getCurrentWeek } from '@/lib/formatGatheringDate';
 
 import { RankingItem } from './RankingItem';
 
@@ -19,9 +21,14 @@ const ITEMS_PER_PAGE_DESKTOP = 10;
 const ITEMS_PER_PAGE_MOBILE = 5;
 
 export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps) {
-  const [{ data }, { data: achievementData }] = useSuspenseQueries({
-    queries: [achievementQueries.ranking(gatheringId), achievementQueries.detail(gatheringId)],
+  const [{ data }, { data: achievementData }, { data: gatheringData }] = useSuspenseQueries({
+    queries: [
+      achievementQueries.ranking(gatheringId),
+      achievementQueries.detail(gatheringId),
+      gatheringQueries.detail(gatheringId),
+    ],
   });
+  const currentWeek = getCurrentWeek(gatheringData.startDate);
   const { user } = useAuth();
   const isDesktop = useMediaQuery('(min-width: 1024px)');
 
@@ -54,6 +61,7 @@ export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps)
                 item={item}
                 isMe={user?.id === item.userId}
                 streakDays={achievementData.members.find((m) => m.userId === item.userId)?.streakDays ?? 0}
+                currentWeek={currentWeek}
               />
             ))}
           </div>
@@ -64,6 +72,7 @@ export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps)
                 item={item}
                 isMe={user?.id === item.userId}
                 streakDays={achievementData.members.find((m) => m.userId === item.userId)?.streakDays ?? 0}
+                currentWeek={currentWeek}
               />
             ))}
           </div>
@@ -76,6 +85,7 @@ export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps)
               item={item}
               isMe={user?.id === item.userId}
               streakDays={achievementData.members.find((m) => m.userId === item.userId)?.streakDays ?? 0}
+              currentWeek={currentWeek}
             />
           ))}
         </div>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/index.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQueries } from '@tanstack/react-query';
 
 import { achievementQueries } from '@/api/achievements/queries';
 import { Pagination } from '@/components/ui/Pagination';
@@ -19,7 +19,9 @@ const ITEMS_PER_PAGE_DESKTOP = 10;
 const ITEMS_PER_PAGE_MOBILE = 5;
 
 export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps) {
-  const { data } = useSuspenseQuery(achievementQueries.ranking(gatheringId));
+  const [{ data }, { data: achievementData }] = useSuspenseQueries({
+    queries: [achievementQueries.ranking(gatheringId), achievementQueries.detail(gatheringId)],
+  });
   const { user } = useAuth();
   const isDesktop = useMediaQuery('(min-width: 1024px)');
 
@@ -47,19 +49,34 @@ export function MemberRankingSection({ gatheringId }: MemberRankingSectionProps)
         <div className='grid grid-cols-2 gap-4'>
           <div className='flex flex-col gap-4'>
             {leftItems.map((item) => (
-              <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
+              <RankingItem
+                key={item.userId}
+                item={item}
+                isMe={user?.id === item.userId}
+                streakDays={achievementData.members.find((m) => m.userId === item.userId)?.streakDays ?? 0}
+              />
             ))}
           </div>
           <div className='flex flex-col gap-4'>
             {rightItems.map((item) => (
-              <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
+              <RankingItem
+                key={item.userId}
+                item={item}
+                isMe={user?.id === item.userId}
+                streakDays={achievementData.members.find((m) => m.userId === item.userId)?.streakDays ?? 0}
+              />
             ))}
           </div>
         </div>
       ) : (
         <div className='flex flex-col gap-4'>
           {currentItems.map((item) => (
-            <RankingItem key={item.userId} item={item} isMe={user?.id === item.userId} />
+            <RankingItem
+              key={item.userId}
+              item={item}
+              isMe={user?.id === item.userId}
+              streakDays={achievementData.members.find((m) => m.userId === item.userId)?.streakDays ?? 0}
+            />
           ))}
         </div>
       )}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -6,7 +6,7 @@ import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
 import { Profile } from '@/components/ui/Profile';
 import { cn } from '@/lib/cn';
 
-import { MemberBadge } from '../../MemberBadge';
+import { MemberBadge, MIN_WEEKS_FOR_WARNING, WARNING_THRESHOLD } from '../../MemberBadge';
 import { MemberTodoGrid } from '../MemberTodoGrid';
 
 import type { Member } from '@/api/memberships/types';
@@ -18,9 +18,6 @@ interface MemberTodoAccordionProps {
   streakDays: number;
   currentWeek: number;
 }
-
-const WARNING_THRESHOLD = 50;
-const MIN_WEEKS_FOR_WARNING = 2;
 
 export function MemberTodoAccordion({ member, todos, streakDays, currentWeek }: MemberTodoAccordionProps) {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -5,9 +5,8 @@ import { useState } from 'react';
 import { ArrowIcon } from '@/components/ui/Icon/ArrowIcon';
 import { Profile } from '@/components/ui/Profile';
 import { cn } from '@/lib/cn';
-import { StateIcon } from '@/components/ui/Icon';
-import { Tag } from '@/components/ui/Tag';
 
+import { MemberBadge } from '../../MemberBadge';
 import { MemberTodoGrid } from '../MemberTodoGrid';
 
 import type { Member } from '@/api/memberships/types';
@@ -51,22 +50,8 @@ export function MemberTodoAccordion({ member, todos, streakDays }: MemberTodoAcc
           </div>
         </div>
         <div className='flex items-center gap-2 md:gap-4'>
-          {isWarning && (
-            <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] px-2 py-0.5 text-orange-400'>
-              <Tag variant='info' state='bad'>
-                <StateIcon variant='warning' size={14} />
-                주의
-              </Tag>
-            </span>
-          )}
-          {!isWarning && streakDays > 0 && (
-            <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] px-2 py-0.5 text-blue-400'>
-              <Tag variant='info' state='good'>
-                <StateIcon variant='active' size={14} />
-                {streakDays}일
-              </Tag>
-            </span>
-          )}
+          {isWarning && <MemberBadge type='warning' label='주의' />}
+          {!isWarning && streakDays > 0 && <MemberBadge type='streak' label={`${streakDays}일`} />}
           <p className='text-small-01-r md:text-body-01-r mr-3 flex gap-1 whitespace-nowrap text-gray-900'>
             달성률
             <span className='text-small-01-sb md:text-body-01-sb flex items-center font-semibold text-blue-300'>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -16,14 +16,15 @@ import type { Todo } from '@/api/todos/types';
 interface MemberTodoAccordionProps {
   member: Member;
   todos: Todo[];
+  streakDays: number;
 }
 
-export function MemberTodoAccordion({ member, todos }: MemberTodoAccordionProps) {
+const WARNING_THRESHOLD = 50;
+
+export function MemberTodoAccordion({ member, todos, streakDays }: MemberTodoAccordionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  // 디자인 시안에 따른 임시 배지 로직 (D-day 및 주의)
-  const isWarning = member.userId % 3 === 0; // 임시 조건
-  const dDay = 14; // 임시 값
+  const isWarning = member.overallAchievementRate < WARNING_THRESHOLD;
 
   return (
     <div
@@ -50,18 +51,19 @@ export function MemberTodoAccordion({ member, todos }: MemberTodoAccordionProps)
           </div>
         </div>
         <div className='flex items-center gap-2 md:gap-4'>
-          {isWarning ? (
+          {isWarning && (
             <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] px-2 py-0.5 text-orange-400'>
               <Tag variant='info' state='bad'>
                 <StateIcon variant='warning' size={14} />
                 주의
               </Tag>
             </span>
-          ) : (
+          )}
+          {!isWarning && streakDays > 0 && (
             <span className='text-small-02-sb inline-flex items-center gap-1 rounded-[4px] px-2 py-0.5 text-blue-400'>
               <Tag variant='info' state='good'>
                 <StateIcon variant='active' size={14} />
-                {dDay}일
+                {streakDays}일
               </Tag>
             </span>
           )}

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoAccordion/index.tsx
@@ -16,14 +16,16 @@ interface MemberTodoAccordionProps {
   member: Member;
   todos: Todo[];
   streakDays: number;
+  currentWeek: number;
 }
 
 const WARNING_THRESHOLD = 50;
+const MIN_WEEKS_FOR_WARNING = 2;
 
-export function MemberTodoAccordion({ member, todos, streakDays }: MemberTodoAccordionProps) {
+export function MemberTodoAccordion({ member, todos, streakDays, currentWeek }: MemberTodoAccordionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const isWarning = member.overallAchievementRate < WARNING_THRESHOLD;
+  const isWarning = member.overallAchievementRate < WARNING_THRESHOLD && currentWeek >= MIN_WEEKS_FOR_WARNING;
 
   return (
     <div

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query';
 
+import { achievementQueries } from '@/api/achievements/queries';
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { membershipQueries } from '@/api/memberships/queries';
 import { todoQueries } from '@/api/todos/queries';
@@ -31,6 +32,8 @@ export function MemberTodoSection({ gatheringId }: MemberTodoSectionProps) {
     ...todoQueries.list(gatheringId, { week: currentWeek }),
   });
 
+  const { data: achievementData } = useSuspenseQuery(achievementQueries.detail(gatheringId));
+
   const totalMembers = membersData.members.length;
   const totalPages = Math.ceil(totalMembers / ITEMS_PER_PAGE);
 
@@ -49,6 +52,7 @@ export function MemberTodoSection({ gatheringId }: MemberTodoSectionProps) {
               key={member.userId}
               member={member}
               todos={todoData.todos.filter((t) => t.userId === member.userId)}
+              streakDays={achievementData.members.find((m) => m.userId === member.userId)?.streakDays ?? 0}
             />
           ))}
         </div>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/index.tsx
@@ -53,6 +53,7 @@ export function MemberTodoSection({ gatheringId }: MemberTodoSectionProps) {
               member={member}
               todos={todoData.todos.filter((t) => t.userId === member.userId)}
               streakDays={achievementData.members.find((m) => m.userId === member.userId)?.streakDays ?? 0}
+              currentWeek={currentWeek}
             />
           ))}
         </div>

--- a/src/mocks/handlers/achievements.ts
+++ b/src/mocks/handlers/achievements.ts
@@ -20,6 +20,7 @@ const mockSunny: GatheringAchievements = {
         { week: 3, rate: 60.0 },
       ],
       overallRate: 80.0,
+      streakDays: 21,
     },
     {
       userId: 2,
@@ -30,6 +31,7 @@ const mockSunny: GatheringAchievements = {
         { week: 3, rate: 40.0 },
       ],
       overallRate: 60.0,
+      streakDays: 14,
     },
     {
       userId: 3,
@@ -40,6 +42,7 @@ const mockSunny: GatheringAchievements = {
         { week: 3, rate: 80.0 },
       ],
       overallRate: 80.0,
+      streakDays: 7,
     },
   ],
   teamWeeklyRates: [
@@ -62,6 +65,7 @@ const mockCloudy: GatheringAchievements = {
         { week: 3, rate: 30.0 },
       ],
       overallRate: 50.0,
+      streakDays: 3,
     },
     {
       userId: 2,
@@ -72,6 +76,7 @@ const mockCloudy: GatheringAchievements = {
         { week: 3, rate: 30.0 },
       ],
       overallRate: 43.3,
+      streakDays: 0,
     },
     {
       userId: 3,
@@ -82,6 +87,7 @@ const mockCloudy: GatheringAchievements = {
         { week: 3, rate: 50.0 },
       ],
       overallRate: 56.7,
+      streakDays: 5,
     },
   ],
   teamWeeklyRates: [
@@ -104,6 +110,7 @@ const mockStormy: GatheringAchievements = {
         { week: 3, rate: 10.0 },
       ],
       overallRate: 23.3,
+      streakDays: 0,
     },
     {
       userId: 2,
@@ -114,6 +121,7 @@ const mockStormy: GatheringAchievements = {
         { week: 3, rate: 10.0 },
       ],
       overallRate: 20.0,
+      streakDays: 0,
     },
     {
       userId: 3,
@@ -124,6 +132,7 @@ const mockStormy: GatheringAchievements = {
         { week: 3, rate: 20.0 },
       ],
       overallRate: 30.0,
+      streakDays: 1,
     },
   ],
   teamWeeklyRates: [
@@ -294,6 +303,17 @@ const synthesizeWeeklyRates = (overall: number) =>
     return { week: i + 1, rate: round1(rate) };
   });
 
+const computeStreakDays = (weeklyRates: { week: number; rate: number }[]): number => {
+  const maxWeek = weeklyRates.reduce((max, wr) => Math.max(max, wr.week), 0);
+  let streak = 0;
+  for (let w = maxWeek; w >= 1; w--) {
+    const wr = weeklyRates.find((r) => r.week === w);
+    if (wr && wr.rate > 0) streak++;
+    else break;
+  }
+  return streak * 7;
+};
+
 const buildAchievementsFromShared = (gatheringId: number): GatheringAchievements | null => {
   const members = GATHERING_MEMBERS[gatheringId];
   if (!members) return null;
@@ -301,11 +321,13 @@ const buildAchievementsFromShared = (gatheringId: number): GatheringAchievements
   const memberAchievements = members.map((m) => {
     const todosWeekly = buildWeeklyRatesFromTodos(m.userId);
     const todosOverall = computeOverallRateFromTodos(m.userId);
+    const weeklyRates = todosWeekly ?? synthesizeWeeklyRates(m.overallAchievementRate);
     return {
       userId: m.userId,
       nickname: m.nickname,
-      weeklyRates: todosWeekly ?? synthesizeWeeklyRates(m.overallAchievementRate),
+      weeklyRates,
       overallRate: todosOverall ?? m.overallAchievementRate,
+      streakDays: computeStreakDays(weeklyRates),
     };
   });
 


### PR DESCRIPTION
## ❓ 이슈

- close #353 

## ✍️ Description

### 배경

모임 대시보드의 멤버 탭, 활동 요약 탭, 주차별 현황 탭에서 각각 연속달성일수와 주의 배지를 표시하고 있었으나, 3가지 문제가 있었습니다.

**1. 연속달성일수 부정확**
프론트에서 `weeklyRates`를 보고 "rate > 0인 연속 주차 수 × 7"로 근사 계산했습니다.
하지만 주마다 할 일을 1개만 완료해도 그 주는 streak으로 카운트되어, 실제 연속달성일이 0일인데도 14일로 표시되는 등 부정확한 값이 나왔습니다.

**2. 하드코딩된 임시값**
활동 요약 탭 랭킹에는 `"14일"` 고정값이, 주차별 현황 탭 멤버 할 일에는 `userId % 3 === 0`이라는 임시 주의 조건이 하드코딩되어 있었습니다.

**3. 탭별로 다른 배지 스타일·주의 조건**
3개 탭이 모두 다른 방식으로 배지를 구현(variant, 구조, 주의 판단 기준 상이)하고 있어 일관성이 없었습니다.

---

### 변경 내용

**① 연속달성일수: API 응답값 직접 사용**

백엔드에서 `GET /gatherings/:gatheringId/achievements` 응답의 `MemberAchievement`에 `streakDays: number` 필드를 추가해줬습니다.
프론트의 클라이언트 계산 로직을 제거하고 이 값을 직접 사용합니다.
- 멤버 탭: `weeklyRates` 루프 계산 → `streakDays` 직접 사용
- 활동 요약 탭: 하드코딩 `"14일"` → `streakDays`
- 주차별 현황 탭: 임시 하드코딩 → `streakDays`

랭킹·할 일 탭에서 별도로 API를 추가 호출하지 않고, 멤버 탭이 이미 페치한 `achievementQueries.detail` 캐시를 재사용합니다.

**② 배지 컴포넌트 공용화**

3개 탭의 배지를 `dashboard/_components/MemberBadge`로 통합했습니다.
- `variant='info'`로 통일 (기존 탭별로 `deadline` / `info` 혼용)
- 반응형 스타일 내장 (모바일: 10px / radius 4px, 데스크톱: 12px / radius 8px)
- 기존 `MemberCard/Badge`의 `MemberBadge`는 공용 컴포넌트로 이동, `MeBadge`만 기존 위치에 유지

**③ 주의 배지 조건 통일**

| 탭 | 변경 전 | 변경 후 |
|---|---|---|
| 멤버 탭 | `달성 주차 수 / 전체 주차 수 <= 0.5 && currentWeek >= 2` | `overallAchievementRate < 50 && currentWeek >= 2` |
| 활동 요약 탭 | `overallRate < 50` (2주 미만 예외 없음) | `overallRate < 50 && currentWeek >= 2` |
| 주차별 현황 탭 | `userId % 3 === 0` (임시) | `overallAchievementRate < 50 && currentWeek >= 2` |

기존 멤버 탭 조건(주차 달성 비율)은 할 일을 1개만 완료해도 그 주를 "달성"으로 카운트하여 참여도를 과대평가할 수 있어, 전체 할 일 완료율(`overallAchievementRate`)을 기준으로 통일했습니다.
모임 시작 후 2주 미만에는 데이터가 충분하지 않으므로 주의 배지를 표시하지 않습니다.


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->


