### PR TITLE
[SM-206] fix: 달성률 게이지 UI 버그 수정 및 Storybook 정비

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,13 @@ import type { Preview } from '@storybook/nextjs-vite';
 import { pretendard } from '../src/app/fonts';
 import '../src/app/globals.css';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+    },
+  },
+});
 
 const preview: Preview = {
   decorators: [

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,12 +1,20 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Preview } from '@storybook/nextjs-vite';
+
 import { pretendard } from '../src/app/fonts';
 import '../src/app/globals.css';
+
+const queryClient = new QueryClient();
 
 const preview: Preview = {
   decorators: [
     (Story) => {
       document.documentElement.classList.add(pretendard.variable, 'font-pretendard');
-      return Story();
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
     },
   ],
   parameters: {

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.stories.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { AchievementGauge } from '.';
+
+const meta = {
+  title: 'app/Dashboard/AchievementGauge',
+  component: AchievementGauge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    arcColor: '#1e58f8',
+  },
+} satisfies Meta<typeof AchievementGauge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Zero: Story = {
+  name: '0% (0자리)',
+  args: {
+    label: '내 달성률',
+    rate: 0,
+  },
+};
+
+export const SingleDigit: Story = {
+  name: '5% (한 자리)',
+  args: {
+    label: '내 달성률',
+    rate: 5,
+  },
+};
+
+export const DoubleDigit: Story = {
+  name: '75% (두 자리)',
+  args: {
+    label: '내 달성률',
+    rate: 75,
+  },
+};
+
+export const Hundred: Story = {
+  name: '100% (세 자리)',
+  args: {
+    label: '내 달성률',
+    rate: 100,
+  },
+};

--- a/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/WeeklySummarySection/AchievementGauge/index.tsx
@@ -75,9 +75,9 @@ export function AchievementGauge({ label, rate, arcColor }: AchievementGaugeProp
         {/* 달성률 숫자 (반원 중앙) */}
         <text x={CX} y={CY - 10} textAnchor='middle' fontSize={42} fontWeight={700} fill='#010937'>
           {rate}
-        </text>
-        <text x={CX + 30} y={CY - 15} textAnchor='middle' fontSize={22} fontWeight={700} fill='#010937'>
-          %
+          <tspan fontSize={22} dy={-7} dx={2}>
+            %
+          </tspan>
         </text>
 
         {/* 0 / 100 라벨 */}

--- a/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.stories.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/WeeklyPlanForm/index.stories.tsx
@@ -11,7 +11,7 @@ interface WeeklyPlanFormStoryArgs {
 }
 
 const meta = {
-  title: 'app/CreateGatheringForm/WeeklyPlanForm',
+  title: 'app/CreateGathering/WeeklyPlanForm',
   args: {
     totalWeeks: 1,
   },
@@ -42,14 +42,14 @@ function WeeklyPlanFormStory({ totalWeeks }: WeeklyPlanFormStoryArgs) {
   );
 }
 
-export const OneWeek: Story = {
+export const MaxOneWeek: Story = {
   args: {
     totalWeeks: 1,
   },
   render: (args) => <WeeklyPlanFormStory totalWeeks={args.totalWeeks} />,
 };
 
-export const ThreeWeeks: Story = {
+export const MaxThreeWeeks: Story = {
   args: {
     totalWeeks: 3,
   },


### PR DESCRIPTION
## ❓ 이슈

- close #355 

## ✍️ Description

### 1. 달성률 게이지 % 기호 겹침 수정

`AchievementGauge` 컴포넌트에서 달성률 숫자와 `%` 기호가 별도 SVG `<text>` 요소로
분리되어 있어 2~3자리 숫자(예: 75, 100)일 때 겹치는 UI 버그가 있었습니다.

두 `<text>`를 단일 `<text>` + `<tspan>` 구조로 통합해 `textAnchor="middle"`이
숫자+% 전체를 기준으로 중앙 정렬되도록 수정했습니다.

### 2. AchievementGauge Storybook 스토리 추가

0% / 5% / 75% / 100% 케이스를 한 화면에서 시각 확인할 수 있도록 스토리를 추가했습니다.

### 3. Storybook 스토리 title 및 스토리명 정비

- `WeeklyPlanForm` 스토리 title을 `app/CreateGathering/WeeklyPlanForm`으로 통일
- 스토리 export명 `OneWeek` → `MaxOneWeek`, `ThreeWeeks` → `MaxThreeWeeks`로 변경
  (`totalWeeks`가 최대 주차 상한선임을 명확히 표현)

### 4. Storybook QueryClientProvider 추가

`MainGatheringCard`가 내부적으로 `useLikeToggle`(→ `useMutation`) 을 사용하는데
Storybook 전역 설정에 `QueryClientProvider`가 없어 Chromatic 빌드 3건이 실패했습니다.

`preview.ts` → `preview.tsx`로 변경 후 전역 decorator에 `QueryClientProvider`를 추가해
모든 스토리에 자동 적용되도록 했습니다.

## 📸 스크린샷 (UI 변경 시)

<img width="1541" height="745" alt="image" src="https://github.com/user-attachments/assets/d303b14c-5a13-4fbf-9a1d-1f8ae24a4807" />


## ✅ Checklist

### PR

- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes
스토리북 배포 링크입니다
https://69c48637f85cbccae03a7ab0-msrbaxqftt.chromatic.com/
