### PR TITLE
[SM-230] fix: 인기/마감임박 모임 카드 전체 클릭 시 상세페이지로 이동하도록 수정

### DIFF
--- a/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
+++ b/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
@@ -42,11 +42,6 @@ export function DeadlineGatheringList() {
               key={gathering.id}
               gathering={gathering}
               href={`/gatherings/${gathering.id}?source=recommendation`}
-              joinButtonLabel='참여하기'
-              joinButtonClassName=''
-              isJoinDisabled={false}
-              initialFavorite={false}
-              className=''
             />
           ))}
         </div>

--- a/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
+++ b/src/app/main/components/DeadlineGatheringSection/DeadlineGatheringList/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
@@ -10,13 +9,8 @@ import { Pagination } from '@/components/ui/Pagination';
 import { useDeadlineGatherings } from './useDeadlineGatherings';
 
 export function DeadlineGatheringList() {
-  const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings } = useDeadlineGatherings();
   const isEmpty = visibleGatherings.length === 0;
-
-  const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}?source=recommendation`);
-  };
 
   return (
     <div>
@@ -47,11 +41,11 @@ export function DeadlineGatheringList() {
             <MainGatheringCard
               key={gathering.id}
               gathering={gathering}
+              href={`/gatherings/${gathering.id}?source=recommendation`}
               joinButtonLabel='참여하기'
               joinButtonClassName=''
               isJoinDisabled={false}
               initialFavorite={false}
-              onJoin={() => handleJoin(gathering.id)}
               className=''
             />
           ))}

--- a/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
+++ b/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
@@ -39,11 +39,6 @@ export function LatestGatheringList() {
               key={gathering.id}
               gathering={gathering}
               href={`/gatherings/${gathering.id}?source=recommendation`}
-              joinButtonLabel='참여하기'
-              joinButtonClassName=''
-              isJoinDisabled={false}
-              initialFavorite={false}
-              className=''
             />
           ))}
         </div>

--- a/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
+++ b/src/app/main/components/LatestGatheringSection/LatestGatheringList/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
@@ -10,13 +9,8 @@ import { Pagination } from '@/components/ui/Pagination';
 import { useLatestGatherings } from './useLatestGatherings';
 
 export function LatestGatheringList() {
-  const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings } = useLatestGatherings();
   const isEmpty = visibleGatherings.length === 0;
-
-  const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}?source=recommendation`);
-  };
 
   return (
     <div>
@@ -44,11 +38,11 @@ export function LatestGatheringList() {
             <MainGatheringCard
               key={gathering.id}
               gathering={gathering}
+              href={`/gatherings/${gathering.id}?source=recommendation`}
               joinButtonLabel='참여하기'
               joinButtonClassName=''
               isJoinDisabled={false}
               initialFavorite={false}
-              onJoin={() => handleJoin(gathering.id)}
               className=''
             />
           ))}

--- a/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
+++ b/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
@@ -42,11 +42,6 @@ export function PopularGatheringList() {
               key={gathering.id}
               gathering={gathering}
               href={`/gatherings/${gathering.id}?source=recommendation`}
-              joinButtonLabel='참여하기'
-              joinButtonClassName=''
-              isJoinDisabled={false}
-              initialFavorite={false}
-              className=''
             />
           ))}
         </div>

--- a/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
+++ b/src/app/main/components/PopularGatheringSection/PopularGatheringList/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 import { EmptyState } from '@/components/EmptyState';
 import { MainGatheringCard } from '@/components/MainGatheringCard';
@@ -10,13 +9,8 @@ import { Pagination } from '@/components/ui/Pagination';
 import { usePopularGatherings } from './usePopularGatherings';
 
 export function PopularGatheringList() {
-  const router = useRouter();
   const { page, setPage, totalPages, visibleGatherings } = usePopularGatherings();
   const isEmpty = visibleGatherings.length === 0;
-
-  const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}?source=recommendation`);
-  };
 
   return (
     <div>
@@ -47,11 +41,11 @@ export function PopularGatheringList() {
             <MainGatheringCard
               key={gathering.id}
               gathering={gathering}
+              href={`/gatherings/${gathering.id}?source=recommendation`}
               joinButtonLabel='참여하기'
               joinButtonClassName=''
               isJoinDisabled={false}
               initialFavorite={false}
-              onJoin={() => handleJoin(gathering.id)}
               className=''
             />
           ))}

--- a/src/components/MainGatheringCard/index.stories.tsx
+++ b/src/components/MainGatheringCard/index.stories.tsx
@@ -50,10 +50,7 @@ export const Default: Story = {
 
 export const Favorite: Story = {
   name: '2. 찜',
-  args: {
-    ...baseArgs,
-    initialFavorite: true,
-  },
+  args: baseArgs,
 };
 
 export const JoinDisabled: Story = {

--- a/src/components/MainGatheringCard/index.stories.tsx
+++ b/src/components/MainGatheringCard/index.stories.tsx
@@ -39,6 +39,7 @@ const gathering: GatheringListItem = {
 
 const baseArgs = {
   gathering,
+  href: `/gatherings/${gathering.id}`,
   joinButtonLabel: '참여하기',
 } satisfies Parameters<typeof MainGatheringCard>[0];
 

--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Link from 'next/link';
+
 import { Button } from '@/components/ui/Button';
 import { GatheringCard } from '@/components/ui/GatheringCard';
 import { HeartIcon, PersonIcon } from '@/components/ui/Icon';
@@ -12,11 +14,11 @@ import type { GatheringListItem } from '@/api/gatherings/types';
 
 interface MainGatheringCardProps {
   gathering: GatheringListItem;
+  href: string;
   joinButtonLabel?: string;
   joinButtonClassName?: string;
   isJoinDisabled?: boolean;
   initialFavorite?: boolean;
-  onJoin?: () => void;
   className?: string;
 }
 
@@ -32,10 +34,10 @@ const toWeeksLabel = (startDate: string, endDate: string) => {
 
 export function MainGatheringCard({
   gathering,
+  href,
   joinButtonLabel = '참여하기',
   joinButtonClassName,
   isJoinDisabled = false,
-  onJoin,
   className,
 }: MainGatheringCardProps) {
   const { isLiked, toggleLike, isPending } = useLikeToggle(gathering.id);
@@ -44,62 +46,63 @@ export function MainGatheringCard({
   const deadlineLabel = formatRecruitDeadlineLabel(gathering.recruitDeadline);
 
   return (
-    <GatheringCard className={cn('flex h-full flex-col', className)}>
-      <GatheringCard.Header className='items-center'>
-        <Tag variant='category' label={gathering.type} sublabel={gathering.categories.join(', ')} />
-        <div className='text-small-02-sb md:text-small-01-sb flex items-center'>
-          <PersonIcon size={16} className='mr-2 text-blue-400' />
-          <span className='text-blue-400'>{gathering.currentMembers}</span>
-          <span className='text-gray-600'>/</span>
-          <span className='text-gray-600'>{gathering.maxMembers}</span>
-        </div>
-      </GatheringCard.Header>
-      <GatheringCard.Body className='mb-4 flex-1 gap-3'>
-        <div className='flex flex-col gap-0.5'>
-          <div className='flex flex-wrap gap-1'>
-            {gathering.tags.map((tag) => (
-              <span key={tag} className='text-small-02-r text-gray-500'>
-                #{tag}
-              </span>
-            ))}
+    <Link href={href}>
+      <GatheringCard className={cn('flex h-full flex-col', className)}>
+        <GatheringCard.Header className='items-center'>
+          <Tag variant='category' label={gathering.type} sublabel={gathering.categories.join(', ')} />
+          <div className='text-small-02-sb md:text-small-01-sb flex items-center'>
+            <PersonIcon size={16} className='mr-2 text-blue-400' />
+            <span className='text-blue-400'>{gathering.currentMembers}</span>
+            <span className='text-gray-600'>/</span>
+            <span className='text-gray-600'>{gathering.maxMembers}</span>
           </div>
-          <p className='text-body-01-b line-clamp-2 text-gray-900'>{gathering.title}</p>
-          <p className='text-small-01-r line-clamp-1 text-gray-800'>{gathering.shortDescription}</p>
-        </div>
-        <div className='flex items-center gap-1'>
-          <Tag variant='duration'>{totalWeeksLabel}</Tag>
-          <Tag variant='deadline' state='goal'>
-            {deadlineLabel}
-          </Tag>
-        </div>
-      </GatheringCard.Body>
-      <GatheringCard.Footer className='border-gray-150 mt-auto items-center gap-2 border-t pt-4'>
-        <Button
-          variant='bookmark'
-          size='bookmark-sm'
-          className='shrink-0'
-          data-selected={isLiked}
-          aria-label='찜하기'
-          aria-pressed={isLiked}
-          disabled={isPending}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            toggleLike();
-          }}
-        >
-          <HeartIcon size={24} variant={isLiked ? 'filled' : 'outline'} />
-        </Button>
-        <Button
-          variant='participation-outline-sm'
-          size='participation-sm'
-          className={cn('w-full', joinButtonClassName)}
-          disabled={isJoinDisabled}
-          onClick={onJoin}
-        >
-          {joinButtonLabel}
-        </Button>
-      </GatheringCard.Footer>
-    </GatheringCard>
+        </GatheringCard.Header>
+        <GatheringCard.Body className='mb-4 flex-1 gap-3'>
+          <div className='flex flex-col gap-0.5'>
+            <div className='flex flex-wrap gap-1'>
+              {gathering.tags.map((tag) => (
+                <span key={tag} className='text-small-02-r text-gray-500'>
+                  #{tag}
+                </span>
+              ))}
+            </div>
+            <p className='text-body-01-b line-clamp-2 text-gray-900'>{gathering.title}</p>
+            <p className='text-small-01-r line-clamp-1 text-gray-800'>{gathering.shortDescription}</p>
+          </div>
+          <div className='flex items-center gap-1'>
+            <Tag variant='duration'>{totalWeeksLabel}</Tag>
+            <Tag variant='deadline' state='goal'>
+              {deadlineLabel}
+            </Tag>
+          </div>
+        </GatheringCard.Body>
+        <GatheringCard.Footer className='border-gray-150 mt-auto items-center gap-2 border-t pt-4'>
+          <Button
+            variant='bookmark'
+            size='bookmark-sm'
+            className='shrink-0'
+            data-selected={isLiked}
+            aria-label='찜하기'
+            aria-pressed={isLiked}
+            disabled={isPending}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleLike();
+            }}
+          >
+            <HeartIcon size={24} variant={isLiked ? 'filled' : 'outline'} />
+          </Button>
+          <Button
+            variant='participation-outline-sm'
+            size='participation-sm'
+            className={cn('w-full', joinButtonClassName)}
+            disabled={isJoinDisabled}
+          >
+            {joinButtonLabel}
+          </Button>
+        </GatheringCard.Footer>
+      </GatheringCard>
+    </Link>
   );
 }

--- a/src/components/MainGatheringCard/index.tsx
+++ b/src/components/MainGatheringCard/index.tsx
@@ -18,7 +18,6 @@ interface MainGatheringCardProps {
   joinButtonLabel?: string;
   joinButtonClassName?: string;
   isJoinDisabled?: boolean;
-  initialFavorite?: boolean;
   className?: string;
 }
 

--- a/src/components/Search/GatheringList/index.tsx
+++ b/src/components/Search/GatheringList/index.tsx
@@ -2,8 +2,6 @@
 
 import { startTransition, useEffect, useRef } from 'react';
 
-import { useRouter } from 'next/navigation';
-
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 
 import { EmptyState } from '@/components/EmptyState';
@@ -18,7 +16,6 @@ import { trackGatheringSearch } from '@/lib/analytics/gathering';
 const PAGE_LIMIT = 12;
 
 export function GatheringList() {
-  const router = useRouter();
   const { query, type, categoryIds, sort, status, page, setParams } = useGatheringSearchParams();
 
   const { data } = useSuspenseQuery(
@@ -41,10 +38,6 @@ export function GatheringList() {
     startTransition(() => {
       setParams({ page: newPage }, { history: 'push' });
     });
-  };
-
-  const handleJoin = (id: number) => {
-    router.push(`/gatherings/${id}?source=search`);
   };
 
   // query / category 조합이 변경되어 새 결과가 도착할 때 1회 search 이벤트 발사.
@@ -86,7 +79,11 @@ export function GatheringList() {
       <GatheringFilterBar totalCount={data.totalCount} />
       <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
         {data.gatherings.map((gathering) => (
-          <MainGatheringCard key={gathering.id} gathering={gathering} onJoin={() => handleJoin(gathering.id)} />
+          <MainGatheringCard
+            key={gathering.id}
+            gathering={gathering}
+            href={`/gatherings/${gathering.id}?source=search`}
+          />
         ))}
       </div>
       {data.totalPages > 1 && (


### PR DESCRIPTION
## ❓ 이슈

- close #403 

## ✍️ Description

### 문제

인기/마감임박/최신 모임, 검색 결과 카드에서:
- 카드의 이미지, 제목, 태그 클릭 → 반응 없음
- "참여하기" 버튼만 클릭 → 상세페이지 이동

다른 카드(내 모임 등)는 카드 전체가 클릭되는데, 이 카드들만 예외라 사용성이 떨어짐.

### 변경 사항

- 카드 전체 클릭 → 상세페이지(`/gatherings/[id]`) 이동
- "참여하기" 버튼 클릭 → 동일하게 상세페이지 이동
- 찜(하트) 버튼 클릭 → 기존과 동일하게 페이지 이동 없이 찜 토글만 실행 (예외 유지)

### 구현 방식

- 카드(`MainGatheringCard`) 전체를 Next.js `Link`로 감쌈
  → 카드 어디를 눌러도 하나의 링크처럼 동작
- "참여하기" 버튼의 클릭 이벤트를 따로 처리하지 않음
  → 버튼 클릭이 자연스럽게 부모(카드)까지 전달되어 같은 곳으로 이동
- 찜 버튼만 `stopPropagation()` + `preventDefault()`로 예외 처리
  → 클릭이 부모로 전달되는 것을 막아, 찜 토글만 단독 실행되도록 기존 코드 유지
- 이 카드를 쓰는 4곳(인기/마감임박/최신 모임, 검색 결과)에서
  → 각자 만들어 쓰던 "클릭 시 이동" 코드를 지우고, "이동할 주소"만 전달하도록 정리

## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

