### PR TITLE
[SM-233] fix: Vercel 배포 환경 MSW 활성 조건 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,8 @@ import { withSentryConfig } from '@sentry/nextjs';
 import { withSerwist } from '@serwist/turbopack';
 import type { NextConfig } from 'next';
 
+const isMswEnabled = process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
+
 const nextConfig: NextConfig = {
   transpilePackages: ['until-async'],
   serverExternalPackages: ['msw'],
@@ -42,8 +44,8 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'sailmate.store',
       },
-      // prod에 MSW용 호스트가 섞이지 않도록 NODE_ENV로 이중 가드.
-      ...(process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true'
+      // TEMP: 백엔드 재배포 전까지 Vercel production MSW 배포에서도 mock 이미지 호스트를 허용한다.
+      ...(isMswEnabled
         ? [
             { protocol: 'https' as const, hostname: 'avatars.githubusercontent.com' },
             { protocol: 'https' as const, hostname: 'placehold.co' },

--- a/src/app/api/livekit/token/route.ts
+++ b/src/app/api/livekit/token/route.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/nextjs';
 import { AccessToken } from 'livekit-server-sdk';
 
 import { requestBackend } from '@/lib/serverFetch';
+import { isMswEnabled } from '@/lib/msw';
 import { withBffErrorHandling } from '@/lib/withBffErrorHandling';
 
 interface BffErrorParams {
@@ -36,14 +37,13 @@ export const GET = withBffErrorHandling(async (req: NextRequest) => {
   }
 
   const gatheringId = parseInt(room.split('-')[1], 10);
-  // prod 환경에서 NEXT_PUBLIC_MSW_ENABLED가 실수로 켜져도 auth bypass 되지 않도록 NODE_ENV로 이중 가드.
-  const isMswDev = process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
 
   let userId: number | undefined;
   let nickname: string | undefined;
 
-  if (isMswDev) {
-    // MSW dev — Next.js 16 + Turbopack에서 msw/node가 서버 fetch를 못 잡아
+  if (isMswEnabled) {
+    // TEMP: 백엔드 재배포 전까지 Vercel production MSW 배포에서도 회의실 시연을 허용한다.
+    // MSW 환경 — Next.js 16 + Turbopack에서 msw/node가 서버 fetch를 못 잡아
     // requestBackend()로 멤버/me 검증이 실패함. CURRENT_USER로 토큰 발급해 회의실 시연 가능하게 함.
     userId = 1;
     nickname = '테스터';
@@ -133,7 +133,7 @@ export const GET = withBffErrorHandling(async (req: NextRequest) => {
     });
   }
 
-  const participantIdentity = isMswDev ? `user-${userId}-${crypto.randomUUID()}` : `user-${userId}`;
+  const participantIdentity = isMswEnabled ? `user-${userId}-${crypto.randomUUID()}` : `user-${userId}`;
 
   const at = new AccessToken(apiKey, apiSecret, {
     identity: participantIdentity,

--- a/src/app/gatherings/[id]/dashboard/page.tsx
+++ b/src/app/gatherings/[id]/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import { fetchGatheringDetail } from '@/api/gatherings';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { getUserIdFromToken } from '@/lib/getUserIdFromToken';
+import { isMswEnabled } from '@/lib/msw';
 
 import { DashboardContent } from './_components/DashboardContent';
 import { DashboardHeader } from './_components/DashboardHeader';
@@ -36,9 +37,6 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
   const hasRefreshToken = cookieStore.has('refreshToken');
   const userId = getUserIdFromToken(accessToken);
 
-  // prod에서 가드가 우회되지 않도록 NODE_ENV로 이중 체크.
-  const isMswDev = process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
-
   // accessToken 없지만 refreshToken 있으면 클라이언트에서 리프레시 처리 → 검증 스킵
   if (userId !== null) {
     try {
@@ -46,11 +44,11 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
       const isMember = gathering.members.some((m) => m.userId === userId);
       if (!isMember) redirect(`/gatherings/${gatheringId}`);
     } catch {
-      // MSW dev — Next.js 16 + Turbopack에서 msw/node가 서버 fetch를 못 잡는 경우가 있음.
-      // 프로덕션은 정상 동작하므로 dev 한정으로만 catch 시 가드를 스킵해 대시보드를 진입 가능하게 한다.
-      if (!isMswDev) redirect(`/gatherings/${gatheringId}`);
+      // TEMP: 백엔드 재배포 전까지 Vercel production MSW 배포에서도 대시보드 시연을 허용한다.
+      // MSW 환경 — Next.js 16 + Turbopack에서 msw/node가 서버 fetch를 못 잡는 경우가 있음.
+      if (!isMswEnabled) redirect(`/gatherings/${gatheringId}`);
     }
-  } else if (!hasRefreshToken && !isMswDev) {
+  } else if (!hasRefreshToken && !isMswEnabled) {
     redirect(`/gatherings/${gatheringId}`);
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { OverlayProvider } from '@/providers/OverlayProvider';
 import { FooterWrapper } from '@/components/Footer/FooterWrapper';
 import { ToastProvider } from '@/components/ui/Toast/ToastProvider';
 import { JsonLd } from '@/components/seo/JsonLd';
+import { isMswEnabled } from '@/lib/msw';
 import {
   SITE_NAME,
   SITE_TITLE_DEFAULT,
@@ -28,7 +29,7 @@ import {
 
 import type { Metadata } from 'next';
 
-const shouldUseSerwist = process.env.NODE_ENV === 'production' || process.env.NEXT_PUBLIC_MSW_ENABLED !== 'true';
+const shouldUseSerwist = !isMswEnabled;
 
 export const generateMetadata = async (): Promise<Metadata> => {
   const siteUrl = getSiteUrl();

--- a/src/app/main/components/HeroSectionContainer/index.tsx
+++ b/src/app/main/components/HeroSectionContainer/index.tsx
@@ -2,14 +2,14 @@ import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { getQueryClient } from '@/lib/getQueryClient';
+import { isMswEnabled } from '@/lib/msw';
 
 import { HeroSection } from '../HeroSection';
 
 export async function HeroSectionContainer() {
   const queryClient = getQueryClient();
-  const isMswDev = process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
 
-  if (!isMswDev) {
+  if (!isMswEnabled) {
     await queryClient.prefetchQuery(gatheringQueries.categories());
   }
 

--- a/src/app/main/components/MainGatheringContainer/index.tsx
+++ b/src/app/main/components/MainGatheringContainer/index.tsx
@@ -2,6 +2,7 @@ import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { getQueryClient } from '@/lib/getQueryClient';
+import { isMswEnabled } from '@/lib/msw';
 
 import { DeadlineGatheringSection } from '../DeadlineGatheringSection';
 import { LatestGatheringSection } from '../LatestGatheringSection';
@@ -10,9 +11,8 @@ import { MAX_GATHERING_LIMIT } from '../../constant/constant';
 
 export async function MainGatheringContainer() {
   const queryClient = getQueryClient();
-  const isMswDev = process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
 
-  if (!isMswDev) {
+  if (!isMswEnabled) {
     await queryClient.prefetchQuery(gatheringQueries.main({ limit: MAX_GATHERING_LIMIT }));
   }
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,10 +1,12 @@
 import * as Sentry from '@sentry/nextjs';
 
+import { isMswEnabled } from './lib/msw';
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('../sentry.server.config');
 
-    if (process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true') {
+    if (isMswEnabled) {
       const { server } = await import('./mocks/server');
       server.listen({ onUnhandledRequest: 'bypass' });
     }

--- a/src/lib/msw.ts
+++ b/src/lib/msw.ts
@@ -1,0 +1,3 @@
+// TEMP: 백엔드 재배포 전까지 Vercel production 배포에서도 MSW를 사용할 수 있게 한다.
+// 제거 예정: 백엔드 재배포 완료 후 production guard를 복구한다.
+export const isMswEnabled = process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';

--- a/src/mocks/init.ts
+++ b/src/mocks/init.ts
@@ -1,5 +1,7 @@
+import { isMswEnabled } from '@/lib/msw';
+
 export const initMsw = async () => {
-  if (process.env.NODE_ENV === 'production' || process.env.NEXT_PUBLIC_MSW_ENABLED !== 'true') return;
+  if (!isMswEnabled) return;
   if (typeof window === 'undefined') return;
 
   if ('serviceWorker' in navigator) {

--- a/src/providers/MSWProvider.tsx
+++ b/src/providers/MSWProvider.tsx
@@ -3,18 +3,17 @@
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
+import { isMswEnabled } from '@/lib/msw';
+
 interface MSWProviderProps {
   children: ReactNode;
 }
 
-// prod에서는 NEXT_PUBLIC_MSW_ENABLED가 잘못 주입되더라도 MSW가 활성화되지 않도록 NODE_ENV로 이중 가드.
-const shouldEnableMsw = process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
-
 export function MSWProvider({ children }: MSWProviderProps) {
-  const [isReady, setIsReady] = useState(!shouldEnableMsw);
+  const [isReady, setIsReady] = useState(!isMswEnabled);
 
   useEffect(() => {
-    if (!shouldEnableMsw) return;
+    if (!isMswEnabled) return;
 
     const init = async () => {
       const { initMsw } = await import('@/mocks/init');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { setAuthCookies } from '@/lib/authCookies';
+import { isMswEnabled } from '@/lib/msw';
 import { extractTokens } from '@/lib/tokenUtils';
 
 const PROTECTED_ROUTES = ['/my', '/gatherings/new'];
@@ -45,7 +46,6 @@ export const proxy = async (request: NextRequest) => {
     PROTECTED_ROUTES.some((route) => pathname.startsWith(route)) ||
     PROTECTED_PATTERNS.some((pattern) => pattern.test(pathname));
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
-  const isMswDev = process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_MSW_ENABLED === 'true';
 
   // accessToken 없고 refreshToken만 있으면 → 갱신 시도
   if (!hasAccessToken && hasRefreshToken) {
@@ -65,7 +65,7 @@ export const proxy = async (request: NextRequest) => {
     }
 
     // 갱신 실패: 보호 라우트면 로그인으로
-    if (isProtectedRoute && !isMswDev) {
+    if (isProtectedRoute && !isMswEnabled) {
       return NextResponse.redirect(new URL('/login', request.url));
     }
     // 공개 라우트면 그냥 진행 (비로그인 상태로)
@@ -73,7 +73,7 @@ export const proxy = async (request: NextRequest) => {
   }
 
   // 보호 라우트: 토큰 하나도 없으면 로그인으로
-  if (isProtectedRoute && !hasAccessToken && !isMswDev) {
+  if (isProtectedRoute && !hasAccessToken && !isMswEnabled) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 


### PR DESCRIPTION
## ❓ 이슈

- close #409
- Jira: SM-233

## ✍️ Description

백엔드 재배포 전까지 Vercel production 배포에서도 `NEXT_PUBLIC_MSW_ENABLED=true`만으로 MSW를 활성화할 수 있도록 조건을 정리했습니다.

- 앱 코드의 MSW 활성 기준을 `src/lib/msw.ts`의 `isMswEnabled`로 모았습니다.
- 클라이언트 worker 초기화, 서버 MSW handler 등록, 메인 페이지 prefetch skip, proxy 보호 라우트 우회, 대시보드 진입 가드, LiveKit 시연 토큰 발급이 같은 기준을 따르도록 맞췄습니다.
- MSW 활성 시 기존 Serwist provider 등록을 막아 service worker 충돌 가능성을 줄였습니다.
- Vercel production MSW 배포에서도 mock 이미지 호스트를 사용할 수 있도록 `next.config.ts`의 remotePatterns 조건을 조정했습니다.
- 백엔드 재배포 후 production guard를 복구해야 하는 임시 조치임을 주석으로 남겼습니다.

## 📸 스크린샷 (UI 변경 시)

- UI 변경 없음

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 타입 체크 통과 (`npx tsc --noEmit`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] 백엔드 재배포 완료 후 production MSW 허용 조건을 복구해야 합니다.