### PR TITLE
[SM-214] fix: 진행중/완료 모임 수정 시 날짜 검증 정책 정합화

### DIFF
--- a/src/api/gatherings/schemas.ts
+++ b/src/api/gatherings/schemas.ts
@@ -52,7 +52,7 @@ export const gatheringFormBaseSchema = z.object({
     .optional(),
 });
 
-/** 날짜 크로스필드 검증 스키마 — 필드 검증은 base schema에 위임, 여기서는 cross-field 검증만 담당 */
+/** 날짜 크로스필드 검증 스키마 (RECRUITING 상태 전용) — 필드 검증은 base schema에 위임, 여기서는 cross-field 검증만 담당 */
 const dateRefinementSchema = z
   .object({
     recruitDeadline: z.string().optional(),
@@ -83,8 +83,36 @@ const dateRefinementSchema = z
     }
   });
 
+/**
+ * 날짜 크로스필드 검증 스키마 (IN_PROGRESS 상태 전용)
+ * recruitDeadline/startDate는 원본과 달라지면 에러,
+ * endDate는 원본 startDate 이후인지만 검증
+ */
+export const createInProgressDateRefinementSchema = (original: { recruitDeadline: string; startDate: string }) =>
+  z
+    .object({
+      recruitDeadline: z.string().optional(),
+      startDate: z.string().optional(),
+      endDate: z.string().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.recruitDeadline && data.recruitDeadline !== original.recruitDeadline) {
+        ctx.addIssue({
+          code: 'custom',
+          message: '모집이 시작되면 모집 마감일을 변경할 수 없습니다.',
+          path: ['recruitDeadline'],
+        });
+      }
+      if (data.startDate && data.startDate !== original.startDate) {
+        ctx.addIssue({ code: 'custom', message: '모임이 시작되면 시작일을 변경할 수 없습니다.', path: ['startDate'] });
+      }
+      if (data.endDate && data.endDate <= original.startDate) {
+        ctx.addIssue({ code: 'custom', message: '종료일은 시작일 이후여야 합니다.', path: ['endDate'] });
+      }
+    });
+
 /** POST `/gatherings` — 모임 생성 폼 */
 export const gatheringFormSchema = gatheringFormBaseSchema.and(dateRefinementSchema);
 
-/** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (모든 필드 optional) */
-export const gatheringUpdateFormSchema = gatheringFormBaseSchema.partial();
+/** PUT `/gatherings/:gatheringId` — 모임 수정 폼 (RECRUITING 상태, 모든 필드 optional) */
+export const gatheringUpdateFormSchema = gatheringFormBaseSchema.partial().and(dateRefinementSchema);

--- a/src/app/gatherings/[id]/_components/GatheringHero/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringHero/index.tsx
@@ -41,7 +41,7 @@ export function GatheringHero({ gatheringId }: GatheringHeroProps) {
           </p>
           <h1 className='text-h5-b md:text-h3-b xl:text-h2-b text-blue-500'>{data.title}</h1>
         </div>
-        {isLeader && <LeaderActionDropdown gatheringId={gatheringId} />}
+        {isLeader && <LeaderActionDropdown gatheringId={gatheringId} gatheringStatus={data.status} />}
       </div>
     </section>
   );

--- a/src/app/gatherings/[id]/_components/LeaderActionDropdown/index.tsx
+++ b/src/app/gatherings/[id]/_components/LeaderActionDropdown/index.tsx
@@ -10,15 +10,19 @@ import { useOverlay } from '@/hooks/useOverlay';
 
 import { DeleteGatheringModal } from './DeleteGatheringModal';
 
+import type { GatheringStatus } from '@/api/gatherings/types';
+
 interface LeaderActionDropdownProps {
   gatheringId: number;
+  gatheringStatus: GatheringStatus;
 }
 
-export function LeaderActionDropdown({ gatheringId }: LeaderActionDropdownProps) {
+export function LeaderActionDropdown({ gatheringId, gatheringStatus }: LeaderActionDropdownProps) {
   const router = useRouter();
   const overlay = useOverlay();
   const { showToast } = useToastStore();
   const { mutate: deleteGathering } = useDeleteGathering(gatheringId);
+  const canEdit = gatheringStatus !== 'COMPLETED';
 
   const handleEdit = () => {
     router.push(`/gatherings/${gatheringId}/edit`);
@@ -51,7 +55,11 @@ export function LeaderActionDropdown({ gatheringId }: LeaderActionDropdownProps)
         containerClassName='right-0'
         className='flex w-20 flex-col gap-3 px-3 py-2 shadow-[0px_0px_12px_0px_rgba(30,88,248,0.04)]'
       >
-        <Dropdown.Item onClick={handleEdit} className='text-body-02-r cursor-pointer text-gray-500 hover:text-blue-300'>
+        <Dropdown.Item
+          onClick={handleEdit}
+          disabled={!canEdit}
+          className='text-body-02-r cursor-pointer text-gray-500 hover:text-blue-300'
+        >
           수정
         </Dropdown.Item>
         <Dropdown.Item

--- a/src/app/gatherings/[id]/edit/_components/EditGatheringContent.tsx
+++ b/src/app/gatherings/[id]/edit/_components/EditGatheringContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import { useSuspenseQueries } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
@@ -32,6 +33,7 @@ interface EditGatheringContentProps {
 }
 
 export function EditGatheringContent({ gatheringId }: EditGatheringContentProps) {
+  const router = useRouter();
   const [{ data: detail }, { data: categoriesData }] = useSuspenseQueries({
     queries: [gatheringQueries.detail(gatheringId), gatheringQueries.categories()],
   });
@@ -43,5 +45,20 @@ export function EditGatheringContent({ gatheringId }: EditGatheringContentProps)
 
   const initialValues = useMemo(() => toFormValues(detail, nameToId), [detail, nameToId]);
 
-  return <CreateGatheringForm mode='edit' gatheringId={gatheringId} initialValues={initialValues} />;
+  const isCompleted = detail.status === 'COMPLETED';
+
+  useEffect(() => {
+    if (isCompleted) router.replace(`/gatherings/${gatheringId}`);
+  }, [isCompleted, gatheringId, router]);
+
+  if (isCompleted) return null;
+
+  return (
+    <CreateGatheringForm
+      mode='edit'
+      gatheringId={gatheringId}
+      initialValues={initialValues}
+      gatheringStatus={detail.status}
+    />
+  );
 }

--- a/src/app/gatherings/new/CreateGatheringForm/index.tsx
+++ b/src/app/gatherings/new/CreateGatheringForm/index.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, useEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { differenceInDays, isValid, parseISO } from 'date-fns';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, type Resolver, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 import { Button } from '@/components/ui/Button';
@@ -18,7 +18,12 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { gatheringQueries, useCreateGathering, useUpdateGathering } from '@/api/gatherings/queries';
-import { gatheringFormSchema } from '@/api/gatherings/schemas';
+import {
+  createInProgressDateRefinementSchema,
+  gatheringFormBaseSchema,
+  gatheringFormSchema,
+  gatheringUpdateFormSchema,
+} from '@/api/gatherings/schemas';
 import { GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 import {
@@ -31,7 +36,7 @@ import { ImageUpload } from './ImageUpload';
 import { TagInput } from './TagInput';
 import { WeeklyPlanForm } from './WeeklyPlanForm';
 
-import type { GatheringForm } from '@/api/gatherings/types';
+import type { GatheringForm, GatheringStatus } from '@/api/gatherings/types';
 
 const RotatingArrow = () => {
   const { isOpen } = useDropdown();
@@ -71,12 +76,19 @@ interface CreateGatheringFormProps {
   mode?: 'create' | 'edit';
   gatheringId?: number;
   initialValues?: Partial<GatheringForm>;
+  gatheringStatus?: GatheringStatus;
 }
 
-export function CreateGatheringForm({ mode = 'create', gatheringId, initialValues }: CreateGatheringFormProps) {
+export function CreateGatheringForm({
+  mode = 'create',
+  gatheringId,
+  initialValues,
+  gatheringStatus,
+}: CreateGatheringFormProps) {
   const router = useRouter();
   const showToast = useToastStore((state) => state.showToast);
   const isEditMode = mode === 'edit';
+  const isInProgressEdit = isEditMode && gatheringStatus === 'IN_PROGRESS';
 
   const { data: categoriesData } = useSuspenseQuery(gatheringQueries.categories());
   const categories = categoriesData.categories;
@@ -84,6 +96,19 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     () => Object.fromEntries(categories.map((c) => [c.id, { label: c.name }])) as Record<number, { label: string }>,
     [categories],
   );
+
+  const schema = useMemo(() => {
+    if (!isEditMode) return gatheringFormSchema;
+    if (isInProgressEdit) {
+      return gatheringFormBaseSchema.partial().and(
+        createInProgressDateRefinementSchema({
+          recruitDeadline: initialValues?.recruitDeadline ?? '',
+          startDate: initialValues?.startDate ?? '',
+        }),
+      );
+    }
+    return gatheringUpdateFormSchema;
+  }, [isEditMode, isInProgressEdit, initialValues?.recruitDeadline, initialValues?.startDate]);
 
   const {
     register,
@@ -93,7 +118,9 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
     trigger,
     formState: { errors, touchedFields, isDirty },
   } = useForm<GatheringForm>({
-    resolver: zodResolver(gatheringFormSchema),
+    // schema는 mode/status에 따라 create/RECRUITING/IN_PROGRESS 스키마 중 하나로 바뀌지만
+    // 셋 다 GatheringForm 필드의 부분집합만 optional로 검증하므로 폼 타입과 안전하게 호환됨
+    resolver: zodResolver(schema) as Resolver<GatheringForm>,
     mode: 'onBlur',
     defaultValues: {
       tags: [],
@@ -501,6 +528,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모집 마감 일정을 선택해주세요'
                   error={errors.recruitDeadline?.message}
+                  disabled={isInProgressEdit}
                   className='bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>
@@ -532,6 +560,7 @@ export function CreateGatheringForm({ mode = 'create', gatheringId, initialValue
                   onBlur={field.onBlur}
                   placeholder='모임 시작일을 선택해주세요'
                   error={errors.startDate?.message}
+                  disabled={isInProgressEdit}
                   className='bg-gray-0 h-[43px] md:h-[58px] lg:h-[72px] lg:px-7 lg:py-5'
                 />
               </div>

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse, delay } from 'msw';
 
-import { gatheringFormBaseSchema, gatheringUpdateFormSchema } from '@/api/gatherings/schemas';
+import { gatheringFormBaseSchema } from '@/api/gatherings/schemas';
 import { getTotalWeeks } from '@/lib/formatGatheringDate';
 import { createApiResponse } from '../utils';
 import { CURRENT_USER, GATHERING_MEMBERS } from '../_data';
@@ -43,7 +43,8 @@ import type { GatheringType } from '@/api/gatherings/types';
 const createBodySchema = gatheringFormBaseSchema
   .omit({ images: true })
   .extend({ type: z.enum(['STUDY', 'PROJECT', '스터디', '프로젝트']) });
-const updateBodySchema = gatheringUpdateFormSchema
+const updateBodySchema = gatheringFormBaseSchema
+  .partial()
   .omit({ images: true })
   .extend({ type: z.enum(['STUDY', 'PROJECT', '스터디', '프로젝트']).optional() });
 


### PR DESCRIPTION
## ❓ 이슈

- close #369 

## ✍️ Description

모임 수정 폼이 생성 폼과 동일한 날짜 검증 스키마(gatheringFormSchema)를 그대로 재사용하고 있어서, 이미 시작된(진행중) 모임을 수정하려고 하면 "오늘 이후여야 합니다" 에러로 저장 자체가 불가능한 버그가 있었습니다. 
모임 상태(RECRUITING/IN_PROGRESS/COMPLETED)에 따라 다른 검증 정책을 적용하도록 정리했습니다.

상태별 정책
- RECRUITING (모집중): 기존과 동일하게 모집 마감일/시작일/종료일 모두 "오늘 이후" + 순서(마감일<시작일<종료일) 검증
- IN_PROGRESS (진행중): 모집 마감일·시작일은 변경 자체를 차단(기존 값과 다르면 에러), 종료일은 기존 시작일 이후인지만 검증. 날짜 입력 필드는 disabled 처리하여 UI에서도 변경 시도 자체를 막음
- COMPLETED (완료): 수정 화면 진입 자체를 차단(상세 페이지로 리다이렉트), 수정 버튼도 드롭다운에서 비활성화

백엔드에서도 validateInProgressImmutableFields로 동일한 정책(진행중 모임의 불변 필드 검증)을 서버 단에서 최종 방어하고 있음을 확인했습니다. 이번 변경은 프론트에서도 동일한 정책을 이중으로 반영해, UX 차원에서 사용자가 애초에 잘못된 요청을 보내지 않도록 막는 것이 목적입니다.

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


- [x] 모집중 모임 수정 → 날짜 자유 변경 가능 확인
- [x] 진행중 모임 수정 → 마감일/시작일 필드 비활성화 확인, 종료일만 변경 가능 확인
- [x] 완료된 모임 → /edit 직접 URL 접근 시 상세 페이지로 리다이렉트 확인
- [x] 완료된 모임 → 상세 페이지 수정 버튼 비활성화 확인
