### PR TITLE
[SM-228] fix: 모임 삭제 시 지연 및 GATHERING_NOT_FOUND 반복 발생 수정

### DIFF
--- a/src/api/applications/keys.ts
+++ b/src/api/applications/keys.ts
@@ -1,0 +1,5 @@
+export const applicationKeys = {
+  all: ['applications'] as const,
+  list: (gatheringId: number) => [...applicationKeys.all, 'list', gatheringId] as const,
+  myList: () => [...applicationKeys.all, 'myList'] as const,
+};

--- a/src/api/applications/queries.ts
+++ b/src/api/applications/queries.ts
@@ -1,4 +1,5 @@
 import { queryOptions, useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 
 import {
   createApplication,
@@ -10,6 +11,8 @@ import {
 
 import { invalidateServerCache } from '@/lib/invalidateServerCache';
 
+import { applicationKeys } from './keys';
+
 import { GATHERING_TAGS } from '../gatherings';
 import { gatheringKeys } from '../gatherings/queries';
 
@@ -20,11 +23,7 @@ import {
   UpdateApplicationStatusResponse,
 } from './types';
 
-export const applicationKeys = {
-  all: ['applications'] as const,
-  list: (gatheringId: number) => [...applicationKeys.all, 'list', gatheringId] as const,
-  myList: () => [...applicationKeys.all, 'myList'] as const,
-};
+export { applicationKeys };
 
 export const applicationQueries = {
   /** GET /v1/gatherings/:gatheringId/applications - 신청 목록 조회(모임장)*/
@@ -32,6 +31,11 @@ export const applicationQueries = {
     queryOptions({
       queryKey: applicationKeys.list(gatheringId),
       queryFn: () => getApplicationList(gatheringId),
+      // 404는 리소스가 실제로 없다는 확정적 응답이므로 재시도하지 않음 (삭제 직후 잔여 구독자로 인한 재요청 낭비 방지)
+      retry: (failureCount, error) => {
+        if (axios.isAxiosError(error) && error.response?.status === 404) return false;
+        return failureCount < 3;
+      },
     }),
 
   /** GET v1/users/me/applications — 내 신청 목록 조회(신청자) */

--- a/src/api/gatherings/queries.ts
+++ b/src/api/gatherings/queries.ts
@@ -1,6 +1,10 @@
 import { queryOptions, useMutation, useQueryClient, isServer } from '@tanstack/react-query';
+import axios from 'axios';
 
 import { invalidateServerCache } from '@/lib/invalidateServerCache';
+
+import { applicationKeys } from '../applications/keys';
+
 import {
   getCategories,
   fetchCategories,
@@ -66,6 +70,11 @@ export const gatheringQueries = {
     queryOptions({
       queryKey: gatheringKeys.detail(gatheringId),
       queryFn: () => (isServer ? fetchGatheringDetail(gatheringId) : getGatheringDetail(gatheringId)),
+      // 404는 리소스가 실제로 없다는 확정적 응답이므로 재시도하지 않음 (삭제 직후 잔여 구독자로 인한 재요청 낭비 방지)
+      retry: (failureCount, error) => {
+        if (axios.isAxiosError(error) && error.response?.status === 404) return false;
+        return failureCount < 3;
+      },
     }),
 
   /** GET /gatherings/:gatheringId/application-status — 모임 신청 상태 */
@@ -150,9 +159,24 @@ export const useDeleteGathering = (gatheringId: number, options?: UseMutationOpt
     ...options,
     onSuccess: async (data, variables, onMutateResult, context) => {
       await invalidateServerCache(GATHERING_TAGS.all);
+
+      // 삭제된 모임의 detail/applicationStatus는 재요청 대상이 아니므로 캐시에서 완전히 제거
+      queryClient.removeQueries({ queryKey: gatheringKeys.detail(gatheringId), exact: true });
+      queryClient.removeQueries({ queryKey: gatheringKeys.applicationStatus(gatheringId), exact: true });
+
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: gatheringKeys.all }),
+        // 목록류(main/list/categories/drafts)는 최신 상태 반영 위해 invalidate 유지,
+        // detail/applicationStatus는 위에서 이미 제거했으므로 제외
+        queryClient.invalidateQueries({
+          queryKey: gatheringKeys.all,
+          predicate: (query) => {
+            const [, resource] = query.queryKey;
+            return resource !== 'detail' && resource !== 'applicationStatus';
+          },
+        }),
         queryClient.invalidateQueries({ queryKey: ['memberships'] }),
+        // 삭제된 모임에 걸린 신청 내역도 더는 유효하지 않으므로 함께 무효화
+        queryClient.invalidateQueries({ queryKey: applicationKeys.all }),
       ]);
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },

--- a/src/app/main/components/MyGatheringSection/MyGatheringList/useMyGatheringList.ts
+++ b/src/app/main/components/MyGatheringSection/MyGatheringList/useMyGatheringList.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useSuspenseQuery, useSuspenseQueries } from '@tanstack/react-query';
+import axios from 'axios';
 
 import { membershipQueries } from '@/api/memberships/queries';
 import { usePerPage } from '@/app/main/hooks/usePerPage';
@@ -20,7 +21,14 @@ export const useMyGatheringList = () => {
   const visibleGatherings = gatherings.slice(startIndex, startIndex + perPage);
 
   const memberQueries = useSuspenseQueries({
-    queries: visibleGatherings.map((gathering) => membershipQueries.members(gathering.id)),
+    queries: visibleGatherings.map((gathering) => ({
+      ...membershipQueries.members(gathering.id),
+      // 목록 갱신이 아직 반영되기 전, 이미 삭제된 모임의 멤버 조회는 재시도해도 계속 404이므로 즉시 포기
+      retry: (failureCount: number, error: unknown) => {
+        if (axios.isAxiosError(error) && error.response?.status === 404) return false;
+        return failureCount < 3;
+      },
+    })),
   });
 
   return {

--- a/src/app/my/_components/PendingGatheringsSection/index.tsx
+++ b/src/app/my/_components/PendingGatheringsSection/index.tsx
@@ -78,9 +78,7 @@ export function PendingGatheringsSection({ pendingSort }: PendingGatheringsSecti
   );
 
   const detailQueries = useQueries({
-    queries: uniqueGatheringIds.map((id) => ({
-      ...gatheringQueries.detail(id),
-    })),
+    queries: uniqueGatheringIds.map((id) => gatheringQueries.detail(id)),
   });
 
   const gatheringIdToQueryIndex = useMemo(() => {


### PR DESCRIPTION
## ❓ 이슈

- close #400 

## ✍️ Description

모임 삭제 후 성공 토스트/리다이렉트가 약 5초 지연되고, 네트워크 탭에 `GATHERING_NOT_FOUND` 404 에러가 반복 발생하던 문제를 수정했습니다.

**원인**

모임 삭제 성공 시 `gatheringKeys.all`을 통째로 `invalidateQueries`하면서, 아직 unmount되지 않은 상세 페이지의 여러 컴포넌트(`GatheringDetailContent`, `PendingApplications` 등)가 이미 삭제된 모임을 즉시 재요청했습니다. 여기에 TanStack Query 기본 재시도 정책(3회)까지 겹쳐 지연과 반복 에러가 발생했습니다.

**수정 내용**

- 삭제된 모임의 `detail`/`applicationStatus` 캐시는 `removeQueries`로 완전히 제거 (재요청 트리거 자체를 없앰)
- 목록류(`main`/`list`/`categories`/`drafts`)는 최신 상태 반영을 위해 `invalidateQueries` 유지
- 삭제된 모임에 걸린 신청 목록(`applicationKeys.all`)도 함께 무효화하도록 추가
- `gatheringQueries.detail`, `applicationQueries.list` 쿼리 정의에 404 무재시도 `retry` 옵션을 기본값으로 추가해, 이 쿼리를 구독하는 모든 컴포넌트에 공통 적용
- `applicationKeys`를 별도 파일(`src/api/applications/keys.ts`)로 분리해 `gatherings`↔`applications` 간 순환 참조 방지

**검증**

`useDeleteGathering`의 `onSuccess` 콜백에 `console.time`/`console.timeEnd`를 임시로 삽입해 수정 전/후 커밋을 오가며 직접 계측했습니다.

| 상태 | 커밋 | `onSuccess` 소요 시간 |
| --- | --- | --- |
| 수정 전 | `ba0b952` (본 PR 직전) | 약 8.9초 |
| 수정 후 | 본 PR 반영 | 약 0.7초 |

콘솔 스택 트레이스에서 `retryer.ts`의 `Promise.then → Promise.catch` 체인이 재귀적으로 여러 겹 쌓이는 것을 확인했고, 이는 404 재시도가 반복되며 대기 시간이 누적된 것을 뒷받침합니다.


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- 계측에 사용한 `console.time`/`console.timeEnd`는 검증 목적의 임시 코드이며, 본 PR에는 포함되어 있지 않습니다.
