### PR TITLE
[SM-234] feat: 진행중 모임 수정 폼 분리 및 상세 페이지 액션 버튼 정리

### DIFF
--- a/src/app/gatherings/[id]/_components/GatheringActionButtons/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringActionButtons/index.tsx
@@ -58,16 +58,17 @@ export function GatheringActionButtons({ gatheringId, gatheringStatus }: Gatheri
       >
         정보 수정
       </Button>
-      <Button
-        type='button'
-        variant='mypage-edit'
-        size={undefined}
-        onClick={handleDelete}
-        disabled={!canDelete}
-        className='text-small-01-sb md:text-body-02-m h-14 w-32.5 shrink-0 border border-gray-200 bg-white text-gray-700 disabled:opacity-50'
-      >
-        모임 삭제
-      </Button>
+      {canDelete && (
+        <Button
+          type='button'
+          variant='mypage-edit'
+          size={undefined}
+          onClick={handleDelete}
+          className='text-small-01-sb md:text-body-02-m h-14 w-32.5 shrink-0 border border-gray-200 bg-white text-gray-700'
+        >
+          모임 삭제
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/app/gatherings/[id]/edit/EditGatheringForm/index.tsx
+++ b/src/app/gatherings/[id]/edit/EditGatheringForm/index.tsx
@@ -17,11 +17,7 @@ import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import { useToastStore } from '@/components/ui/Toast/useToastStore';
 import { gatheringQueries, useUpdateGathering } from '@/api/gatherings/queries';
-import {
-  createInProgressDateRefinementSchema,
-  gatheringFormBaseSchema,
-  gatheringUpdateFormSchema,
-} from '@/api/gatherings/schemas';
+import { gatheringUpdateFormSchema } from '@/api/gatherings/schemas';
 import { ImageUpload } from '@/app/gatherings/_gathering-form-components/ImageUpload';
 import { TagInput } from '@/app/gatherings/_gathering-form-components/TagInput';
 import { WeeklyPlanForm } from '@/app/gatherings/_gathering-form-components/WeeklyPlanForm';
@@ -29,16 +25,15 @@ import { GATHERING_TYPES } from '@/constants/gathering';
 import { cn } from '@/lib/cn';
 import { getTotalWeeks } from '@/lib/formatGatheringDate';
 
-import type { GatheringForm, GatheringStatus } from '@/api/gatherings/types';
+import type { GatheringForm } from '@/api/gatherings/types';
 
-const RotatingArrow = ({ isInProgressEdit }: { isInProgressEdit: boolean }) => {
+const RotatingArrow = () => {
   const { isOpen } = useDropdown();
   return (
     <ArrowIcon
       className={cn(
         'size-4 rotate-90 transition-transform duration-200 md:size-6 lg:size-7',
         isOpen ? '-rotate-90' : '',
-        isInProgressEdit && 'text-gray-400',
       )}
     />
   );
@@ -61,15 +56,6 @@ const CategoryTriggerBorder = ({ children }: { children: ReactNode }) => {
 
 const DATE_FIELDS = ['recruitDeadline', 'startDate', 'endDate'] as const;
 
-interface RequiredMarkProps {
-  isInProgressEdit: boolean;
-}
-
-const RequiredMark = ({ isInProgressEdit }: RequiredMarkProps) => {
-  if (!isInProgressEdit) return null;
-  return <span className='text-small-02-r lg:text-small-01-r font-normal text-gray-400'>(수정 불가)</span>;
-};
-
 const TYPE_META = {
   스터디: { label: '스터디', subtitle: '함께 학습하고 성장해요', Icon: StudyIcon },
   프로젝트: { label: '프로젝트', subtitle: '함께 만들고 완성해요', Icon: ProjectIcon },
@@ -78,13 +64,11 @@ const TYPE_META = {
 interface EditGatheringFormProps {
   gatheringId: number;
   initialValues: Partial<GatheringForm>;
-  gatheringStatus: GatheringStatus;
 }
 
-export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus }: EditGatheringFormProps) {
+export function EditGatheringForm({ gatheringId, initialValues }: EditGatheringFormProps) {
   const router = useRouter();
   const showToast = useToastStore((state) => state.showToast);
-  const isInProgressEdit = gatheringStatus === 'IN_PROGRESS';
 
   const { data: categoriesData } = useSuspenseQuery(gatheringQueries.categories());
   const categories = categoriesData.categories;
@@ -92,18 +76,6 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
     () => Object.fromEntries(categories.map((c) => [c.id, { label: c.name }])) as Record<number, { label: string }>,
     [categories],
   );
-
-  const schema = useMemo(() => {
-    if (isInProgressEdit) {
-      return gatheringFormBaseSchema.partial().and(
-        createInProgressDateRefinementSchema({
-          recruitDeadline: initialValues?.recruitDeadline ?? '',
-          startDate: initialValues?.startDate ?? '',
-        }),
-      );
-    }
-    return gatheringUpdateFormSchema;
-  }, [isInProgressEdit, initialValues?.recruitDeadline, initialValues?.startDate]);
 
   const {
     register,
@@ -113,9 +85,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
     trigger,
     formState: { errors, touchedFields, isValid },
   } = useForm<GatheringForm>({
-    // schema는 status(RECRUITING/IN_PROGRESS)에 따라 둘 중 하나로 바뀌지만
-    // 둘 다 GatheringForm 필드의 부분집합만 optional로 검증하므로 폼 타입과 안전하게 호환됨
-    resolver: zodResolver(schema) as Resolver<GatheringForm>,
+    resolver: zodResolver(gatheringUpdateFormSchema) as Resolver<GatheringForm>,
     mode: 'onChange',
     defaultValues: {
       categoryIds: [],
@@ -162,14 +132,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
       <Card className='hover:shadow-02 shadow-02 flex flex-col gap-10 border-none p-6 py-10 md:gap-14 md:p-10 md:py-14 lg:gap-20 lg:p-14 lg:py-18'>
         {/* 모임 유형 */}
         <section className='flex flex-col gap-3'>
-          <p
-            className={cn(
-              'text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800',
-              isInProgressEdit && 'text-gray-400',
-            )}
-          >
-            모임 유형 <RequiredMark isInProgressEdit={isInProgressEdit} />
-          </p>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>모임 유형</p>
           <Controller
             name='type'
             control={control}
@@ -185,13 +148,10 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                         'flex h-40 items-center gap-6 rounded-lg px-8 shadow-none hover:shadow-none',
                         'h-21.25',
                         'md:h-40 md:w-auto md:flex-1 md:gap-6 md:px-8',
-                        isInProgressEdit ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+                        'cursor-pointer',
                         isSelected ? 'border-focus-100 bg-blue-50' : 'border-gray-300 bg-gray-100',
                       )}
-                      onClick={() => {
-                        if (isInProgressEdit) return;
-                        field.onChange(type);
-                      }}
+                      onClick={() => field.onChange(type)}
                     >
                       <CheckIcon
                         className={cn('size-8 md:size-10 lg:size-14', isSelected ? 'text-blue-300' : 'text-gray-300')}
@@ -230,33 +190,18 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
 
         {/* 기본 정보 */}
         <section className='flex flex-col gap-6 md:gap-8'>
-          <p
-            className={cn(
-              'text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800',
-              isInProgressEdit && 'text-gray-400',
-            )}
-          >
-            기본 정보 <RequiredMark isInProgressEdit={isInProgressEdit} />
-          </p>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>기본 정보</p>
           <div className='flex flex-col gap-6 lg:flex-row lg:gap-4'>
             <div className='flex w-full flex-col gap-1 lg:flex-1'>
               <div className='relative'>
                 <Input
                   label={
-                    <span
-                      className={cn(
-                        'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                        isInProgressEdit && 'text-gray-400',
-                      )}
-                    >
-                      모임 제목
-                    </span>
+                    <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 제목</span>
                   }
                   maxLength={30}
                   placeholder='제목을 입력하세요'
                   error={errors.title?.message}
                   hideErrorMessage
-                  disabled={isInProgressEdit}
                   {...register('title')}
                   className={cn(
                     'text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 pr-12 disabled:text-gray-400 lg:px-7 lg:py-5 lg:pr-20',
@@ -282,7 +227,6 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                 const MAX_CATEGORIES = 3;
 
                 const toggleCategory = (id: number) => {
-                  if (isInProgressEdit) return;
                   if (selected.includes(id)) {
                     field.onChange(selected.filter((v) => v !== id));
                     return;
@@ -292,43 +236,19 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                 };
 
                 return (
-                  <div
-                    className={cn(
-                      'flex w-full flex-col gap-1.5 lg:flex-1',
-                      isInProgressEdit && 'pointer-events-none opacity-60',
-                    )}
-                  >
-                    <p
-                      className={cn(
-                        'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                        isInProgressEdit && 'text-gray-400',
-                      )}
-                    >
-                      카테고리
-                    </p>
+                  <div className='flex w-full flex-col gap-1.5 lg:flex-1'>
+                    <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>카테고리</p>
                     <Dropdown className='flex w-full flex-col'>
                       <Dropdown.Trigger>
                         <CategoryTriggerBorder>
                           <div className='flex items-center gap-2'>
-                            <CategoryIcon
-                              className={cn('size-4 md:size-6 lg:size-7', isInProgressEdit && 'text-gray-400')}
-                            />
+                            <CategoryIcon className='size-4 md:size-6 lg:size-7' />
                             {selected.length > 0 ? (
                               <div className='flex items-center gap-1'>
-                                <span
-                                  className={cn(
-                                    'text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-900',
-                                    isInProgressEdit && 'text-gray-400',
-                                  )}
-                                >
+                                <span className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-900'>
                                   카테고리({selected.length})
                                 </span>
-                                <span
-                                  className={cn(
-                                    'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-900',
-                                    isInProgressEdit && 'text-gray-400',
-                                  )}
-                                >
+                                <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-900'>
                                   {selected.map((id) => categoryMeta[id]?.label).join(', ')}
                                 </span>
                               </div>
@@ -338,7 +258,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                               </span>
                             )}
                           </div>
-                          <RotatingArrow isInProgressEdit={isInProgressEdit} />
+                          <RotatingArrow />
                         </CategoryTriggerBorder>
                       </Dropdown.Trigger>
                       <Dropdown.Menu
@@ -378,20 +298,12 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
             <div className='relative'>
               <Input
                 label={
-                  <span
-                    className={cn(
-                      'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                      isInProgressEdit && 'text-gray-400',
-                    )}
-                  >
-                    한 줄 소개
-                  </span>
+                  <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>한 줄 소개</span>
                 }
                 maxLength={50}
                 placeholder='소개를 적어주세요'
                 error={errors.shortDescription?.message}
                 hideErrorMessage
-                disabled={isInProgressEdit}
                 {...register('shortDescription')}
                 className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-10.75 pr-12 disabled:text-gray-400 md:h-14.5 lg:h-18 lg:px-7 lg:py-5 lg:pr-20'
               />
@@ -411,12 +323,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
             <div className='relative'>
               <Input
                 label={
-                  <span
-                    className={cn(
-                      'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                      isInProgressEdit && 'text-gray-400',
-                    )}
-                  >
+                  <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>
                     모임 최종 목표
                   </span>
                 }
@@ -424,7 +331,6 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                 placeholder='모임의 최종 목표를 적어주세요'
                 error={errors.goal?.message}
                 hideErrorMessage
-                disabled={isInProgressEdit}
                 {...register('goal')}
                 className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-10.75 pr-14 disabled:text-gray-400 md:h-14.5 lg:h-18 lg:px-7 lg:py-5 lg:pr-24'
               />
@@ -440,13 +346,8 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
           </div>
 
           {/* 태그 */}
-          <div className={cn('flex flex-col gap-1', isInProgressEdit && 'pointer-events-none opacity-60')}>
-            <p
-              className={cn(
-                'text-small-02-m md:text-body-02-m lg:text-body-01-m flex items-center gap-1 text-gray-800',
-                isInProgressEdit && 'text-gray-400',
-              )}
-            >
+          <div className='flex flex-col gap-1'>
+            <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m flex items-center gap-1 text-gray-800'>
               태그
             </p>
             <Controller
@@ -468,14 +369,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
       <Card className='hover:shadow-02 shadow-02 flex flex-col gap-10 border-none p-6 py-10 md:gap-14 md:p-10 md:py-14 lg:gap-20 lg:p-14 lg:py-18'>
         {/* 모집 정보 */}
         <section className='flex flex-col gap-4'>
-          <p
-            className={cn(
-              'text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800',
-              isInProgressEdit && 'text-gray-400',
-            )}
-          >
-            모집 정보 <RequiredMark isInProgressEdit={isInProgressEdit} />
-          </p>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>모집 정보</p>
 
           <div className='flex w-full flex-col gap-4 md:flex-row'>
             <div className='flex w-full flex-col gap-1.5'>
@@ -484,18 +378,10 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                 min={2}
                 max={10}
                 label={
-                  <span
-                    className={cn(
-                      'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                      isInProgressEdit && 'text-gray-400',
-                    )}
-                  >
-                    모집 인원
-                  </span>
+                  <span className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모집 인원</span>
                 }
                 placeholder='모집 인원을 적어주세요'
                 error={errors.maxMembers?.message}
-                disabled={isInProgressEdit}
                 {...register('maxMembers', { valueAsNumber: true })}
                 className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 h-10.75 disabled:text-gray-400 md:h-14.5 lg:h-18 lg:px-7 lg:py-5'
               />
@@ -506,14 +392,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
               control={control}
               render={({ field }) => (
                 <div className='flex w-full flex-col gap-1.5'>
-                  <p
-                    className={cn(
-                      'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                      isInProgressEdit && 'text-gray-400',
-                    )}
-                  >
-                    모집 마감 일정
-                  </p>
+                  <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모집 마감 일정</p>
                   <DatePicker
                     value={field.value}
                     onChange={(value) => {
@@ -524,7 +403,6 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                     onBlur={field.onBlur}
                     placeholder='모집 마감 일정을 선택해주세요'
                     error={errors.recruitDeadline?.message}
-                    disabled={isInProgressEdit}
                     className='bg-gray-0 h-10.75 md:h-14.5 lg:h-18 lg:px-7 lg:py-5'
                   />
                 </div>
@@ -535,14 +413,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
 
         {/* 모임 일정 */}
         <section className='flex flex-col gap-4'>
-          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>
-            모임 일정
-            {isInProgressEdit && (
-              <span className='text-small-02-r lg:text-small-01-r ml-1 font-normal text-gray-400'>
-                (종료일만 수정 가능)
-              </span>
-            )}
-          </p>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>모임 일정</p>
 
           <div className='flex flex-col gap-4 md:flex-row'>
             <Controller
@@ -550,14 +421,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
               control={control}
               render={({ field }) => (
                 <div className='flex w-full flex-col gap-1.5'>
-                  <p
-                    className={cn(
-                      'text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800',
-                      isInProgressEdit && 'text-gray-400',
-                    )}
-                  >
-                    모임 시작일
-                  </p>
+                  <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 시작일</p>
                   <DatePicker
                     value={field.value}
                     onChange={(value) => {
@@ -568,7 +432,6 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
                     onBlur={field.onBlur}
                     placeholder='모임 시작일을 선택해주세요'
                     error={errors.startDate?.message}
-                    disabled={isInProgressEdit}
                     className='bg-gray-0 h-10.75 md:h-14.5 lg:h-18 lg:px-7 lg:py-5'
                   />
                 </div>
@@ -610,10 +473,7 @@ export function EditGatheringForm({ gatheringId, initialValues, gatheringStatus 
       <Card className='hover:shadow-02 shadow-02 flex flex-col gap-6 border-none p-6 py-10 md:gap-8 md:p-10 md:py-14 lg:p-14 lg:py-18'>
         {/* 모임 세부 정보 */}
         <section className='flex flex-col gap-6 md:gap-8'>
-          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>
-            모임 세부 정보
-            <span className='text-small-02-r lg:text-small-01-r ml-1 font-normal text-gray-400'>(수정 가능)</span>
-          </p>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>모임 세부 정보</p>
 
           <WeeklyPlanForm control={control} register={register} errors={errors} totalWeeks={totalWeeks} />
 

--- a/src/app/gatherings/[id]/edit/InProgressEditForm/index.tsx
+++ b/src/app/gatherings/[id]/edit/InProgressEditForm/index.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { Controller, type Resolver, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import { DatePicker } from '@/components/ui/DatePicker';
+import { Textarea } from '@/components/ui/Textarea';
+import { useToastStore } from '@/components/ui/Toast/useToastStore';
+import { useUpdateGathering } from '@/api/gatherings/queries';
+import { createInProgressDateRefinementSchema, gatheringFormBaseSchema } from '@/api/gatherings/schemas';
+import { WeeklyPlanForm } from '@/app/gatherings/_gathering-form-components/WeeklyPlanForm';
+import { getTotalWeeks } from '@/lib/formatGatheringDate';
+
+import type { GatheringForm } from '@/api/gatherings/types';
+
+const DATE_FIELDS = ['startDate', 'endDate'] as const;
+
+interface InProgressEditFormProps {
+  gatheringId: number;
+  initialValues: Partial<GatheringForm>;
+}
+
+export function InProgressEditForm({ gatheringId, initialValues }: InProgressEditFormProps) {
+  const router = useRouter();
+  const showToast = useToastStore((state) => state.showToast);
+
+  const schema = useMemo(
+    () =>
+      gatheringFormBaseSchema.partial().and(
+        createInProgressDateRefinementSchema({
+          recruitDeadline: initialValues?.recruitDeadline ?? '',
+          startDate: initialValues?.startDate ?? '',
+        }),
+      ),
+    [initialValues?.recruitDeadline, initialValues?.startDate],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    trigger,
+    formState: { errors, touchedFields, isValid },
+  } = useForm<GatheringForm>({
+    resolver: zodResolver(schema) as Resolver<GatheringForm>,
+    mode: 'onChange',
+    defaultValues: {
+      categoryIds: [],
+      tags: [],
+      weeklyGuides: [],
+      ...initialValues,
+    },
+  });
+
+  // resolver(zodResolver)가 있는 useForm은 마운트 시 formState.isValid를 자동 계산하지 않는다.
+  // initialValues가 서버 응답으로 채워진 뒤 렌더링되므로, 여기서 한 번 trigger해
+  // 사용자가 아무 필드도 건드리기 전부터 제출 버튼 상태가 실제 값과 일치하도록 만든다.
+  useEffect(() => {
+    trigger();
+  }, [trigger]);
+
+  const { mutate, isPending } = useUpdateGathering(gatheringId);
+
+  const descValue = watch('description') ?? '';
+  const startDateValue = watch('startDate');
+  const endDateValue = watch('endDate');
+  const totalWeeks = startDateValue && endDateValue ? getTotalWeeks(startDateValue, endDateValue) : 0;
+
+  const onSubmit = (data: GatheringForm) => {
+    mutate(
+      { ...data, description: data.description?.trim() || undefined },
+      {
+        onSuccess: () => {
+          showToast({ variant: 'success', title: '모임이 수정되었습니다.' });
+          router.push(`/gatherings/${gatheringId}`);
+        },
+        onError: () => {
+          showToast({ variant: 'error', title: '모임 수정에 실패했습니다.' });
+        },
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-10 md:gap-12 lg:gap-14'>
+      <Card className='hover:shadow-02 shadow-02 flex flex-col gap-10 border-none p-6 py-10 md:gap-14 md:p-10 md:py-14 lg:gap-20 lg:p-14 lg:py-18'>
+        <p className='text-small-02-r md:text-body-02-r lg:text-body-01-r rounded-lg bg-blue-50 px-4 py-3 text-blue-300 lg:px-7 lg:py-5'>
+          진행 중인 모임은 일부 정보만 수정할 수 있어요. 모임 종료일, 주차별 계획, 상세 설명을 변경할 수 있어요.
+        </p>
+
+        {/* 모임 일정 */}
+        <section className='flex flex-col gap-4'>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>모임 일정</p>
+
+          <div className='flex flex-col gap-4 md:flex-row'>
+            <Controller
+              name='startDate'
+              control={control}
+              render={({ field }) => (
+                <div className='flex w-full flex-col gap-1.5'>
+                  <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 시작일</p>
+                  <DatePicker
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    placeholder='모임 시작일을 선택해주세요'
+                    disabled
+                    className='bg-gray-0 h-10.75 md:h-14.5 lg:h-18 lg:px-7 lg:py-5'
+                  />
+                </div>
+              )}
+            />
+
+            <Controller
+              name='endDate'
+              control={control}
+              render={({ field }) => (
+                <div className='flex w-full flex-col gap-1.5'>
+                  <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m text-gray-800'>모임 종료일</p>
+                  <DatePicker
+                    value={field.value}
+                    onChange={(value) => {
+                      field.onChange(value);
+                      const fieldsToTrigger = DATE_FIELDS.filter((f) => f === field.name || touchedFields[f]);
+                      trigger(fieldsToTrigger);
+                    }}
+                    onBlur={field.onBlur}
+                    placeholder='모임 종료일을 선택해주세요'
+                    error={errors.endDate?.message}
+                    className='bg-gray-0 h-10.75 md:h-14.5 lg:h-18 lg:px-7 lg:py-5'
+                  />
+                </div>
+              )}
+            />
+          </div>
+
+          <div className='mt-2 flex h-10.75 items-center justify-between rounded-lg bg-gray-100 px-7 py-5 md:mt-4 md:h-14.5 lg:h-18'>
+            <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>모임 기간</p>
+            <p className='text-small-02-sb md:text-body-02-sb lg:text-body-01-sb text-gray-800'>
+              <span className='text-blue-400'>{totalWeeks}</span> 주
+            </p>
+          </div>
+        </section>
+
+        {/* 모임 세부 정보 */}
+        <section className='flex flex-col gap-6 md:gap-8'>
+          <p className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb text-gray-800'>모임 세부 정보</p>
+
+          <WeeklyPlanForm control={control} register={register} errors={errors} totalWeeks={totalWeeks} />
+
+          {/* 상세 설명 */}
+          <div className='flex flex-col gap-1'>
+            <p className='text-small-02-m md:text-body-02-m lg:text-body-01-m flex items-center gap-1 text-gray-800'>
+              상세 설명
+            </p>
+            <div className='relative'>
+              <Textarea
+                maxLength={1000}
+                rows={8}
+                placeholder='모임을 설명을 상세히 적어주세요'
+                error={errors.description?.message}
+                hideErrorMessage
+                {...register('description')}
+                className='text-small-02-r md:text-body-02-r lg:text-body-01-r bg-gray-0 px-4 py-3 pb-7 lg:px-7 lg:py-5 lg:pb-8'
+              />
+              <span className='md:text-small-02-r pointer-events-none absolute right-3 bottom-3 text-[8px] text-gray-400 lg:right-5 lg:bottom-4'>
+                {descValue.length}/1000
+              </span>
+            </div>
+            {errors.description?.message && (
+              <p className='text-xs text-red-200' role='alert'>
+                {errors.description.message}
+              </p>
+            )}
+          </div>
+        </section>
+      </Card>
+
+      <div className='flex justify-end gap-3'>
+        <Button
+          type='button'
+          variant='mypage-edit'
+          size={undefined}
+          onClick={() => router.push(`/gatherings/${gatheringId}`)}
+          className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb bg-gray-150 h-12 w-25 border-gray-400 text-gray-700 md:h-18 md:w-56 lg:h-20 lg:w-75'
+        >
+          취소
+        </Button>
+        <Button
+          type='submit'
+          variant='action'
+          size='action-sm'
+          disabled={isPending || !isValid}
+          className='text-small-01-sb md:text-body-01-sb lg:text-h5-sb h-12 w-25 bg-blue-300 md:h-18 md:w-56 lg:h-20 lg:w-75'
+        >
+          변경 사항 저장
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/gatherings/[id]/edit/_components/EditGatheringContent.tsx
+++ b/src/app/gatherings/[id]/edit/_components/EditGatheringContent.tsx
@@ -8,6 +8,7 @@ import { gatheringQueries } from '@/api/gatherings/queries';
 import { mapGatheringDetailToFormValues } from '@/app/gatherings/new/CreateGatheringFunnel/mapGatheringDetailToFormValues';
 
 import { EditGatheringForm } from '../EditGatheringForm';
+import { InProgressEditForm } from '../InProgressEditForm';
 
 import type { Category } from '@/api/gatherings/types';
 
@@ -36,5 +37,9 @@ export function EditGatheringContent({ gatheringId }: EditGatheringContentProps)
 
   if (isCompleted) return null;
 
-  return <EditGatheringForm gatheringId={gatheringId} initialValues={initialValues} gatheringStatus={detail.status} />;
+  if (detail.status === 'IN_PROGRESS') {
+    return <InProgressEditForm gatheringId={gatheringId} initialValues={initialValues} />;
+  }
+
+  return <EditGatheringForm gatheringId={gatheringId} initialValues={initialValues} />;
 }


### PR DESCRIPTION
## ❓ 이슈

- close #412 

## ✍️ Description

진행중 상태인 모임에서 수정 불가능한 필드를 disabled로 남겨두던 기존 `EditGatheringForm` 하나로 모든 상태를 처리하던 방식에서, 진행중 모임 전용 `InProgressEditForm`을 새로 분리했습니다.

**변경 배경**

진행중 모임은 모집중 모임과 달리 수정 가능한 필드가 제한적입니다(시작일·카테고리·정원 등은 이미 확정되어 변경 불가). 기존에는 이 필드들을 `disabled` input으로 그대로 렌더링해 사용자가 "왜 못 바꾸지?"를 클릭해보고 나서야 알 수 있었습니다. 이를 진행중 상태에 맞는 별도 폼으로 분리해, 실제로 의미 있는 필드만 보여주도록 개선했습니다.

**InProgressEditForm 주요 내용**

- 노출 필드: 모임 시작일(`startDate`, disabled 유지)/종료일(`endDate`, 수정 가능), 주차별 계획(`WeeklyPlanForm`), 상세 설명(`description`)
- 종료일 변경 시 총 주차 수(`getTotalWeeks`)를 재계산해 실시간으로 모임 기간을 보여줌
- 날짜 검증은 기존 `gatheringFormBaseSchema`에 진행중 전용 `createInProgressDateRefinementSchema`(현재 `recruitDeadline`/`startDate` 기준으로 종료일 유효성 검증)를 결합해 별도 스키마로 처리
- 상단에 "진행 중인 모임은 일부 정보만 수정할 수 있어요" 안내 문구 추가

**기존 EditGatheringForm**

- `gatheringStatus` prop 및 상태 분기 로직을 제거하고 모집중 상태 전용으로 단순화 (192줄 → 대폭 축소)
- 라우팅은 `EditGatheringContent`에서 `detail.status === 'IN_PROGRESS'` 여부로 두 폼 중 하나를 선택

**모임 삭제 버튼 (부수 변경)**

같은 "수정 불가 항목을 disabled 대신 비노출로" 원칙을 상세 페이지 `GatheringActionButtons`에도 적용했습니다. '모임 삭제' 버튼을 `disabled` 처리 대신 `canDelete`가 `true`일 때만 렌더링하도록 변경했습니다 (완료 상태에서의 기존 동작은 그대로 유지).

## 📸 스크린샷 (UI 변경 시)
<img width="797" height="729" alt="image" src="https://github.com/user-attachments/assets/d2ce2002-6a70-405e-8025-3abb4a699088" />

<img width="804" height="670" alt="image" src="https://github.com/user-attachments/assets/aaad2579-ce4b-4da7-a368-ac7d57a6b7c4" />



## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test

- [x] 로컬 작동 확인
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes


