### PR TITLE
[SM-220] fix: PWA 설치 프롬프트 미지원 환경 처리

### DIFF
--- a/src/components/Header/PWAInstallBanner/index.tsx
+++ b/src/components/Header/PWAInstallBanner/index.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 
 import { usePWAInstall } from '@/hooks/usePWAInstall';
 import { CloseIcon } from '@/components/ui/Icon';
+import { BottomSheet } from '@/components/ui/BottomSheet';
 import { IOSInstallGuideBottomSheet } from '@/components/PWAInstallButton/IOSInstallGuideBottomSheet';
 
 const LANDING_PATHNAME = '/';
@@ -15,21 +16,26 @@ const getIsDismissedFromStorage = () => sessionStorage.getItem(PWA_BANNER_DISMIS
 
 export function PWAInstallBanner() {
   const pathname = usePathname();
-  const { isIOS, promptInstall } = usePWAInstall();
+  const { isInstallable, isIOS, isStandalone, promptInstall } = usePWAInstall();
   const [isManuallyDismissed, setIsManuallyDismissed] = useState(false);
   const [isIOSGuideOpen, setIsIOSGuideOpen] = useState(false);
+  const [isDesktopGuideOpen, setIsDesktopGuideOpen] = useState(false);
 
   // sessionStorage는 마운트 시점에만 읽으면 되므로 subscribe는 no-op (변경 알림은 로컬 state로 처리)
   const isDismissedInSession = useSyncExternalStore(noopSubscribe, getIsDismissedFromStorage, () => false);
   const isDismissed = isManuallyDismissed || isDismissedInSession;
 
-  const isVisible = pathname === LANDING_PATHNAME && !isDismissed;
+  const isVisible = pathname === LANDING_PATHNAME && !isDismissed && !isStandalone;
 
   if (!isVisible) return null;
 
   const handleInstallClick = () => {
     if (isIOS) {
       setIsIOSGuideOpen(true);
+      return;
+    }
+    if (!isInstallable) {
+      setIsDesktopGuideOpen(true);
       return;
     }
     void promptInstall();
@@ -65,6 +71,27 @@ export function PWAInstallBanner() {
         </button>
       </div>
       {isIOS && <IOSInstallGuideBottomSheet isOpen={isIOSGuideOpen} onClose={() => setIsIOSGuideOpen(false)} />}
+      <DesktopInstallGuideBottomSheet isOpen={isDesktopGuideOpen} onClose={() => setIsDesktopGuideOpen(false)} />
     </>
+  );
+}
+
+interface DesktopInstallGuideBottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function DesktopInstallGuideBottomSheet({ isOpen, onClose }: DesktopInstallGuideBottomSheetProps) {
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose} ariaLabel='브라우저 앱 설치 안내'>
+      <BottomSheet.Header>
+        <h2 className='text-h5-b text-gray-800'>브라우저에서 앱 설치하기</h2>
+      </BottomSheet.Header>
+      <BottomSheet.Body>
+        <p className='text-body-02-m text-gray-700'>
+          주소창 오른쪽의 설치 아이콘이나 Chrome 메뉴의 저장 및 공유에서 완성도를 설치할 수 있어요.
+        </p>
+      </BottomSheet.Body>
+    </BottomSheet>
   );
 }


### PR DESCRIPTION
## ❓ 이슈

- close #381
- Jira: SM-220

## ✍️ Description

PWA 설치 프롬프트가 지원되지 않는 브라우저에서도 앱 설치 유도 UI가 무응답처럼 보이지 않도록 개선했습니다.

- `beforeinstallprompt` 이벤트를 저장한 환경에서는 사용자가 `앱 설치하기`를 클릭했을 때 브라우저 설치 프롬프트를 띄웁니다.
- 설치 프롬프트가 제공되지 않는 환경에서는 앱 설치 유도 UI를 유지하고, 클릭 시 브라우저별 수동 설치 안내를 보여줍니다.
- iOS Safari에서는 기존처럼 공유 버튼에서 홈 화면 추가를 안내합니다.
- 이미 설치 앱 모드(`display-mode: standalone`)로 실행 중이면 설치 유도 UI를 숨깁니다.

## 📸 스크린샷 (UI 변경 시)

- 없음

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)
