### PR TITLE
[SM-219] refactor: 참여 멤버 리스트 UI를 아바타 그룹 링크 → 텍스트 링크 방식으로 변경

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoAside/index.tsx
@@ -82,7 +82,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
     <div>
       {/* 모집 상태 바 - 항상 노출 */}
       {tagState === 'recruiting' && (
-        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+        <div className='border-focus-100 mb-4 flex justify-between rounded-lg border bg-blue-100 px-8 py-2.5'>
           <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
           <div className='flex items-center gap-2'>
             <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
@@ -93,7 +93,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
         </div>
       )}
       {tagState === 'progressing' && (
-        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+        <div className='border-focus-100 mb-4 flex justify-between rounded-lg border bg-blue-100 px-8 py-2.5'>
           <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
           <div className='flex items-center gap-2'>
             <span className='text-body-02-sb text-blue-300'>{getCurrentWeek(data.startDate)}주차</span>
@@ -102,7 +102,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
         </div>
       )}
       {tagState === 'completed' && (
-        <div className='border-gray-150 bg-gray-150 mb-4 flex justify-between rounded-[8px] border px-8 py-2.5'>
+        <div className='border-gray-150 bg-gray-150 mb-4 flex justify-between rounded-lg border px-8 py-2.5'>
           <div className='text-body-02-sb flex items-center text-gray-600'>{displayLabel}</div>
           <div className='flex items-center gap-2'>
             <span className='text-body-02-m text-gray-500'>완료된 모임</span>
@@ -159,7 +159,7 @@ export function GatheringInfoAside({ gatheringId }: GatheringInfoAsideProps) {
 
             <div className='flex flex-col'>
               <InfoAccordion data={data} className='mb-7' />
-              <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-7' />
+              <ParticipantsList members={data.members} className='mb-7' />
             </div>
 
             <Button

--- a/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/GatheringInfoCard/index.tsx
@@ -22,7 +22,7 @@ export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
   return (
     <section className='xl:hidden'>
       {tagState === 'recruiting' && (
-        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+        <div className='border-focus-100 mb-4 flex justify-between rounded-lg border bg-blue-100 px-8 py-2.5'>
           <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
           <div className='flex items-center gap-2'>
             <span className='text-body-02-m text-gray-700'>모집 마감까지</span>
@@ -34,7 +34,7 @@ export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
       )}
 
       {tagState === 'progressing' && (
-        <div className='border-focus-100 mb-4 flex justify-between rounded-[8px] border bg-blue-100 px-8 py-2.5'>
+        <div className='border-focus-100 mb-4 flex justify-between rounded-lg border bg-blue-100 px-8 py-2.5'>
           <div className='text-body-02-sb flex items-center text-blue-400'>{displayLabel}</div>
           <div className='flex items-center gap-2'>
             <span className='text-body-02-sb text-blue-300'>{getCurrentWeek(data.startDate)}주차</span>
@@ -44,7 +44,7 @@ export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
       )}
 
       {tagState === 'completed' && (
-        <div className='border-gray-150 bg-gray-150 mb-4 flex justify-between rounded-[8px] border px-8 py-2.5'>
+        <div className='border-gray-150 bg-gray-150 mb-4 flex justify-between rounded-lg border px-8 py-2.5'>
           <div className='text-body-02-sb flex items-center text-gray-600'>{displayLabel}</div>
           <div className='flex items-center gap-2'>
             <span className='text-body-02-m text-gray-500'>완료된 모임</span>
@@ -56,7 +56,7 @@ export function GatheringInfoCard({ gatheringId }: GatheringInfoCardProps) {
       <InfoAccordion data={data} className='mb-4' />
 
       {/* 참여자 목록 */}
-      <ParticipantsList members={data.members} maxMembers={data.maxMembers} className='mb-8' />
+      <ParticipantsList members={data.members} className='mb-8' />
     </section>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -3,12 +3,12 @@
 import { cn } from '@/lib/cn';
 import { AvatarGroup } from '@/components/ui/AvatarGroup';
 import { Dropdown } from '@/components/ui/Dropdown';
+import { ArrowIcon } from '@/components/ui/Icon';
 import { useOverlay } from '@/hooks/useOverlay';
 
 import { MemberDetailModal } from '../MemberDetailModal';
 
 import type { MemberInfo } from '@/api/gatherings/types';
-import { ArrowIcon } from '@/components/ui/Icon';
 
 interface ParticipantsListProps {
   members: MemberInfo[];

--- a/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/ParticipantsList/index.tsx
@@ -8,31 +8,26 @@ import { useOverlay } from '@/hooks/useOverlay';
 import { MemberDetailModal } from '../MemberDetailModal';
 
 import type { MemberInfo } from '@/api/gatherings/types';
+import { ArrowIcon } from '@/components/ui/Icon';
 
 interface ParticipantsListProps {
   members: MemberInfo[];
-  maxMembers: number;
   className?: string;
 }
 
-export function ParticipantsList({ members, maxMembers, className }: ParticipantsListProps) {
+export function ParticipantsList({ members, className }: ParticipantsListProps) {
   const overlay = useOverlay();
-  const remainingCount = maxMembers - members.length;
 
   return (
     <div className={cn('flex items-center justify-end gap-2', className)}>
       <Dropdown>
         <Dropdown.Trigger>
-          <div className='relative flex cursor-pointer items-center'>
-            <AvatarGroup
-              avatars={members.map((member) => ({ id: member.userId, imageUrl: member.profileImage }))}
-              max={maxMembers}
-              size='md'
-              shape='full'
-            />
+          <div className='text-body-02-m relative flex cursor-pointer items-center text-blue-400'>
+            참여 멤버 보기
+            <ArrowIcon size={24} className='text-body-02-m text-blue-400' />
           </div>
         </Dropdown.Trigger>
-        <Dropdown.Menu className='custom-scrollbar shadow-01 absolute top-[-20px] right-[-110px] z-50 mt-2 max-h-84.5 w-55 overflow-y-auto rounded-lg bg-white p-2 md:right-[-130px] md:w-48'>
+        <Dropdown.Menu className='custom-scrollbar shadow-01 absolute -top-2.5 -right-27.5 z-50 mt-2 max-h-84.5 w-55 overflow-y-auto rounded-lg bg-white p-2 md:w-48'>
           {members.map((member) => (
             <Dropdown.Item
               key={member.userId}
@@ -59,12 +54,6 @@ export function ParticipantsList({ members, maxMembers, className }: Participant
           ))}
         </Dropdown.Menu>
       </Dropdown>
-
-      {remainingCount > 0 && (
-        <span className='text-small-01-sb text-blue-300'>
-          <span className='mr-2'>·</span> {remainingCount}명 남음
-        </span>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## ❓ 이슈

- close #379

## ✍️ Description

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다! -->
- Dropdown.Trigger UI를 AvatarGroup에서 텍스트("참여 멤버 보기") + ArrowIcon으로 교체
- maxMembers prop 및 remainingCount 계산 로직 제거 (컴포넌트 인터페이스 단순화)
- Dropdown.Menu 위치 값(top/right)을 새 트리거 크기에 맞게 재조정
- 호출부(data.maxMembers 전달 코드) 정리

## 📸 스크린샷 (UI 변경 시)
<img width="598" height="735" alt="스크린샷 2026-08-01 오후 10 58 31" src="https://github.com/user-attachments/assets/4c4498f1-d1bf-43d8-84c7-326835899295" />

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
