### PR TITLE
[SM-226] fix: 모임 카드 상태 라벨 표시 개선

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/DeadlineLabel/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/DeadlineLabel/index.tsx
@@ -1,19 +1,10 @@
-import { formatDate, MILLISECONDS_IN_A_DAY } from '../utils/dateUtils';
+import { formatRecruitDeadlineDday } from '@/lib/formatGatheringDate';
 
 interface DeadlineLabelProps {
   recruitDeadline: string;
 }
 
 export function DeadlineLabel({ recruitDeadline }: DeadlineLabelProps) {
-  const today = new Date();
-  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-
-  const deadline = new Date(recruitDeadline);
-  if (Number.isNaN(deadline.getTime())) {
-    return <span>{formatDate(recruitDeadline)}</span>;
-  }
-  const deadlineMidnight = new Date(deadline.getFullYear(), deadline.getMonth(), deadline.getDate());
-  const diffDays = Math.ceil((deadlineMidnight.getTime() - todayMidnight.getTime()) / MILLISECONDS_IN_A_DAY);
-  const label = diffDays > 0 ? `D-${diffDays}` : diffDays === 0 ? 'D-day' : '마감';
+  const label = formatRecruitDeadlineDday(recruitDeadline);
   return <span className='text-small-01-sb text-red-200'>{label}</span>;
 }

--- a/src/app/main/components/MyGatheringSection/MyGatheringCard/index.tsx
+++ b/src/app/main/components/MyGatheringSection/MyGatheringCard/index.tsx
@@ -3,7 +3,6 @@ import { differenceInDays, startOfDay } from 'date-fns';
 import { cn } from '@/lib/cn';
 import { AvatarGroup } from '@/components/ui/AvatarGroup';
 import { GatheringCard } from '@/components/ui/GatheringCard';
-import { ProjectIcon, StudyIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { Tag } from '@/components/ui/Tag';
 
@@ -14,11 +13,6 @@ interface MyGatheringCardProps {
   onClick?: () => void;
   className?: string;
 }
-
-const TYPE_ICON = {
-  스터디: StudyIcon,
-  프로젝트: ProjectIcon,
-} as const;
 
 export function MyGatheringCard({ gathering, members = [], onClick, className }: MyGatheringCardProps) {
   const now = startOfDay(new Date());
@@ -31,20 +25,12 @@ export function MyGatheringCard({ gathering, members = [], onClick, className }:
   const passedDays = differenceInDays(now, startDate);
   const progressRate = totalDays > 0 ? Math.min(100, Math.max(0, Math.floor((passedDays / totalDays) * 100))) : 0;
 
-  const dDayText = dDay > 0 ? `D-${dDay}` : dDay === 0 ? 'D-Day' : `D+${Math.abs(dDay)}`;
+  const goalLabel = dDay > 0 ? `목표 D-${dDay}` : dDay === 0 ? '목표 D-Day' : '목표달성';
 
   return (
     <GatheringCard onClick={onClick} className={cn('flex h-full cursor-pointer flex-col', className)}>
       <GatheringCard.Header className='items-center'>
-        <Tag
-          variant='category'
-          icon={(() => {
-            const Icon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] || StudyIcon;
-            return <Icon size={14} className='text-blue-200' />;
-          })()}
-          label={gathering.type}
-          sublabel={gathering.categories.join(', ')}
-        />
+        <Tag variant='category' label={gathering.type} sublabel={gathering.categories.join(', ')} />
         <AvatarGroup max={4} avatars={members.map((m) => ({ id: m.userId, imageUrl: m.profileImage }))} size='sm' />
       </GatheringCard.Header>
       <GatheringCard.Body className='flex-1'>
@@ -63,7 +49,7 @@ export function MyGatheringCard({ gathering, members = [], onClick, className }:
         <div className='mb-1.5 flex gap-1'>
           <Tag variant='duration'>총 {totalWeeks}주</Tag>
           <Tag variant='deadline' state='goal'>
-            목표 {dDayText}
+            {goalLabel}
           </Tag>
         </div>
       </GatheringCard.Body>

--- a/src/app/main/components/MyGatheringSection/MyGatheringCard/index.tsx
+++ b/src/app/main/components/MyGatheringSection/MyGatheringCard/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { differenceInDays, startOfDay } from 'date-fns';
 
 import { cn } from '@/lib/cn';

--- a/src/app/my/_components/LikedGatheringCard/index.tsx
+++ b/src/app/my/_components/LikedGatheringCard/index.tsx
@@ -7,32 +7,17 @@ import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, PersonIcon, StudyIcon, ProjectIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
+import { formatRecruitDeadlineLabel } from '@/lib/formatGatheringDate';
 import { getGatheringDisplayStatus } from '@/lib/gatheringStatus';
 
 import type { GatheringListItem } from '@/api/gatherings/types';
 
 const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
 
-const formatDate = (isoDate: string) => isoDate.slice(0, 10);
-
 const TYPE_ICON = {
   스터디: StudyIcon,
   프로젝트: ProjectIcon,
 } as const;
-
-const toDeadlineDdayLabel = (recruitDeadline: string) => {
-  const today = new Date();
-  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-
-  const deadline = new Date(recruitDeadline);
-  if (Number.isNaN(deadline.getTime())) {
-    return `모집 마감 ${formatDate(recruitDeadline)}`;
-  }
-  const deadlineMidnight = new Date(deadline.getFullYear(), deadline.getMonth(), deadline.getDate());
-  const diffDays = Math.ceil((deadlineMidnight.getTime() - todayMidnight.getTime()) / MILLISECONDS_IN_A_DAY);
-
-  return `모집 마감 D-${Math.max(0, diffDays)}`;
-};
 
 const toWeeksLabel = (startDate: string, endDate: string) => {
   const start = new Date(startDate);
@@ -67,7 +52,7 @@ export function LikedGatheringCard({
   });
 
   const totalWeeksLabel = toWeeksLabel(gathering.startDate, gathering.endDate);
-  const deadlineLabel = toDeadlineDdayLabel(gathering.recruitDeadline);
+  const deadlineLabel = formatRecruitDeadlineLabel(gathering.recruitDeadline);
 
   const CategoryIcon = TYPE_ICON[gathering.type as keyof typeof TYPE_ICON] ?? StudyIcon;
 

--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -5,6 +5,7 @@ import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, PersonIcon } from '@/components/ui/Icon';
 import { Tag } from '@/components/ui/Tag';
 import { cn } from '@/lib/cn';
+import { formatRecruitDeadlineLabel } from '@/lib/formatGatheringDate';
 import { useLikeToggle } from '@/api/likes/hooks';
 
 import type { GatheringListItem } from '@/api/gatherings/types';
@@ -20,22 +21,6 @@ interface MainGatheringCardProps {
 }
 
 const MILLISECONDS_IN_A_DAY = 1000 * 60 * 60 * 24;
-
-const formatDate = (isoDate: string) => isoDate.slice(0, 10);
-
-const toDeadlineDdayLabel = (recruitDeadline: string) => {
-  const today = new Date();
-  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-
-  const deadline = new Date(recruitDeadline);
-  if (Number.isNaN(deadline.getTime())) {
-    return `모집 마감 ${formatDate(recruitDeadline)}`;
-  }
-  const deadlineMidnight = new Date(deadline.getFullYear(), deadline.getMonth(), deadline.getDate());
-  const diffDays = Math.ceil((deadlineMidnight.getTime() - todayMidnight.getTime()) / MILLISECONDS_IN_A_DAY);
-
-  return `모집 마감 D-${Math.max(0, diffDays)}`;
-};
 
 const toWeeksLabel = (startDate: string, endDate: string) => {
   const start = new Date(startDate);
@@ -56,7 +41,7 @@ export function MainGatheringCard({
   const { isLiked, toggleLike, isPending } = useLikeToggle(gathering.id);
 
   const totalWeeksLabel = toWeeksLabel(gathering.startDate, gathering.endDate);
-  const deadlineLabel = `${toDeadlineDdayLabel(gathering.recruitDeadline)}`;
+  const deadlineLabel = formatRecruitDeadlineLabel(gathering.recruitDeadline);
 
   return (
     <GatheringCard className={cn('flex h-full flex-col', className)}>

--- a/src/lib/formatGatheringDate.ts
+++ b/src/lib/formatGatheringDate.ts
@@ -29,6 +29,26 @@ export const formatDday = (targetDateString: string): string => {
   return `D+${Math.abs(diff)}`;
 };
 
+/** 모집 마감일까지의 D-day 텍스트 반환 ("D-3" | "D-day" | "마감") */
+export const formatRecruitDeadlineDday = (targetDateString: string): string => {
+  const today = startOfDay(new Date());
+  const target = startOfDay(new Date(targetDateString));
+
+  if (Number.isNaN(target.getTime())) return targetDateString.slice(0, 10);
+
+  const diff = differenceInDays(target, today);
+
+  if (diff > 0) return `D-${diff}`;
+  if (diff === 0) return 'D-day';
+  return '마감';
+};
+
+/** 모집 마감 라벨 반환 ("모집 마감 D-3" | "모집 마감 D-day" | "모집 마감") */
+export const formatRecruitDeadlineLabel = (targetDateString: string): string => {
+  const dday = formatRecruitDeadlineDday(targetDateString);
+  return dday === '마감' ? '모집 마감' : `모집 마감 ${dday}`;
+};
+
 /** 시작일과 종료일 사이의 총 주차 반환 */
 export const getTotalWeeks = (startDate: string, endDate: string): number => {
   const start = startOfDay(new Date(startDate));


### PR DESCRIPTION
## ❓ 이슈

- close #395
- Jira: SM-226

## ✍️ Description

SM-226 범위로 모임 카드와 상세 페이지의 모집 마감/D-day 라벨 표시 기준을 정리했습니다.

- D-day 계산과 표시 문구를 `formatGatheringDate` 유틸로 모아 메인 카드, 찜한 모임 카드, 상세 `DeadlineLabel`의 표시 기준을 맞췄습니다.
- 모집 마감 상태에서는 `모집 마감 마감`처럼 중복 문구가 나오지 않고 `모집 마감`만 보이도록 정리했습니다.
- 내 모임 카드에서는 카테고리 태그 아이콘을 제거하고, 목표 완료 상태는 `목표 d + n` 대신 `목표달성`으로 표시되도록 조정했습니다.

## 📸 스크린샷 (UI 변경 시)

- 모임 상세 마감 상태에서 `모집 마감` 단일 문구 확인
- 내 모임 카드 목표 완료 상태에서 `목표달성` 문구 확인
- 내 모임 카드 카테고리 태그 아이콘 제거 확인

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 타입 체크 통과 (`npx tsc --noEmit`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)