### PR TITLE
[SM-235] fix: MSW 환경 상세/대시보드 진입 지연 개선

### DIFF
--- a/src/api/gatherings/queries.ts
+++ b/src/api/gatherings/queries.ts
@@ -10,7 +10,6 @@ import {
   fetchCategories,
   getApplicationStatus,
   fetchMainGatherings,
-  fetchGatheringDetail,
   getGatheringDetail,
   getGatherings,
   createGathering,
@@ -24,6 +23,7 @@ import {
   GATHERING_TAGS,
   getMainGatherings,
 } from './index';
+import { fetchCachedGatheringDetail } from './server';
 
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type {
@@ -69,7 +69,7 @@ export const gatheringQueries = {
   detail: (gatheringId: number) =>
     queryOptions({
       queryKey: gatheringKeys.detail(gatheringId),
-      queryFn: () => (isServer ? fetchGatheringDetail(gatheringId) : getGatheringDetail(gatheringId)),
+      queryFn: () => (isServer ? fetchCachedGatheringDetail(gatheringId) : getGatheringDetail(gatheringId)),
       // 404는 리소스가 실제로 없다는 확정적 응답이므로 재시도하지 않음 (삭제 직후 잔여 구독자로 인한 재요청 낭비 방지)
       retry: (failureCount, error) => {
         if (axios.isAxiosError(error) && error.response?.status === 404) return false;

--- a/src/api/gatherings/server.ts
+++ b/src/api/gatherings/server.ts
@@ -1,0 +1,5 @@
+import { cache } from 'react';
+
+import { fetchGatheringDetail } from './index';
+
+export const fetchCachedGatheringDetail = cache(fetchGatheringDetail);

--- a/src/app/gatherings/[id]/_components/GatheringDetailContainer/index.tsx
+++ b/src/app/gatherings/[id]/_components/GatheringDetailContainer/index.tsx
@@ -2,6 +2,7 @@ import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
 import { gatheringQueries } from '@/api/gatherings/queries';
 import { getQueryClient } from '@/lib/getQueryClient';
+import { isMswEnabled } from '@/lib/msw';
 
 import { AnchorTabNav } from '../AnchorTabNav';
 import { FloatingActionBar } from '../ApplySection/FloatingActionBar';
@@ -17,7 +18,9 @@ interface GatheringDetailContainerProps {
 export async function GatheringDetailContainer({ gatheringId }: GatheringDetailContainerProps) {
   const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery(gatheringQueries.detail(gatheringId));
+  if (!isMswEnabled) {
+    await queryClient.prefetchQuery(gatheringQueries.detail(gatheringId));
+  }
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/gatherings/[id]/dashboard/page.tsx
+++ b/src/app/gatherings/[id]/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { fetchGatheringDetail } from '@/api/gatherings';
+import { fetchCachedGatheringDetail } from '@/api/gatherings/server';
 import { SuspenseBoundary } from '@/components/SuspenseBoundary';
 import { getUserIdFromToken } from '@/lib/getUserIdFromToken';
 import { isMswEnabled } from '@/lib/msw';
@@ -38,15 +38,13 @@ export default async function DashboardPage({ params, searchParams }: DashboardP
   const userId = getUserIdFromToken(accessToken);
 
   // accessToken 없지만 refreshToken 있으면 클라이언트에서 리프레시 처리 → 검증 스킵
-  if (userId !== null) {
+  if (userId !== null && !isMswEnabled) {
     try {
-      const gathering = await fetchGatheringDetail(gatheringId);
+      const gathering = await fetchCachedGatheringDetail(gatheringId);
       const isMember = gathering.members.some((m) => m.userId === userId);
       if (!isMember) redirect(`/gatherings/${gatheringId}`);
     } catch {
-      // TEMP: 백엔드 재배포 전까지 Vercel production MSW 배포에서도 대시보드 시연을 허용한다.
-      // MSW 환경 — Next.js 16 + Turbopack에서 msw/node가 서버 fetch를 못 잡는 경우가 있음.
-      if (!isMswEnabled) redirect(`/gatherings/${gatheringId}`);
+      redirect(`/gatherings/${gatheringId}`);
     }
   } else if (!hasRefreshToken && !isMswEnabled) {
     redirect(`/gatherings/${gatheringId}`);

--- a/src/app/gatherings/[id]/page.tsx
+++ b/src/app/gatherings/[id]/page.tsx
@@ -1,8 +1,6 @@
-import { Suspense } from 'react';
-
-import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { fetchGatheringDetail } from '@/api/gatherings';
 import { JsonLd } from '@/components/seo/JsonLd';
+import { fetchCachedGatheringDetail } from '@/api/gatherings/server';
+import { isMswEnabled } from '@/lib/msw';
 import {
   OG_IMAGES,
   SITE_DESCRIPTION,
@@ -11,9 +9,7 @@ import {
   buildGatheringEventJsonLd,
   getDefaultOpenGraph,
 } from '@/lib/seo';
-import { GatheringHero } from './_components/GatheringHero';
 import { GatheringDetailContainer } from './_components/GatheringDetailContainer';
-import { GatheringDetailSkeleton } from './_components/GatheringDetailSkeleton';
 import { GatheringDetailTracker } from './_components/GatheringDetailTracker';
 import { MainGatheringStreaming } from './_components/GatheringStreaming';
 
@@ -34,12 +30,12 @@ export const generateMetadata = async ({ params }: GatheringDetailPageProps): Pr
   const { id } = await params;
   const gatheringId = Number(id);
 
-  if (Number.isNaN(gatheringId)) {
+  if (Number.isNaN(gatheringId) || isMswEnabled) {
     return { title: '모임', robots: { index: false, follow: false } };
   }
 
   try {
-    const detail = await fetchGatheringDetail(gatheringId);
+    const detail = await fetchCachedGatheringDetail(gatheringId);
     const description = truncateDescription(detail.shortDescription || detail.description || SITE_DESCRIPTION);
     const heroImage = detail.images?.[0]?.url;
     const canonical = `/gatherings/${gatheringId}`;
@@ -74,9 +70,9 @@ export default async function GatheringDetailPage({ params }: GatheringDetailPag
   const gatheringId = Number(id);
 
   let detail: GatheringDetail | null = null;
-  if (!Number.isNaN(gatheringId)) {
+  if (!Number.isNaN(gatheringId) && !isMswEnabled) {
     try {
-      detail = await fetchGatheringDetail(gatheringId);
+      detail = await fetchCachedGatheringDetail(gatheringId);
     } catch {
       // SSR fetch 실패 시 클라이언트 스트리밍 컴포넌트가 자체 fallback 렌더
     }

--- a/src/components/Header/AuthSection.tsx
+++ b/src/components/Header/AuthSection.tsx
@@ -2,9 +2,10 @@
 
 import { useRouter } from 'next/navigation';
 
-import { useLogout } from '@/api/auth/queries';
+import { useLogin, useLogout } from '@/api/auth/queries';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/cn';
+import { isMswEnabled } from '@/lib/msw';
 import { revokeFcmTokenOnLogout } from '@/lib/pushNotification';
 import { Dropdown } from '@/components/ui/Dropdown';
 import { NotificationDropdown } from './NotificationDropdown';
@@ -14,6 +15,12 @@ import { Button } from '@/components/ui/Button';
 export function AuthSection() {
   const router = useRouter();
   const { user, isLoggedIn, isLoading } = useAuth();
+
+  const { mutate: loginAsGuest, isPending: isGuestLoginPending } = useLogin({
+    onSuccess: () => {
+      router.refresh();
+    },
+  });
 
   const { mutate: logout, isPending: isLogoutPending } = useLogout({
     onSuccess: () => {
@@ -25,11 +32,20 @@ export function AuthSection() {
   const handleMoveLogin = () => router.push('/login');
   const handleMoveRegister = () => router.push('/register');
   const handleMoveMyPage = () => router.push('/my');
+  const handleGuestLogin = () => loginAsGuest({ email: 'tester@sailmate.dev', password: 'password123' });
 
   if (isLoading) {
     return <div className='h-[42px] w-[154px]' aria-hidden />;
   }
   if (!isLoggedIn) {
+    if (isMswEnabled) {
+      return (
+        <Button variant='primary' size='join-sm' onClick={handleGuestLogin} disabled={isGuestLoginPending}>
+          체험하기
+        </Button>
+      );
+    }
+
     return (
       <div className='flex items-center gap-2 lg:gap-2'>
         <Button variant='login-outline' size='login-sm' onClick={handleMoveLogin}>

--- a/src/mocks/init.ts
+++ b/src/mocks/init.ts
@@ -1,5 +1,23 @@
 import { isMswEnabled } from '@/lib/msw';
 
+const MSW_CONTROLLER_RELOAD_KEY = 'sailmate:msw-controller-reloaded';
+const MSW_WORKER_FILE = '/mockServiceWorker.js';
+
+const isControlledByMsw = () => navigator.serviceWorker.controller?.scriptURL.endsWith(MSW_WORKER_FILE) ?? false;
+
+const reloadOnceForMswController = () => {
+  if (isControlledByMsw()) {
+    sessionStorage.removeItem(MSW_CONTROLLER_RELOAD_KEY);
+    return false;
+  }
+
+  if (sessionStorage.getItem(MSW_CONTROLLER_RELOAD_KEY)) return false;
+
+  sessionStorage.setItem(MSW_CONTROLLER_RELOAD_KEY, 'true');
+  window.location.reload();
+  return true;
+};
+
 export const initMsw = async () => {
   if (!isMswEnabled) return;
   if (typeof window === 'undefined') return;
@@ -20,4 +38,6 @@ export const initMsw = async () => {
   await worker.start({
     onUnhandledRequest: 'bypass',
   });
+
+  if (reloadOnceForMswController()) return;
 };


### PR DESCRIPTION
## ❓ 이슈

- close #414
- Jira: SM-235

## ✍️ Description

MSW 활성 환경에서 상세 페이지와 대시보드가 서버 fetch 실패/retry를 기다리며 느리게 진입하던 문제를 정리했습니다. 상세 페이지 metadata, JSON-LD, React Query prefetch와 대시보드 멤버 검증은 MSW 환경에서 서버 fetch를 건너뛰고, 브라우저 MSW가 클라이언트 쿼리를 처리하도록 했습니다.

정상 운영 환경에서는 `fetchCachedGatheringDetail`을 통해 상세 서버 fetch를 재사용하면서 기존 SSR metadata, JSON-LD, hydration, 대시보드 권한 검증 흐름을 유지합니다. MSW 환경의 비로그인 Header에서는 로그인/회원가입 대신 `체험하기` 버튼을 노출하고, 기존 로그인 mutation으로 mock 계정 로그인을 수행하도록 변경했습니다.

배포 사이트 최초 진입이나 기존 service worker 교체 타이밍에 현재 페이지가 `mockServiceWorker.js`에 의해 제어되지 않으면 클라이언트 쿼리가 `/api` BFF로 새어 ErrorBoundary가 노출될 수 있습니다. 이를 막기 위해 MSW 시작 후 controller를 확인하고, MSW controller가 아니면 sessionStorage 플래그로 1회만 자동 reload하도록 보강했습니다.

## 📸 스크린샷 (UI 변경 시)

- MSW 환경 Header 비로그인 영역: 로그인/회원가입 대신 `체험하기` 버튼 노출

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [x] 타입 체크 통과 (`npx tsc --noEmit`)
- [x] 빌드 통과 (`npm run build`)
- [x] 린트 통과 (`npm run lint`)

### Additional Notes

- [ ] 백엔드 재배포 후 `NEXT_PUBLIC_MSW_ENABLED`를 끄면 기존 운영 서버 fetch 및 로그인/회원가입 버튼 흐름으로 복귀합니다.
- [ ] MSW controller 보장은 sessionStorage 플래그로 1회 reload만 허용해 무한 새로고침을 방지합니다.