### PR TITLE
[SM-227] fix: 참여 멤버 상세 모달 반응형 UI 정리

### DIFF
--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/KeywordTags.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/KeywordTags.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { cn } from '@/lib/cn';
-import { Tag } from '@/components/ui/Tag';
+import { CloseIcon } from '@/components/ui/Icon';
 
 const TAGS_PER_PAGE_MOBILE = 2;
 const TAGS_PER_PAGE_TABLET = 6;
@@ -29,26 +29,31 @@ export function KeywordTags({ tags }: KeywordTagsProps) {
   const tagsPerPage = isMobile ? TAGS_PER_PAGE_MOBILE : TAGS_PER_PAGE_TABLET;
   const totalPages = Math.ceil((tags?.length || 0) / tagsPerPage);
   const safeIndex = currentIndex >= totalPages ? 0 : currentIndex;
-  const currentTags = tags.slice(safeIndex * tagsPerPage, (safeIndex + 1) * tagsPerPage);
+  const visibleTags = isMobile ? tags.slice(safeIndex * tagsPerPage, (safeIndex + 1) * tagsPerPage) : tags;
 
   if (!tags || tags.length === 0)
     return (
-      <div className='rounded-xl bg-gray-50 p-2 text-center text-sm text-gray-400'>
+      <div className='rounded-lg bg-gray-100 p-4 text-center text-sm text-gray-400'>
         아직 등록된 키워드 평가가 없습니다.
       </div>
     );
 
   return (
-    <div className='flex flex-col gap-2 rounded-xl bg-gray-50 p-2'>
-      <div className='flex min-h-[32px] items-center justify-center gap-2 md:min-h-[72px]'>
-        {currentTags.map((tag) => (
-          <Tag key={tag.text} variant='bad' count={tag.count} className='text-small-02-m md:text-small-01-m'>
+    <div className='flex min-h-[85px] flex-col gap-3 rounded-lg bg-gray-100 p-4 min-[744px]:min-h-[132px] min-[744px]:justify-center min-[744px]:gap-2 min-[744px]:p-6'>
+      <div className='flex min-w-0 flex-wrap items-center gap-2 overflow-hidden min-[744px]:overflow-visible'>
+        {visibleTags.map((tag) => (
+          <span
+            key={tag.text}
+            className='text-small-02-m min-[744px]:text-small-01-m bg-gray-150 inline-flex w-fit items-center justify-center gap-0.5 rounded-lg px-3 py-2 whitespace-nowrap text-gray-600'
+          >
             {tag.text}
-          </Tag>
+            <CloseIcon size={16} className='text-gray-400' />
+            <span className='text-small-02-m min-[744px]:text-small-01-m text-gray-700'>{tag.count}</span>
+          </span>
         ))}
       </div>
 
-      {totalPages > 1 && (
+      {isMobile && totalPages > 1 && (
         <div className='flex items-center justify-center gap-1.5'>
           {Array.from({ length: totalPages }).map((_, idx) => (
             <button

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/KeywordTags.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/KeywordTags.tsx
@@ -1,7 +1,9 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
-import { cn } from '@/lib/cn';
 import { CloseIcon } from '@/components/ui/Icon';
+import { cn } from '@/lib/cn';
 
 const TAGS_PER_PAGE_MOBILE = 2;
 const TAGS_PER_PAGE_TABLET = 6;

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ProfileHeader.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ProfileHeader.tsx
@@ -2,10 +2,11 @@
 
 import Image from 'next/image';
 
+import { IllustrationIcon } from '@/components/ui/Icon';
 import { ProgressBar } from '@/components/ui/Progress';
 import { Tag } from '@/components/ui/Tag';
-import { IllustrationIcon } from '@/components/ui/Icon';
 import { useFallbackImage } from '@/hooks/useFallbackImage';
+
 import type { UserPublicProfile } from '@/api/users/types';
 
 interface ProfileHeaderProps {

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ProfileHeader.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ProfileHeader.tsx
@@ -16,28 +16,28 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
   const { imgSrc, onError } = useFallbackImage(profile.profileImage);
 
   return (
-    <>
-      <div className='relative h-19.75 w-19.75 shrink-0 overflow-hidden rounded-2xl bg-gray-100 shadow-sm md:h-32.75 md:w-32.75'>
+    <div className='flex w-full items-center gap-4 min-[744px]:gap-6'>
+      <div className='relative size-19.75 shrink-0 overflow-hidden rounded-lg bg-gray-100 shadow-sm min-[744px]:size-32.75 min-[744px]:rounded-2xl'>
         <Image src={imgSrc} alt={`${profile.nickname} 프로필 이미지`} fill className='object-cover' onError={onError} />
       </div>
 
-      <div className='flex flex-1 flex-col justify-center'>
-        <div className='mb-4 flex items-center gap-4'>
-          <div className='text-body-02-b md:text-h3-b text-gray-900'>{profile.nickname}</div>
+      <div className='flex min-w-0 flex-1 flex-col justify-center gap-4 min-[744px]:gap-7'>
+        <div className='flex min-w-0 items-center gap-3 min-[744px]:gap-4'>
+          <div className='text-body-02-b min-[744px]:text-h3-b text-gray-900'>{profile.nickname}</div>
           <Tag variant='mate'>{profile.reputationLabel || '참여 메이트'}</Tag>
         </div>
-        <ProgressBar value={profile.reputationScore || 0} barClassName='h-4'>
+        <ProgressBar value={profile.reputationScore || 0} barClassName='h-2 min-[744px]:h-4'>
           <div className='text-small-02-m flex items-center justify-between'>
-            <div className='text-small-02-m md:text-body-01-m text-gray-800'>활동 에너지</div>
+            <div className='text-small-02-m min-[744px]:text-body-01-m text-gray-800'>활동 에너지</div>
             <div className='flex items-center gap-2'>
-              <span className='text-small-02-sb md:text-body-01-sb text-blue-300'>
+              <span className='text-small-02-sb min-[744px]:text-body-01-sb text-blue-300'>
                 {profile.reputationScore || 0}점
               </span>
-              <IllustrationIcon variant='fire' className='size-6 md:size-8' />
+              <IllustrationIcon variant='fire' className='size-5 min-[744px]:size-8' />
             </div>
           </div>
         </ProgressBar>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ReviewItem.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ReviewItem.tsx
@@ -15,9 +15,9 @@ export function ReviewItem({ review, profileImg }: ReviewItemProps) {
   const { imgSrc, onError } = useFallbackImage(profileImg);
 
   return (
-    <li className='border-gray-150 flex flex-col gap-2 rounded-xl border bg-gray-100 p-4 shadow-sm md:gap-4 md:p-6'>
+    <li className='border-gray-150 flex min-h-[118px] flex-col gap-2 rounded-lg border bg-gray-100 p-4 min-[744px]:min-h-[151px] min-[744px]:gap-4 min-[744px]:px-7 min-[744px]:py-6'>
       <div className='flex items-start gap-2'>
-        <div className='relative h-6 w-6 shrink-0 overflow-hidden rounded-lg bg-gray-200 md:h-12 md:w-12'>
+        <div className='relative size-6 shrink-0 overflow-hidden rounded bg-gray-200 min-[744px]:size-[45px] min-[744px]:rounded-lg'>
           <Image
             src={imgSrc}
             alt={`${review.reviewer?.nickname || '익명'} 프로필`}
@@ -27,17 +27,21 @@ export function ReviewItem({ review, profileImg }: ReviewItemProps) {
           />
         </div>
         <div className='flex flex-1 justify-between'>
-          <div className='flex flex-col text-left'>
-            <span className='md:text-body-02-sb text-[13px] font-bold text-gray-800'>
+          <div className='flex min-w-0 flex-col text-left'>
+            <span className='text-small-02-sb min-[744px]:text-body-02-sb truncate text-gray-800'>
               {review.reviewer?.nickname || '익명'}
             </span>
-            <span className='text-small-01-r text-gray-400'>{review.gatheringTitle}</span>
+            <span className='min-[744px]:text-small-02-r text-[8px] leading-[160%] font-normal break-keep text-gray-400'>
+              {review.gatheringTitle}
+            </span>
           </div>
-          <span className='md:text-small-01-r text-[8px] text-gray-400'>{formatReviewDate(review.createdAt)}</span>
+          <span className='min-[744px]:text-small-01-r text-[8px] text-gray-400'>
+            {formatReviewDate(review.createdAt)}
+          </span>
         </div>
       </div>
       <div className='border-gray-150 border-t' />
-      <p className='text-small-02-r md:text-body-02-r text-gray-700'>{review.comment}</p>
+      <p className='text-small-02-r min-[744px]:text-body-02-r text-gray-700'>{review.comment}</p>
     </li>
   );
 }

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ReviewItem.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/ReviewItem.tsx
@@ -3,7 +3,9 @@
 import Image from 'next/image';
 
 import { useFallbackImage } from '@/hooks/useFallbackImage';
+
 import { formatReviewDate } from '../../utils/dateUtils';
+
 import type { Review } from '@/api/reviews/types';
 
 interface ReviewItemProps {

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/index.tsx
@@ -17,22 +17,22 @@ export function MemberDetailContent({ memberId }: Pick<MemberDetailModalProps, '
 
   return (
     <>
-      <Modal.Header className='mt-6 flex gap-6'>
+      <Modal.Header className='px-5 pt-7 pb-4 min-[744px]:px-7 min-[744px]:pt-12 min-[744px]:pb-8'>
         <ProfileHeader profile={userProfile} />
       </Modal.Header>
 
-      <Modal.Body className='scrollbar-hide custom-scrollbar flex max-h-[60vh] flex-col gap-4 overflow-y-auto px-6'>
+      <Modal.Body className='scrollbar-hide custom-scrollbar flex flex-1 flex-col gap-6 overflow-y-auto px-5 py-0 min-[744px]:gap-8 min-[744px]:px-7'>
         <div className='border-gray-150 border-t' />
-        <section className='flex flex-col gap-2'>
-          <h3 className='text-small-02-sb md:text-body-01-sb text-gray-900'>키워드 평가</h3>
+        <section className='flex flex-col gap-2 min-[744px]:gap-4'>
+          <h3 className='text-small-02-sb min-[744px]:text-body-01-sb text-gray-900'>키워드 평가</h3>
           <KeywordTags tags={aggregatedTags} />
         </section>
-        <section className='flex w-full flex-col gap-3'>
-          <h3 className='text-small-02-sb md:text-body-01-sb text-gray-800'>
-            받은 리뷰 <span className='text-blue-500'>{reviewsData?.totalCount || 0}</span>
+        <section className='flex w-full flex-col gap-2 min-[744px]:gap-4'>
+          <h3 className='text-small-02-sb min-[744px]:text-body-01-sb text-gray-800'>
+            받은 리뷰 <span className='text-gray-600'>{reviewsData?.totalCount || 0}</span>
           </h3>
 
-          <ul className='flex w-full flex-col gap-2'>
+          <ul className='flex w-full flex-col gap-2 min-[744px]:gap-4 lg:gap-6'>
             {reviewsData?.reviews.map((review) => (
               <ReviewItem key={review.id} review={review} profileImg={reviewerProfilesMap[review.reviewer.id]} />
             ))}
@@ -40,15 +40,16 @@ export function MemberDetailContent({ memberId }: Pick<MemberDetailModalProps, '
         </section>
       </Modal.Body>
 
-      <Modal.Footer className='px-6'>
+      <Modal.Footer className='px-5 pt-6 pb-7 min-[744px]:px-7 min-[744px]:pt-8 min-[744px]:pb-12'>
         {totalPages > 1 && (
-          <div className='mt-2 mb-12 flex w-full justify-center'>
+          <div className='flex w-full justify-center'>
             <Pagination
               disabled={isPending}
               variant='numbered'
               currentPage={page}
               totalPages={totalPages}
               onPageChange={setPage}
+              className='min-[744px]:[&_button]:text-body-02-m min-[744px]:gap-10 min-[744px]:[&_svg]:size-12'
             />
           </div>
         )}

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/MemberDetailContent/index.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import { Modal } from '@/components/ui/Modal';
 import { Pagination } from '@/components/ui/Pagination';
+
 import { useMemberDetail } from '../../hooks/useMemberDetail';
 import { KeywordTags } from './KeywordTags';
 import { ProfileHeader } from './ProfileHeader';

--- a/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/index.tsx
+++ b/src/app/gatherings/[id]/_components/ApplySection/MemberDetailModal/index.tsx
@@ -13,8 +13,16 @@ interface MemberDetailModalProps<T = boolean> {
 
 export function MemberDetailModal({ memberId, isOpen, onClose }: MemberDetailModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={() => onClose(false)} className='w-[calc(100%-48px)] max-w-2xl md:w-full'>
-      <CloseIcon size={48} onClick={() => onClose(false)} className='absolute top-6 right-6 z-10 cursor-pointer p-2' />
+    <Modal
+      isOpen={isOpen}
+      onClose={() => onClose(false)}
+      className='max-h-[90vh] w-[327px] max-w-[calc(100%-48px)] overflow-hidden rounded-2xl min-[744px]:w-[600px] lg:w-[688px]'
+    >
+      <CloseIcon
+        size={48}
+        onClick={() => onClose(false)}
+        className='absolute top-4 right-4 z-10 size-7 cursor-pointer p-1 text-gray-600 min-[744px]:top-5 min-[744px]:right-5 min-[744px]:size-12 min-[744px]:p-2'
+      />
       <SuspenseBoundary
         errorFallback={<div>에러</div>}
         pendingFallback={

--- a/src/components/ui/AvatarGroup/index.tsx
+++ b/src/components/ui/AvatarGroup/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { cva } from 'class-variance-authority';
 import Image from 'next/image';
+import { cva } from 'class-variance-authority';
 
-import { cn } from '@/lib/cn';
 import { useFallbackImage } from '@/hooks/useFallbackImage';
+import { cn } from '@/lib/cn';
 
 const avatarSizeVariants = cva('relative bg-gray-300 flex items-center justify-center overflow-hidden', {
   variants: {

--- a/src/components/ui/AvatarGroup/index.tsx
+++ b/src/components/ui/AvatarGroup/index.tsx
@@ -28,27 +28,30 @@ const avatarSizeVariants = cva('relative bg-gray-300 flex items-center justify-c
   },
 });
 
-const overflowSizeVariants = cva('bg-gray-200 flex items-center justify-center text-gray-500 font-medium', {
-  variants: {
-    size: {
-      sm: 'h-5 w-5 text-[8px]',
-      md: 'h-8 w-8 text-[10px]',
+const overflowSizeVariants = cva(
+  'relative z-10 flex items-center justify-center bg-gray-200 font-medium text-gray-500',
+  {
+    variants: {
+      size: {
+        sm: 'h-5 w-5 text-[8px]',
+        md: 'h-8 w-8 text-[10px]',
+      },
+      shape: {
+        full: 'rounded-full',
+        lg: 'rounded-lg',
+      },
+      hasBorder: {
+        true: 'border-2 border-gray-0',
+        false: 'border-0',
+      },
     },
-    shape: {
-      full: 'rounded-full',
-      lg: 'rounded-lg',
-    },
-    hasBorder: {
-      true: 'border-2 border-gray-0',
-      false: 'border-0',
+    defaultVariants: {
+      size: 'sm',
+      shape: 'full',
+      hasBorder: true,
     },
   },
-  defaultVariants: {
-    size: 'sm',
-    shape: 'full',
-    hasBorder: true,
-  },
-});
+);
 
 interface AvatarItem {
   id?: number;

--- a/src/components/ui/AvatarGroup/index.tsx
+++ b/src/components/ui/AvatarGroup/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+
 import { cva } from 'class-variance-authority';
 
 import { useFallbackImage } from '@/hooks/useFallbackImage';


### PR DESCRIPTION
## ❓ 이슈

- close #396
- Jira: SM-227

## ✍️ Description

SM-227 범위로 모임 상세 페이지의 참여 멤버 상세 모달 UI를 Figma PC, tablet, mobile 시안에 맞춰 정리했습니다.

- 모달 컨테이너의 반응형 폭, 내부 여백, 헤더/본문 폰트 크기를 시안 기준으로 보정했습니다.
- 키워드 태그 영역이 모달 폭 밖으로 밀려나지 않도록 줄바꿈과 overflow 처리를 정리했습니다.
- 리뷰 카드의 아바타, 텍스트, 날짜 배치를 breakpoint별로 조정했습니다.
- `AvatarGroup`의 초과 인원 카운터가 겹친 아바타 뒤로 밀리지 않도록 z-index를 보정했습니다.

## 📸 스크린샷 (UI 변경 시)

- Figma PC node: 20289:63261 기준 모달 레이아웃 확인
- Figma tablet node: 20365:21434 기준 744px typography 확인
- Figma mobile node: 20365:22296 기준 horizontal overflow 없음 확인
- 참여자 아바타 `+n` 카운터가 최상단에 보이는지 확인

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 타입 체크 통과 (`npx tsc --noEmit`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] (없음)