### PR TITLE
[SM-229]  fix: 모임 카드 클릭 시 모집중이면 상세페이지로 이동하도록 수정

### DIFF
--- a/src/app/main/components/MyGatheringSection/MyGatheringList/index.tsx
+++ b/src/app/main/components/MyGatheringSection/MyGatheringList/index.tsx
@@ -15,8 +15,10 @@ export function MyGatheringList() {
   const { page, setPage, totalPages, visibleGatherings, memberQueries } = useMyGatheringList();
   const isEmpty = visibleGatherings.length === 0;
 
-  const handleCardClick = (id: number) => {
-    router.push(`/gatherings/${id}/dashboard`);
+  const handleCardClick = (gathering: MembershipGathering) => {
+    const path =
+      gathering.status === 'RECRUITING' ? `/gatherings/${gathering.id}` : `/gatherings/${gathering.id}/dashboard`;
+    router.push(path);
   };
 
   return (
@@ -46,7 +48,7 @@ export function MyGatheringList() {
               key={gathering.id}
               gathering={gathering}
               members={memberQueries[index].data.members}
-              onClick={() => handleCardClick(gathering.id)}
+              onClick={() => handleCardClick(gathering)}
             />
           ))}
         </div>

--- a/src/app/my/_components/MyGatheringsCard/index.tsx
+++ b/src/app/my/_components/MyGatheringsCard/index.tsx
@@ -37,8 +37,11 @@ export function MyGatheringsCard({ gathering }: MyGatheringsCardProps) {
 
   const { displayLabel, tagState, isFinished } = getGatheringDisplayStatus(gathering);
 
+  const href =
+    gathering.status === 'RECRUITING' ? `/gatherings/${gathering.id}` : `/gatherings/${gathering.id}/dashboard`;
+
   return (
-    <Link href={`/gatherings/${gathering.id}/dashboard`}>
+    <Link href={href}>
       <GatheringCard>
         <GatheringCard.Header className='items-start'>
           <div className='flex gap-1'>

--- a/src/mocks/handlers/memberships.ts
+++ b/src/mocks/handlers/memberships.ts
@@ -21,7 +21,23 @@ const STATUS_FILTER_MAP: Record<string, GatheringStatus> = {
   completed: 'COMPLETED',
 };
 
-// gatherings.ts BASE_GATHERINGS와 ID·title·dates를 일치시킨 "내 모임" 데이터.
+const formatMockDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const addDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+const today = new Date();
+
+// gatherings.ts BASE_GATHERINGS와 ID·title을 일치시킨 "내 모임" 데이터.
+// 날짜는 오늘 기준 상대값(addDays)으로 계산해 시간이 지나도 status와 화면 표시가 어긋나지 않도록 함.
 // 리뷰 작성 흐름 테스트를 위해 id 7(독서 기록 앱, COMPLETED)을 포함.
 const mockGatherings: MembershipGathering[] = [
   {
@@ -33,8 +49,8 @@ const mockGatherings: MembershipGathering[] = [
     tags: ['React', 'Next.js', 'TypeScript'],
     maxMembers: 6,
     currentMembers: 4,
-    startDate: '2026-06-20',
-    endDate: '2026-08-15',
+    startDate: formatMockDate(addDays(today, 12)),
+    endDate: formatMockDate(addDays(today, 12 + 56)),
     status: 'RECRUITING',
     myRole: 'LEADER',
     hasReviewed: false,
@@ -50,8 +66,8 @@ const mockGatherings: MembershipGathering[] = [
     tags: ['SaaS', 'React', 'Node.js'],
     maxMembers: 5,
     currentMembers: 4,
-    startDate: '2026-07-05',
-    endDate: '2026-11-30',
+    startDate: formatMockDate(addDays(today, 7)),
+    endDate: formatMockDate(addDays(today, 7 + 120)),
     status: 'RECRUITING',
     myRole: 'MEMBER',
     hasReviewed: false,
@@ -67,8 +83,8 @@ const mockGatherings: MembershipGathering[] = [
     tags: ['Java', 'Spring', 'JPA'],
     maxMembers: 8,
     currentMembers: 7,
-    startDate: '2026-05-05',
-    endDate: '2026-08-05',
+    startDate: formatMockDate(addDays(today, -30)),
+    endDate: formatMockDate(addDays(today, 40)),
     status: 'IN_PROGRESS',
     myRole: 'MEMBER',
     hasReviewed: false,
@@ -84,8 +100,8 @@ const mockGatherings: MembershipGathering[] = [
     tags: ['영어', '회화'],
     maxMembers: 8,
     currentMembers: 3, // GATHERING_MEMBERS[4].length와 일치
-    startDate: '2026-06-15',
-    endDate: '2026-09-15',
+    startDate: formatMockDate(addDays(today, 9)),
+    endDate: formatMockDate(addDays(today, 9 + 90)),
     status: 'RECRUITING',
     myRole: 'LEADER',
     hasReviewed: false,
@@ -101,8 +117,8 @@ const mockGatherings: MembershipGathering[] = [
     tags: ['독서', '사이드프로젝트', 'Flutter'],
     maxMembers: 4,
     currentMembers: 4,
-    startDate: '2026-04-01',
-    endDate: '2026-05-15',
+    startDate: formatMockDate(addDays(today, -90)),
+    endDate: formatMockDate(addDays(today, -60)),
     status: 'COMPLETED',
     myRole: 'MEMBER',
     hasReviewed: false,


### PR DESCRIPTION
## ❓ 이슈

- close #402 

## ✍️ Description

메인페이지 "내 모임" 섹션과 마이페이지 "나의 모임" 목록에서 모임 카드를 클릭하면 모임 상태(모집중/진행중/완료)와 무관하게 항상 모임 대시보드로 이동하던 것을, 상태에 따라 분기하도록 수정했습니다.

- 모집중(RECRUITING) → 모임 상세페이지(`/gatherings/[id]`)로 이동
- 진행중(IN_PROGRESS)/완료(COMPLETED) → 모임 대시보드(`/gatherings/[id]/dashboard`)로 이동 (기존과 동일)

마이페이지 "만든 모임" 목록은 기존과 동일하게 항상 상세페이지로 이동하며 변경하지 않았습니다.

추가로, 검증 과정에서 `mockGatherings`의 날짜가 고정 문자열이라 시간이 지나면 `status` 필드와 화면에 표시되는 상태가 어긋나는 문제를 발견해 오늘 날짜 기준 상대 날짜로 계산하도록 함께 수정했습니다 (`gatherings.ts`에 이미 있던 `formatMockDate`/`addDays` 패턴 재사용).

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


