### PR TITLE
[SM-232] style: 대시보드 UI 수정

### DIFF
--- a/src/app/gatherings/[id]/dashboard/_components/MemberListSection/MemberCard/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberListSection/MemberCard/index.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/cn';
 import { Profile } from '@/components/ui/Profile';
 import { HandIcon } from '@/components/ui/Icon';
 import { Button } from '@/components/ui/Button';
+import { Tag } from '@/components/ui/Tag';
 
 import { ReviewButton } from '../ReviewButton';
 import { MemberBadge } from '../../MemberBadge';
@@ -43,9 +44,9 @@ export function MemberCard({
   return (
     <article
       className={cn(
-        'shadow-02 rounded-2xl border bg-white',
+        'shadow-02 rounded-2xl bg-white',
         'p-6 md:p-7',
-        isMe ? 'border-focus-100' : 'border-gray-150',
+        isMe ? 'border-gradient-primary' : 'border-gray-150',
       )}
     >
       <div className='flex items-start gap-2 md:gap-4'>
@@ -56,7 +57,15 @@ export function MemberCard({
         />
         <div className='min-w-0 flex-1'>
           <div className='flex items-center gap-1.5'>
-            <span className='text-body-02-sb md:text-h5-sb truncate text-gray-900'>{member.nickname}</span>
+            <span className={cn('text-body-02-sb md:text-h5-sb truncate text-gray-900', isMe ? 'text-blue-300' : '')}>
+              {member.nickname}
+              {isMe ? <span className='text-blue-300'> (나)</span> : null}
+            </span>
+            {member.role === 'LEADER' && (
+              <Tag variant='coreFeatureSmall' className='text-gray-0 text-small-02-m bg-blue-300 px-3 py-1'>
+                모임장
+              </Tag>
+            )}
             {badgeType && <MemberBadge type={badgeType} label={badgeLabel} />}
           </div>
           <p className='text-small-02-r md:text-body-01-r mt-0.5 text-gray-800'>{goalText}</p>
@@ -64,17 +73,17 @@ export function MemberCard({
 
         <div className='shrink-0'>
           {isMe ? (
-            <MeBadge />
+            ''
           ) : isGatheringEnded ? (
             <ReviewButton hasReviewed={hasReviewed} onClick={onReviewClick} />
           ) : (
             <Button
               variant='icon-hand'
-              size='icon-hand'
               onClick={onPokeClick}
               aria-label={`${member.nickname}에게 콕 찌르기`}
+              className='text-small-02-sb md:text-body-02-sb h-auto w-fit shrink-0 items-center gap-1 bg-blue-100 px-5 py-2.5 text-blue-300'
             >
-              <HandIcon />
+              콕 찌르기
             </Button>
           )}
         </div>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberRankingSection/RankingItem/index.tsx
@@ -25,7 +25,7 @@ export function RankingItem({ item, isMe, streakDays, currentWeek }: RankingItem
 
   return (
     <div
-      className={`flex items-center gap-3 rounded-2xl bg-gray-100 px-7 py-5 ${isMe ? 'border-gradient-primary' : ''}`}
+      className={`border-gray-150 flex items-center gap-3 rounded-2xl border bg-gray-100 px-7 py-5 ${isMe ? 'border-gradient-primary' : ''}`}
     >
       <RankBadge rank={item.rank} />
 
@@ -37,7 +37,9 @@ export function RankingItem({ item, isMe, streakDays, currentWeek }: RankingItem
         <ProgressBar value={item.overallRate}>
           <div className='flex items-center justify-between'>
             <div className='flex items-center gap-1 md:gap-2'>
-              <span className='text-small-02-m md:text-body-01-m text-gray-900'>{item.nickname}</span>
+              <span className={`text-small-02-m md:text-body-01-m ${isMe ? 'text-blue-300' : 'text-gray-900'}`}>
+                {isMe ? `${item.nickname}(나)` : item.nickname}
+              </span>
               {isWarning && <MemberBadge type='warning' label='주의' />}
               {!isWarning && streakDays > 0 && <MemberBadge type='streak' label={`${streakDays}일`} />}
             </div>
@@ -48,12 +50,6 @@ export function RankingItem({ item, isMe, streakDays, currentWeek }: RankingItem
           </div>
         </ProgressBar>
       </div>
-
-      {isMe && (
-        <Button variant='tag' size='tag' className='h-8 w-8 cursor-default md:h-12 md:w-12'>
-          나
-        </Button>
-      )}
 
       {!isMe && (
         <Button variant='icon-hand' size='icon-hand' className='h-8 w-8 md:h-12 md:w-12'>

--- a/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MemberTodoSection/MemberTodoItem/index.tsx
@@ -41,9 +41,13 @@ export function MemberTodoItem({ content, isCompleted }: MemberTodoItemProps) {
       <button
         type='button'
         onClick={() => setIsFired((prev) => !prev)}
-        className='flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-lg md:h-12 md:w-12'
+        className={cn(
+          'text-small-02-sb md:text-body-02-sb flex h-8 shrink-0 cursor-pointer items-center gap-1 rounded-lg px-2 text-blue-300 transition-colors md:h-12 md:px-4',
+          isFired ? 'bg-gray-200 text-gray-500' : 'bg-blue-100 text-blue-300',
+        )}
       >
-        <FireButtonIcon variant={isFired ? 'disabled' : 'active'} className='h-8 w-8 md:h-12 md:w-12' />
+        <FireButtonIcon variant={isFired ? 'disabled' : 'active'} className='h-5 w-5 md:h-7 md:w-7' />
+        {isFired ? '응원완료' : '응원하기'}
       </button>
     </div>
   );

--- a/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/TodoAddForm/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/TodoAddForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { useCreateTodo } from '@/api/todos/queries';
 import { Button } from '@/components/ui/Button';
@@ -14,19 +14,12 @@ interface TodoAddFormProps {
 }
 
 export function TodoAddForm({ gatheringId, week, className }: TodoAddFormProps) {
-  const [isAdding, setIsAdding] = useState(false);
   const [value, setValue] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
   const showToast = useToastStore((state) => state.showToast);
-
-  const closeForm = () => {
-    setValue('');
-    setIsAdding(false);
-  };
 
   const { mutate, isPending } = useCreateTodo(gatheringId, {
     onSuccess: () => {
-      closeForm();
+      setValue('');
     },
     onError: (error: Error) => {
       showToast({
@@ -37,13 +30,9 @@ export function TodoAddForm({ gatheringId, week, className }: TodoAddFormProps) 
     },
   });
 
-  useEffect(() => {
-    if (isAdding) inputRef.current?.focus();
-  }, [isAdding]);
-
   const submit = () => {
     const content = value.trim();
-    if (!content) return closeForm();
+    if (!content) return;
     if (isPending) return;
     mutate({ week, content });
   };
@@ -53,45 +42,26 @@ export function TodoAddForm({ gatheringId, week, className }: TodoAddFormProps) 
     submit();
   };
 
-  const handleBlur = () => {
-    if (!value.trim()) closeForm();
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Escape') closeForm();
+    if (e.key === 'Escape') setValue('');
   };
-
-  if (!isAdding) {
-    return (
-      <Button
-        variant='add-task'
-        onClick={() => setIsAdding(true)}
-        className={cn('text-small-01-sb md:text-body-01-sb h-13 w-full md:h-18', className)}
-      >
-        + 할 일 추가
-      </Button>
-    );
-  }
 
   return (
     <form onSubmit={handleSubmit} className={cn('flex w-full gap-2', className)}>
       <input
-        ref={inputRef}
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
-        onBlur={handleBlur}
         disabled={isPending}
-        placeholder='할 일을 입력해 주세요'
-        aria-label='할 일을 입력해 주세요'
-        className='border-gray-150 bg-gray-0 text-body-02-r flex-1 rounded-lg border px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300 focus:border-blue-200'
+        placeholder='할 일을 적어주세요'
+        aria-label='할 일을 적어주세요'
+        className='border-gray-150 bg-gray-0 text-body-01-r flex-1 rounded-lg border px-7 py-5 text-gray-900 outline-none placeholder:text-gray-300 focus:border-blue-200'
       />
       <Button
         type='submit'
         variant='check'
-        size='check'
         disabled={isPending || !value.trim()}
-        className='h-auto shrink-0 px-4 py-3'
+        className='text-h5-sb h-18 w-50 shrink-0'
       >
         추가
       </Button>

--- a/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/TodoItem/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/TodoItem/index.tsx
@@ -6,7 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { todoKeys, useDeleteTodo, useUpdateTodo } from '@/api/todos/queries';
 import { Dropdown } from '@/components/ui/Dropdown';
-import { CheckIcon, MoreIcon, IllustrationIcon, CloseIcon } from '@/components/ui/Icon';
+import { CheckIcon, MoreIcon, IllustrationIcon } from '@/components/ui/Icon';
 import { cn } from '@/lib/cn';
 
 import type { MyTodoListResponse, Todo } from '@/api/todos/types';
@@ -15,15 +15,14 @@ interface TodoItemProps {
   gatheringId: number;
   week: number;
   todo: Todo;
+  streakDays: number;
 }
 
 interface OptimisticContext {
   prev?: MyTodoListResponse;
 }
 
-const STREAK_PLACEHOLDER = 3;
-
-export function TodoItem({ gatheringId, week, todo }: TodoItemProps) {
+export function TodoItem({ gatheringId, week, todo, streakDays }: TodoItemProps) {
   const queryClient = useQueryClient();
 
   const queryKey = useMemo(() => todoKeys.myList(gatheringId, { week }), [gatheringId, week]);
@@ -153,14 +152,10 @@ export function TodoItem({ gatheringId, week, todo }: TodoItemProps) {
         )}
       </div>
 
-      {todo.isCompleted && (
-        <div className='flex items-center gap-1 text-gray-600'>
-          <span aria-hidden>
-            <IllustrationIcon variant='fire' size={24} className='md:size-8' />
-          </span>
-          <span className='text-small-02-r md:text-body-02-r'>
-            <CloseIcon size={12} className='md:size-4' /> {STREAK_PLACEHOLDER}
-          </span>
+      {todo.isCompleted && streakDays > 0 && (
+        <div className='bg-gray-150 flex items-center gap-1 rounded-lg px-6 py-3'>
+          <IllustrationIcon variant='fire' size={20} className='md:size-6' aria-hidden />
+          <span className='text-small-02-sb md:text-body-02-sb text-blue-300'>{streakDays}</span>
         </div>
       )}
 

--- a/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/index.tsx
+++ b/src/app/gatherings/[id]/dashboard/_components/MyTodoSection/index.tsx
@@ -79,7 +79,7 @@ export function MyTodoSection({ gatheringId }: MyTodoSectionProps) {
       <div className='px-7'>
         <ul className='flex flex-col gap-3'>
           {sortedTodos.map((todo) => (
-            <TodoItem key={todo.id} gatheringId={gatheringId} week={week} todo={todo} />
+            <TodoItem key={todo.id} gatheringId={gatheringId} week={week} todo={todo} streakDays={data.streakDays} />
           ))}
         </ul>
 


### PR DESCRIPTION
## ❓ 이슈

- close #407 

## ✍️ Description

### 1. 멤버 달성률 랭킹 (`MemberRankingSection/RankingItem`)
- 본인 항목 닉네임을 `닉네임(나)`로, 파란색(`blue-300`)으로 표시
- 오른쪽에 별도로 떠 있던 "나" 뱃지 버튼 제거

### 2. 이번주 할 일 (`MyTodoSection`)
- **완료 뱃지 버그 수정**: 완료된 할 일에 붙는 연속일수 뱃지가 `CloseIcon`(✕)을 잘못 사용하고 있었고, 값도 `STREAK_PLACEHOLDER = 3` 하드코딩이었음. 아이콘을 제거하고, API 응답(`MyTodoListResponse.streakDays`)에 이미 있었지만 연결되지 않았던 실제 연속일수를 `MyTodoSection → TodoItem`으로 내려주도록 수정. 뱃지 모양도 네모 박스 스타일로 변경
- **할 일 추가 UX 변경**: "+ 할 일 추가" 트리거 버튼을 없애고 입력창 + 추가 버튼이 항상 보이도록 변경 (`isAdding` 토글 상태, 관련 blur/focus 로직 제거)
- placeholder 문구 수정: "할 일을 입력해 주세요" → "할 일을 적어주세요"
- "추가" 버튼 크기/폰트를 디자인 스펙에 맞춤

### 3. 멤버 할 일 (`MemberTodoSection/MemberTodoItem`)
- 아이콘만 있던 응원 버튼에 "응원하기"(파란 배경) / "응원완료"(회색 배경) 텍스트 라벨 추가

### 4. 멤버 카드 (`MemberListSection/MemberCard`)
- 본인 카드 닉네임 뒤에 `(나)` 표시 (파란색)
- `role === 'LEADER'`인 멤버 닉네임 옆에 "모임장" 태그 추가
- "콕 찌르기" 버튼을 아이콘 전용에서 아이콘 없이 텍스트 라벨(`콕 찌르기`)로 변경


## 📸 스크린샷 (UI 변경 시)

## ✅ Checklist

### PR

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선, `chore/*` 설정/환경
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정

### Test

- [ ] 로컬 작동 확인
- [ ] 빌드 통과 (`npm run build`)
- [ ] 린트 통과 (`npm run lint`)

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [ ] (없음)
