### PR TITLE
[SM-223] style: 메인/탐색 UI 디자인 시안 반영

### DIFF
--- a/src/app/main/components/HeroSection/index.tsx
+++ b/src/app/main/components/HeroSection/index.tsx
@@ -3,10 +3,12 @@ import { MainHeroSearchForm } from './MainHeroSearchForm';
 export function HeroSection() {
   return (
     <section className='bg-gradient-sub-200 w-full'>
-      <div className='mx-auto flex max-w-420 flex-col items-center px-4 pt-20 pb-10 md:px-7 md:pb-14 xl:pb-20'>
-        <div className='mb-10 flex flex-col items-center justify-center gap-4 md:mb-12'>
-          <h1 className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-blue-400'>모임 탐색</h1>
-          <h2 className='text-h5-b md:text-h3-b lg:text-h2-b text-gray-900'>원하는 모임을 찾아보세요.</h2>
+      <div className='mx-auto flex h-[277px] w-[calc(100%_-_32px)] max-w-420 flex-col items-center pt-[50px] min-[744px]:h-[419px] min-[744px]:w-[calc(100%_-_56px)] min-[744px]:pt-20 xl:h-[382px] xl:w-[calc(100%_-_clamp(56px,_12.5vw,_240px))] xl:max-w-none'>
+        <div className='mb-5 flex w-[247px] flex-col items-center justify-center gap-4 min-[744px]:mb-8 min-[744px]:w-[410px] xl:gap-2'>
+          <h1 className='text-small-02-sb min-[744px]:text-body-02-sb xl:text-body-01-sb text-blue-400'>모임 탐색</h1>
+          <h2 className='text-h5-b min-[744px]:text-h3-b xl:text-h2-b w-full text-center whitespace-nowrap text-gray-900'>
+            원하는 모임을 찾아보세요.
+          </h2>
         </div>
         <MainHeroSearchForm />
       </div>

--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
-import { HeartIcon, PersonIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
+import { HeartIcon, PersonIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
 import { useLikeToggle } from '@/api/likes/hooks';
@@ -22,11 +22,6 @@ interface MainGatheringCardProps {
 const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
 const formatDate = (isoDate: string) => isoDate.slice(0, 10);
-
-const TYPE_ICON = {
-  스터디: StudyIcon,
-  프로젝트: ProjectIcon,
-} as const;
 
 const toDeadlineDdayLabel = (recruitDeadline: string) => {
   const today = new Date();
@@ -66,15 +61,7 @@ export function MainGatheringCard({
   return (
     <GatheringCard className={cn('flex h-full flex-col', className)}>
       <GatheringCard.Header className='items-center'>
-        <Tag
-          variant='category'
-          icon={(() => {
-            const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] || StudyIcon;
-            return <Icon size={14} className='text-blue-200' />;
-          })()}
-          label={gathering.type}
-          sublabel={gathering.categories.join(', ')}
-        />
+        <Tag variant='category' label={gathering.type} sublabel={gathering.categories.join(', ')} />
         <div className='text-small-02-sb md:text-small-01-sb flex items-center'>
           <PersonIcon size={16} className='mr-2 text-blue-400' />
           <span className='text-blue-400'>{gathering.currentMembers}</span>

--- a/src/components/Search/GatheringFilterBar/StatusFilter.tsx
+++ b/src/components/Search/GatheringFilterBar/StatusFilter.tsx
@@ -35,7 +35,7 @@ export function StatusFilter({ value, onChange }: StatusFilterProps) {
 
   return (
     <Dropdown className='**:[[role=listbox]]:-left-3'>
-      <Dropdown.Trigger>
+      <Dropdown.Trigger className='cursor-pointer'>
         <div className='flex items-center gap-2'>
           <span className='text-small-02-m md:text-body-02-m text-gray-800'>{selectedLabel}</span>
           <RotatingArrow />

--- a/src/components/Search/HeroSearchForm/index.tsx
+++ b/src/components/Search/HeroSearchForm/index.tsx
@@ -23,14 +23,14 @@ const ALL_CATEGORY_LABEL = '카테고리 전체';
 
 function HeroSearchFormSkeleton() {
   return (
-    <div className='flex w-full flex-col gap-5'>
-      <div className='flex w-full gap-4'>
-        <div className='h-14 flex-1 animate-pulse rounded-lg bg-gray-100 md:h-18' />
-        <div className='h-14 w-14 shrink-0 animate-pulse rounded-lg bg-gray-100 md:h-18 md:w-18' />
+    <div className='flex w-full flex-col gap-2 min-[744px]:gap-4'>
+      <div className='flex w-full gap-2 min-[744px]:gap-4'>
+        <div className='h-[54px] flex-1 animate-pulse rounded-xl bg-gray-100 min-[744px]:h-18 min-[744px]:rounded-2xl' />
+        <div className='h-[54px] w-[54px] shrink-0 animate-pulse rounded-xl bg-gray-100 min-[744px]:h-18 min-[744px]:w-18' />
       </div>
-      <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
-        <div className='h-9 w-full max-w-md animate-pulse rounded-md bg-gray-100' />
-        <div className='h-8 w-64 animate-pulse rounded-md bg-gray-100' />
+      <div className='flex flex-col gap-2 min-[744px]:gap-4 xl:w-[calc(100%_-_88px)] xl:flex-row xl:items-center xl:justify-between xl:self-start'>
+        <div className='h-5 w-full max-w-2xl animate-pulse rounded-md bg-gray-100 min-[744px]:h-9' />
+        <div className='h-5 w-48 animate-pulse rounded-md bg-gray-100 min-[744px]:h-8' />
       </div>
     </div>
   );
@@ -58,13 +58,21 @@ export function HeroSearchFormBoundary({ children }: HeroSearchFormBoundaryProps
   );
 }
 
-function FilterArrow() {
+interface FilterArrowProps {
+  className?: string;
+}
+
+function FilterArrow({ className }: FilterArrowProps) {
   const { isOpen } = useDropdown();
 
   return (
     <ArrowIcon
       size={16}
-      className={cn('shrink-0 rotate-90 text-gray-800 transition-transform duration-200', isOpen && 'rotate-270')}
+      className={cn(
+        'shrink-0 rotate-90 text-gray-800 transition-transform duration-200',
+        className,
+        isOpen && 'rotate-270',
+      )}
     />
   );
 }
@@ -89,9 +97,9 @@ function HeroFilterDropdown<T extends string | number>({
   return (
     <Dropdown className='**:[[role=listbox]]:right-0 **:[[role=listbox]]:w-40'>
       <Dropdown.Trigger>
-        <div className='text-body-02-sb md:text-body-01-sb flex cursor-pointer items-center gap-2 text-gray-800'>
+        <div className='text-small-02-sb min-[744px]:text-body-01-sb flex cursor-pointer items-center gap-1 text-gray-800 min-[744px]:gap-2'>
           <span>{selectedLabel}</span>
-          <FilterArrow />
+          <FilterArrow className='size-4 min-[744px]:size-6' />
         </div>
       </Dropdown.Trigger>
       <Dropdown.Menu className='flex flex-col gap-1 p-2' containerClassName='right-0'>
@@ -183,42 +191,44 @@ export function HeroSearchForm({
   };
 
   return (
-    <div className='flex w-full flex-col gap-5'>
-      <form onSubmit={handleSubmit} className='flex w-full gap-4'>
-        <div className='border-gradient-primary bg-gray-0 flex h-14 flex-1 items-center gap-3 rounded-lg px-5 md:h-18 md:px-7'>
+    <div className='flex w-full flex-col gap-2 min-[744px]:gap-4'>
+      <form onSubmit={handleSubmit} className='flex w-full gap-2 min-[744px]:gap-4'>
+        <div className='border-gradient-primary bg-gray-0 flex h-[54px] min-w-0 flex-1 items-center rounded-xl px-[21px] min-[744px]:h-18 min-[744px]:rounded-2xl min-[744px]:px-7'>
           <input
             type='text'
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
             placeholder='모임명 또는 키워드를 검색하세요'
-            className='text-body-02-r md:text-body-01-r h-full w-full outline-none placeholder:text-gray-400'
+            className='text-small-01-r min-[744px]:text-body-01-r h-full w-full min-w-0 outline-none placeholder:text-gray-600'
           />
         </div>
         <button
           type='submit'
           aria-label='모임 검색'
-          className='flex h-14 w-14 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-blue-300 text-white transition-colors hover:bg-blue-400 md:h-18 md:w-18'
+          className='flex h-[54px] w-[54px] shrink-0 cursor-pointer items-center justify-center rounded-xl bg-blue-300 text-white transition-colors hover:bg-blue-400 min-[744px]:h-18 min-[744px]:w-18'
         >
-          <SearchIcon className='h-6 w-6 md:h-8 md:w-8' />
+          <SearchIcon className='size-6 min-[744px]:size-8' />
         </button>
       </form>
 
-      <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
-        <div className='flex flex-wrap items-center gap-2 md:gap-3'>
-          <span className='text-small-01-sb md:text-body-02-sb mr-2 text-gray-600'>추천 검색어</span>
+      <div className='flex flex-col gap-2 min-[744px]:gap-4 xl:w-[calc(100%_-_88px)] xl:flex-row xl:items-center xl:justify-between xl:self-start'>
+        <div className='flex flex-wrap items-center gap-1.5 min-[744px]:gap-2'>
+          <span className='min-[744px]:text-body-02-sb text-[8px] leading-[160%] font-semibold text-gray-700 min-[744px]:mr-3'>
+            추천 검색어
+          </span>
           {RECOMMENDED_KEYWORDS.map((keyword) => (
             <button
               key={keyword}
               type='button'
               onClick={() => handleKeywordClick(keyword)}
-              className='text-small-01-r md:text-body-02-r bg-gray-0 cursor-pointer rounded-md px-4 py-2 text-gray-700 transition-colors hover:bg-blue-100 hover:text-blue-400'
+              className='min-[744px]:text-body-02-m cursor-pointer rounded-md bg-gray-50 px-3 py-1 text-[8px] leading-[160%] font-medium text-gray-700 transition-colors hover:bg-blue-100 hover:text-blue-400 min-[744px]:rounded-lg min-[744px]:px-4'
             >
               {keyword}
             </button>
           ))}
         </div>
 
-        <div className='flex items-center justify-end gap-8 md:gap-12'>
+        <div className='flex items-center justify-start gap-5 xl:gap-7'>
           <HeroFilterDropdown<GatheringType>
             label={ALL_TYPE_LABEL}
             selectedLabel={type ?? ALL_TYPE_LABEL}

--- a/src/components/Search/SearchHero/index.tsx
+++ b/src/components/Search/SearchHero/index.tsx
@@ -7,12 +7,12 @@ interface SearchHeroProps {
 export function SearchHero({ children }: SearchHeroProps) {
   return (
     <section className='bg-gradient-sub-200 w-full'>
-      <div className='mx-auto flex max-w-420 flex-col items-center px-4 pt-20 pb-10 md:px-7 md:pb-14 xl:pb-20'>
-        <div className='mb-10 flex flex-col items-center gap-4 md:mb-12'>
-          <p className='text-small-02-m md:text-body-02-sb xl:text-body-01-sb font-semibold text-blue-400 md:font-semibold'>
-            모임 탐색
-          </p>
-          <h1 className='text-h5-b md:text-h3-b xl:text-h2-b text-gray-900'>원하는 모임을 찾아보세요.</h1>
+      <div className='mx-auto flex h-[277px] w-[calc(100%_-_32px)] max-w-420 flex-col items-center pt-[50px] min-[744px]:h-[419px] min-[744px]:w-[calc(100%_-_56px)] min-[744px]:pt-20 xl:h-[382px] xl:w-[calc(100%_-_clamp(56px,_12.5vw,_240px))] xl:max-w-none'>
+        <div className='mb-5 flex w-[247px] flex-col items-center gap-4 min-[744px]:mb-8 min-[744px]:w-[410px] xl:gap-2'>
+          <p className='text-small-02-sb min-[744px]:text-body-02-sb xl:text-body-01-sb text-blue-400'>모임 탐색</p>
+          <h1 className='text-h5-b min-[744px]:text-h3-b xl:text-h2-b w-full text-center whitespace-nowrap text-gray-900'>
+            원하는 모임을 찾아보세요.
+          </h1>
         </div>
         {children}
       </div>

--- a/src/components/ui/Dropdown/Trigger.tsx
+++ b/src/components/ui/Dropdown/Trigger.tsx
@@ -10,9 +10,10 @@ import { useDropdown } from './context';
 
 interface TriggerProps {
   children: ReactNode;
+  className?: string;
 }
 
-export function Trigger({ children }: TriggerProps) {
+export function Trigger({ children, className }: TriggerProps) {
   const { toggle, isOpen, close } = useDropdown();
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -36,7 +37,7 @@ export function Trigger({ children }: TriggerProps) {
       onClick={toggle}
       onKeyDown={handleKeyDown}
       style={{ transitionDuration: `${OVERLAY_ANIMATION_DURATION}ms` }}
-      className={cn('transition-colors')}
+      className={cn('transition-colors', className)}
     >
       {children}
     </button>

--- a/src/components/ui/Tag/types.ts
+++ b/src/components/ui/Tag/types.ts
@@ -4,7 +4,7 @@ type TagBaseProps = Omit<React.ComponentProps<'span'>, 'color' | 'children'>;
 
 interface CategoryTagProps extends TagBaseProps {
   variant: 'category';
-  icon: ReactNode;
+  icon?: ReactNode;
   label: string;
   sublabel: string;
 }


### PR DESCRIPTION
## ❓ 이슈

- close #388
- Jira: SM-223

## ✍️ Description

SM-223 디자인 반영 범위로 메인/탐색 카드와 검색 UI의 시각 요소를 정리했습니다.

- `MainGatheringCard`에서 카테고리 태그에 전달하던 `StudyIcon`, `ProjectIcon`을 제거했습니다. 메인 페이지와 모임 탐색 페이지의 카드 상단 태그가 Figma 기준처럼 `스터디 > 개발`, `프로젝트 > 기타` 형태의 텍스트만 노출되도록 맞췄고, 공통 `Tag`의 category icon prop은 다른 사용처를 위해 optional로 유지했습니다.
- 공통 `Dropdown.Trigger`가 `className`을 받을 수 있도록 확장하고, 모임 탐색 페이지의 상태 필터 트리거에 `cursor-pointer`를 적용했습니다. 기존 Dropdown 기본 스타일은 유지하면서 클릭 가능한 필터 UI임을 커서 상태로 드러내도록 정리했습니다.
- Figma MCP로 확인한 PC, tablet, mobile 검색섹션 프레임 기준에 맞춰 `/main`과 `/gatherings`의 검색 히어로 높이, 제목 위치, 검색 폼 크기를 조정했습니다. `HeroSearchForm`은 공통 컴포넌트로 유지해 두 페이지가 같은 검색 UI 규칙을 공유하도록 했습니다.
- tablet 시안이 `744px` 기준이라 Tailwind 기본 `md(768px)` 대신 검색 히어로 내부에서 `min-[744px]` breakpoint를 사용했습니다.
- PC에서는 1920px 기준 Figma와 동일한 좌우 120px 여백을 유지하면서, 1300px대 노트북 화면에서도 검색 영역이 화면 끝까지 붙지 않도록 `calc`와 `clamp` 기반 유동 폭을 적용했습니다.

## 📸 스크린샷 (UI 변경 시)

- Figma MCP 기준 검색 히어로 치수 확인
  - PC 1920px: `section 1920x382`, `form x=120 y=216 w=1680 h=72`
  - 1300px 노트북: `form x=81.3 w=1137.5 h=72`
  - Tablet 744px: `form x=28 y=204.8 w=688 h=72`
  - Mobile 375px: `form x=16 y=143.6 w=343 h=54`

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 타입 체크 통과 (`npx tsc --noEmit`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)
