### PR TITLE
[SM-211] feat: PWA 오프라인 지원(L2) — 폴백 페이지·이미지 캐싱·오프라인 토스트

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { pretendard } from './fonts';
 import { AnalyticsScripts } from '@/components/analytics/AnalyticsScripts';
 import { BeusableScript } from '@/components/analytics/BeusableScript';
 import { Header } from '@/components/Header';
+import { NetworkStatusToast } from '@/components/NetworkStatusToast';
 import { MSWProvider } from '@/providers/MSWProvider';
 import { QueryParamsProvider } from '@/providers/QueryParamsProvider';
 import { QueryProvider } from '@/providers/QueryProvider';
@@ -78,6 +79,7 @@ export default function RootLayout({
             <QueryProvider>
               <QueryParamsProvider>
                 <ToastProvider>
+                  <NetworkStatusToast />
                   <Header />
                   {children}
                   <FooterWrapper />

--- a/src/app/serwist/[path]/route.ts
+++ b/src/app/serwist/[path]/route.ts
@@ -1,9 +1,27 @@
+import { spawnSync } from 'node:child_process';
+
 import { createSerwistRoute } from '@serwist/turbopack';
 
 // Serwist(turbopack): src/app/sw.ts를 esbuild로 컴파일해 /serwist/sw.js로 서빙한다.
 // (webpack 플러그인 대신 route handler 방식 — Next 16 Turbopack 호환)
-// L2에서 오프라인 폴백을 도입할 때 additionalPrecacheEntries로 /offline 등을 추가한다.
+
+// 프리캐시 버스팅용 revision. 배포(커밋)마다 바뀌어 /~offline이 최신으로 갱신된다.
+// .git이 없는 환경(일부 배포)에서는 임의값으로 폴백.
+const revision = spawnSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).stdout?.trim() || crypto.randomUUID();
+
 export const { dynamic, dynamicParams, revalidate, generateStaticParams, GET } = createSerwistRoute({
+  // L2 오프라인 폴백 페이지를 프리캐시 (sw.ts의 fallbacks가 이 URL을 가리킴)
+  additionalPrecacheEntries: [{ url: '/~offline', revision }],
+  // /images/landing/* 은 파일명에 공백이 있어(예: "Route 1-PC.png") SW 프리캐시 fetch가
+  // 308 리다이렉트로 실패 → install 전체가 깨짐(엔트리 하나라도 비200이면 실패).
+  // 랜딩 장식 이미지라 오프라인에 불필요하므로 제외한다.
+  // (로고 /images/logo.svg 등 공백 없는 정적 이미지는 그대로 precache → 오프라인 보장)
+  manifestTransforms: [
+    (entries) => ({
+      manifest: entries.filter((entry) => !entry.url.includes('/images/landing/')),
+      warnings: [],
+    }),
+  ],
   swSrc: 'src/app/sw.ts',
   useNativeEsbuild: true,
 });

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -1,6 +1,6 @@
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
-import { Serwist } from 'serwist';
+import { ExpirationPlugin, NetworkOnly, Serwist, StaleWhileRevalidate } from 'serwist';
 
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist';
 
@@ -16,12 +16,46 @@ declare const self: ServiceWorkerGlobalScope;
 
 const serwist = new Serwist({
   // 정적 자산(JS/CSS/폰트/이미지/앱 셸) 프리캐시.
-  // L2 결정 "정적만" — runtimeCaching(API 캐싱)은 의도적으로 비워둠.
+  // L2 결정 "정적만" — runtimeCaching(API 캐싱)은 의도적으로 비워둠(3겹 캐시 버그 방지).
   precacheEntries: self.__SW_MANIFEST,
   skipWaiting: true, // 새 SW가 대기 없이 즉시 활성화 (반영 빠름)
   clientsClaim: true, // 활성화 즉시 열려 있는 탭을 SW가 관리
   navigationPreload: true,
-  // runtimeCaching: L2에서 정적 자산 한정 전략 추가 (API는 제외 — 3겹 캐시 버그 방지)
+  // navigation(페이지) 요청을 SW가 "처리"하게 만든다. NetworkOnly라 페이지는
+  // 캐시하지 않지만(정적만 유지), 요청이 SW를 거치므로 오프라인 시 fallback이 발동한다.
+  // (runtimeCaching을 아예 비우면 navigation이 passthrough돼 fallback이 안 터짐)
+  runtimeCaching: [
+    {
+      matcher({ request }) {
+        return request.mode === 'navigate';
+      },
+      handler: new NetworkOnly(),
+    },
+    // 이미지(로고·아바타·썸네일 등)는 정적 자산이므로 런타임 캐싱.
+    // precache(빌드 타임)는 /images/* 백엔드 rewrite의 308 때문에 실패 → 런타임으로 캐싱.
+    // StaleWhileRevalidate: 캐시 즉시 표시 + 뒤에서 갱신. 오프라인 시 캐시본 사용.
+    {
+      matcher({ request }) {
+        return request.destination === 'image';
+      },
+      handler: new StaleWhileRevalidate({
+        cacheName: 'images',
+        plugins: [new ExpirationPlugin({ maxEntries: 80, maxAgeSeconds: 30 * 24 * 60 * 60 })],
+      }),
+    },
+  ],
+  // L2 오프라인 폴백: 네트워크가 끊겨 "문서(페이지)"를 못 불러오면
+  // 프리캐시된 /~offline 페이지를 대신 보여준다. (route handler가 /~offline을 precache)
+  fallbacks: {
+    entries: [
+      {
+        url: '/~offline',
+        matcher({ request }) {
+          return request.destination === 'document';
+        },
+      },
+    ],
+  },
 });
 
 // install / activate / fetch 등 Serwist 기본 이벤트 연결

--- a/src/app/~offline/RetryButton/index.tsx
+++ b/src/app/~offline/RetryButton/index.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export function RetryButton() {
+  return (
+    <button
+      type='button'
+      onClick={() => window.location.reload()}
+      className='bg-gradient-primary text-body-02-sb mt-2 rounded-lg px-6 py-3 text-white'
+    >
+      다시 시도
+    </button>
+  );
+}

--- a/src/app/~offline/page.tsx
+++ b/src/app/~offline/page.tsx
@@ -1,0 +1,21 @@
+import { RetryButton } from './RetryButton';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '오프라인',
+};
+
+export default function OfflinePage() {
+  return (
+    <main className='flex min-h-[calc(100dvh_-_48px)] flex-col items-center justify-center gap-3 px-6 text-center md:min-h-[calc(100dvh_-_88px)]'>
+      <h1 className='text-h5-b text-gray-800'>오프라인이에요</h1>
+      <p className='text-body-01-r text-gray-500'>
+        네트워크 연결이 끊겼어요.
+        <br />
+        연결 상태를 확인하고 다시 시도해 주세요.
+      </p>
+      <RetryButton />
+    </main>
+  );
+}

--- a/src/components/NetworkStatusToast/index.tsx
+++ b/src/components/NetworkStatusToast/index.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
+
+// 오프라인 토스트는 온라인 복귀 시 수동으로 제거하므로, 자동 닫힘을 사실상 막는 긴 값.
+// (setTimeout 한계인 ~24.8일 이내)
+const OFFLINE_TOAST_DURATION = 24 * 60 * 60 * 1000;
+
+/**
+ * 네트워크 연결이 끊기면 토스트로 알린다.
+ * 오프라인 폴백 페이지(`/~offline`)가 "이동/새로고침" 상황을 다룬다면,
+ * 이 컴포넌트는 "이미 보고 있는 화면에서 연결이 끊긴" 상황을 다룬다.
+ * 순수 브라우저 이벤트(online/offline)만 사용 — SW 불필요. 렌더링은 없음.
+ *
+ * 참고: 온라인 복귀 시 SerwistProvider가 reloadOnOnline(기본 true)으로 페이지를
+ * 새로고침해 자동 복구한다. 그때 토스트 store도 초기화되므로 별도 "복구 토스트"는 두지 않는다.
+ * (handleOnline의 removeToast는 reload 전 정리 + reloadOnOnline을 끌 경우의 안전장치)
+ */
+export function NetworkStatusToast() {
+  const showToast = useToastStore((state) => state.showToast);
+  const removeToast = useToastStore((state) => state.removeToast);
+  const offlineToastIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const handleOffline = () => {
+      if (offlineToastIdRef.current) return; // 이미 떠 있으면 중복 방지
+      offlineToastIdRef.current = showToast(
+        { variant: 'error', title: '인터넷 연결이 끊겼어요', description: '연결 상태를 확인해 주세요.' },
+        OFFLINE_TOAST_DURATION,
+      );
+    };
+
+    const handleOnline = () => {
+      if (!offlineToastIdRef.current) return;
+      removeToast(offlineToastIdRef.current);
+      offlineToastIdRef.current = null;
+    };
+
+    // 마운트 시점에 이미 오프라인이면 즉시 표시 (offline 이벤트는 전환 시에만 발생)
+    if (!navigator.onLine) handleOffline();
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, [showToast, removeToast]);
+
+  return null;
+}


### PR DESCRIPTION
## ❓ 이슈

- close #364

## ✍️ Description

PWA 오프라인 지원(L2). L1 서비스워커 골격 위에 오프라인 폴백을 얹는다.

- **오프라인 폴백 페이지**(`/~offline`): 네트워크 끊긴 채로 페이지 이동/새로고침 시 SW가 대신 표시. 뷰포트를 채워 footer가 항상 바닥에 위치
- **sw.ts**: navigation을 `NetworkOnly`로 처리(페이지는 캐시 안 함 = 정적만 유지하되, SW를 거치므로 오프라인 시 fallback 발동) + 이미지 `StaleWhileRevalidate` 런타임 캐싱
- **route handler**: `/~offline` precache + `/images/landing/`(공백 파일명 → 308) 제외. 로고 등 정적 이미지는 precache로 오프라인 보장
- **NetworkStatusToast**: 이미 보고 있는 화면에서 연결이 끊기면 토스트로 알림(기존 `ToastProvider` 재사용). 복귀는 `SerwistProvider`의 reloadOnOnline이 자동 처리
- ⚠️ **API 응답 캐싱은 하지 않음** (정적만 결정 — SW 캐시가 TanStack Query/Next Data Cache와 3겹으로 겹쳐 옛 데이터 버그 유발 방지)

## 📸 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/67896147-1093-4a4a-ae9b-c101d8f54e67


오프라인 폴백 페이지 + 연결 끊김 토스트. (DevTools › Application › Service Workers › Offline 체크 시 확인. **Bypass for network는 해제** 필요)


## ✅ Checklist

### PR

- [x] Branch Convention 확인 (`feat/SM-211`)
- [x] Base Branch 확인 (`dev`)
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인 (프로덕션 빌드 + Playwright로 오프라인 폴백·로고 precache·오프라인 토스트 실측)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] 검증은 프로덕션 빌드(`npm run build && npx next start`)에서. dev는 SW precache 불완전
